### PR TITLE
Add test for discrete callback

### DIFF
--- a/src/DelayDiffEq.jl
+++ b/src/DelayDiffEq.jl
@@ -16,7 +16,7 @@ import OrdinaryDiffEq: initialize!, perform_step!, loopfooter!,
        handle_callback_modifiers!
 
 import DiffEqBase: solve, solve!, init, resize!, u_cache, user_cache,
-                   du_cache, full_cache, deleteat!, terminate!
+                   du_cache, full_cache, deleteat!, terminate!, u_modified!
 
 import OrdinaryDiffEq: Rosenbrock23Cache, Rosenbrock32Cache,
                        ImplicitEulerCache, TrapezoidCache

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -83,6 +83,10 @@ u_cache(integrator::DDEIntegrator) = u_cache(integrator.cache)
 du_cache(integrator::DDEIntegrator)= du_cache(integrator.cache)
 full_cache(integrator::DDEIntegrator) = chain(u_cache(integrator),du_cache(integrator.cache))
 
+@inline function u_modified!(integrator::DDEIntegrator,bool::Bool)
+  integrator.u_modified = bool
+end
+
 resize!(integrator::DDEIntegrator,i::Int) = resize!(integrator,integrator.cache,i)
 function resize!(integrator::DDEIntegrator,cache,i)
   for c in full_cache(integrator)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 DiffEqDevTools
+DiffEqCallbacks


### PR DESCRIPTION
Hi!

As suggested in https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/67, I added a first test for discrete callbacks with the `AutoAbstol` to the already existing test for continuous callbacks. I also had to define `u_modified!` for `DDEIntegrator`.