### PR TITLE
Fix bug in execution of history function

### DIFF
--- a/src/history_function.jl
+++ b/src/history_function.jl
@@ -14,11 +14,7 @@ function (f::HistoryFunction)(t,deriv::Type=Val{0},idxs=nothing)
   elseif t <= f.sol.t[end] # Put equals back
     return f.sol.interp(t,idxs,deriv)
   else
-    if typeof(idxs) <: Void
-      return OrdinaryDiffEq.current_interpolant(t,f.integrator,eachindex(f.integrator.uprev),deriv)
-    else
-      return OrdinaryDiffEq.current_interpolant(t,f.integrator,idxs,deriv)
-    end
+    return OrdinaryDiffEq.current_interpolant(t,f.integrator,idxs,deriv)
   end
 end
 
@@ -32,10 +28,6 @@ function (f::HistoryFunction)(val,t,deriv::Type=Val{0},idxs=nothing)
   elseif t <= f.sol.t[end] # Put equals back
     return f.sol.interp(val,t,idxs,deriv)
   else
-    if typeof(idxs) <: Void
-      return OrdinaryDiffEq.current_interpolant!(val,t,f.integrator,eachindex(f.integrator.uprev),deriv)
-    else
-      return OrdinaryDiffEq.current_interpolant!(val,t,f.integrator,idxs,deriv)
-    end
+    return OrdinaryDiffEq.current_interpolant!(val,t,f.integrator,idxs,deriv)
   end
 end

--- a/src/history_function.jl
+++ b/src/history_function.jl
@@ -15,7 +15,7 @@ function (f::HistoryFunction)(t,deriv::Type=Val{0},idxs=nothing)
     return f.sol.interp(t,idxs,deriv)
   else
     if typeof(idxs) <: Void
-      return OrdinaryDiffEq.current_interpolant(t,f.integrator,size(f.integrator.uprev),deriv)
+      return OrdinaryDiffEq.current_interpolant(t,f.integrator,eachindex(f.integrator.uprev),deriv)
     else
       return OrdinaryDiffEq.current_interpolant(t,f.integrator,idxs,deriv)
     end


### PR DESCRIPTION
Hi!

I discovered a bug in the execution of the history function, I guess. Running the following simple example
```julia
using OrdinaryDiffEq,DelayDiffEq

function f(t,u,h,du)
	du[1] = u[1]-u[1]*h(t-1)[2]
	du[2] = -u[2]
end

u₀ = ones(2)
h = t -> u₀
lags = [1.]

prob = ConstantLagDDEProblem(f,h,u₀,lags,(0.,20.))
alg = MethodOfSteps(Tsit5())

sol = solve(prob,alg)
```
returns the following error on the `master` branch:
```julia
ERROR: MethodError: no method matching size(::Tuple{Int64})
Closest candidates are:
  size(::Tuple, ::Any) at tuple.jl:20
  size(::Any, ::Integer, ::Integer, ::Integer...) where N at abstractarray.jl:23
  size(::Char) at char.jl:13
  ...
Stacktrace:
 [1] ode_interpolant(::Float64, ::Float64, ::Array{Float64,1}, ::Array{Float64,1}, ::Array{Array{Float64,1},1}, ::OrdinaryDiffEq.Tsit5Cache{Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}}, ::Tuple{Int64}, ::Type{Val{0}}) at /home/david/.julia/v0.6/OrdinaryDiffEq/src/dense/generic_dense.jl:328
 [2] ode_interpolant at /home/david/.julia/v0.6/OrdinaryDiffEq/src/dense/generic_dense.jl:18 [inlined]
 [3] current_interpolant at /home/david/.julia/v0.6/OrdinaryDiffEq/src/dense/generic_dense.jl:36 [inlined]
 [4] (::DelayDiffEq.HistoryFunction{##1#2,DiffEqBase.ODESolution{Float64,2,Array{Array{Float64,1},1},Void,Void,Array{Float64,1},Array{Array{Array{Float64,1},1},1},DiffEqBase.ConstantLagDDEProblem{Array{Float64,1},Float64,Array{Float64,1},true,#f,##1#2,Void,UniformScaling{Int64}},OrdinaryDiffEq.Tsit5,OrdinaryDiffEq.InterpolationData{DelayDiffEq.##13#17{DiffEqBase.ConstantLagDDEProblem{Array{Float64,1},Float64,Array{Float64,1},true,#f,##1#2,Void,UniformScaling{Int64}}},Array{Array{Float64,1},1},Array{Float64,1},Array{Array{Array{Float64,1},1},1},OrdinaryDiffEq.Tsit5Cache{Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}}}},OrdinaryDiffEq.ODEIntegrator{OrdinaryDiffEq.Tsit5,Array{Float64,1},Float64,Float64,Float64,Array{Array{Float64,1},1},DiffEqBase.ODESolution{Float64,2,Array{Array{Float64,1},1},Void,Void,Array{Float64,1},Array{Array{Array{Float64,1},1},1},DiffEqBase.ODEProblem{Array{Float64,1},Float64,true,#f,Void,UniformScaling{Int64}},OrdinaryDiffEq.Tsit5,OrdinaryDiffEq.InterpolationData{#f,Array{Array{Float64,1},1},Array{Float64,1},Array{Array{Array{Float64,1},1},1},OrdinaryDiffEq.Tsit5Cache{Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}}}},Array{Float64,1},#f,Void,OrdinaryDiffEq.Tsit5Cache{Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}},OrdinaryDiffEq.DEOptions{Float64,Float64,Float64,Float64,DiffEqBase.#ODE_DEFAULT_NORM,DiffEqBase.CallbackSet{Tuple{},Tuple{}},DiffEqBase.#ODE_DEFAULT_ISOUTOFDOMAIN,DiffEqBase.#ODE_DEFAULT_PROG_MESSAGE,DiffEqBase.#ODE_DEFAULT_UNSTABLE_CHECK,DataStructures.BinaryHeap{Float64,DataStructures.LessThan},Void,Void},Array{Float64,1}}})(::Float64, ::Type{T} where T, ::Void) at /home/david/.julia/v0.6/DelayDiffEq/src/history_function.jl:18
 [5] (::DelayDiffEq.HistoryFunction{##1#2,DiffEqBase.ODESolution{Float64,2,Array{Array{Float64,1},1},Void,Void,Array{Float64,1},Array{Array{Array{Float64,1},1},1},DiffEqBase.ConstantLagDDEProblem{Array{Float64,1},Float64,Array{Float64,1},true,#f,##1#2,Void,UniformScaling{Int64}},OrdinaryDiffEq.Tsit5,OrdinaryDiffEq.InterpolationData{DelayDiffEq.##13#17{DiffEqBase.ConstantLagDDEProblem{Array{Float64,1},Float64,Array{Float64,1},true,#f,##1#2,Void,UniformScaling{Int64}}},Array{Array{Float64,1},1},Array{Float64,1},Array{Array{Array{Float64,1},1},1},OrdinaryDiffEq.Tsit5Cache{Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}}}},OrdinaryDiffEq.ODEIntegrator{OrdinaryDiffEq.Tsit5,Array{Float64,1},Float64,Float64,Float64,Array{Array{Float64,1},1},DiffEqBase.ODESolution{Float64,2,Array{Array{Float64,1},1},Void,Void,Array{Float64,1},Array{Array{Array{Float64,1},1},1},DiffEqBase.ODEProblem{Array{Float64,1},Float64,true,#f,Void,UniformScaling{Int64}},OrdinaryDiffEq.Tsit5,OrdinaryDiffEq.InterpolationData{#f,Array{Array{Float64,1},1},Array{Float64,1},Array{Array{Array{Float64,1},1},1},OrdinaryDiffEq.Tsit5Cache{Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}}}},Array{Float64,1},#f,Void,OrdinaryDiffEq.Tsit5Cache{Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}},OrdinaryDiffEq.DEOptions{Float64,Float64,Float64,Float64,DiffEqBase.#ODE_DEFAULT_NORM,DiffEqBase.CallbackSet{Tuple{},Tuple{}},DiffEqBase.#ODE_DEFAULT_ISOUTOFDOMAIN,DiffEqBase.#ODE_DEFAULT_PROG_MESSAGE,DiffEqBase.#ODE_DEFAULT_UNSTABLE_CHECK,DataStructures.BinaryHeap{Float64,DataStructures.LessThan},Void,Void},Array{Float64,1}}})(::Float64) at /home/david/.julia/v0.6/DelayDiffEq/src/history_function.jl:8
 [6] f at ./REPL[2]:2 [inlined]
 [7] (::DelayDiffEq.##15#19{DiffEqBase.ConstantLagDDEProblem{Array{Float64,1},Float64,Array{Float64,1},true,#f,##1#2,Void,UniformScaling{Int64}}})(::Float64, ::Array{Float64,1}, ::Array{Float64,1}) at /home/david/.julia/v0.6/DelayDiffEq/src/solve.jl:62
 [8] perform_step! at /home/david/.julia/v0.6/OrdinaryDiffEq/src/integrators/low_order_rk_integrators.jl:386 [inlined]
 [9] perform_step! at /home/david/.julia/v0.6/OrdinaryDiffEq/src/integrators/low_order_rk_integrators.jl:366 [inlined]
 [10] perform_step!(::DelayDiffEq.DDEIntegrator{OrdinaryDiffEq.Tsit5,Array{Float64,1},Float64,Float64,Float64,Array{Float64,1},Float64,Float64,Array{Array{Float64,1},1},DiffEqBase.ODESolution{Float64,2,Array{Array{Float64,1},1},Void,Void,Array{Float64,1},Array{Array{Array{Float64,1},1},1},DiffEqBase.ConstantLagDDEProblem{Array{Float64,1},Float64,Array{Float64,1},true,#f,##1#2,Void,UniformScaling{Int64}},OrdinaryDiffEq.Tsit5,OrdinaryDiffEq.InterpolationData{DelayDiffEq.##13#17{DiffEqBase.ConstantLagDDEProblem{Array{Float64,1},Float64,Array{Float64,1},true,#f,##1#2,Void,UniformScaling{Int64}}},Array{Array{Float64,1},1},Array{Float64,1},Array{Array{Array{Float64,1},1},1},OrdinaryDiffEq.Tsit5Cache{Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}}}},Array{Float64,1},DelayDiffEq.##15#19{DiffEqBase.ConstantLagDDEProblem{Array{Float64,1},Float64,Array{Float64,1},true,#f,##1#2,Void,UniformScaling{Int64}}},Void,OrdinaryDiffEq.Tsit5Cache{Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}},OrdinaryDiffEq.ODEIntegrator{OrdinaryDiffEq.Tsit5,Array{Float64,1},Float64,Float64,Float64,Array{Array{Float64,1},1},DiffEqBase.ODESolution{Float64,2,Array{Array{Float64,1},1},Void,Void,Array{Float64,1},Array{Array{Array{Float64,1},1},1},DiffEqBase.ODEProblem{Array{Float64,1},Float64,true,#f,Void,UniformScaling{Int64}},OrdinaryDiffEq.Tsit5,OrdinaryDiffEq.InterpolationData{#f,Array{Array{Float64,1},1},Array{Float64,1},Array{Array{Array{Float64,1},1},1},OrdinaryDiffEq.Tsit5Cache{Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}}}},Array{Float64,1},#f,Void,OrdinaryDiffEq.Tsit5Cache{Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}},OrdinaryDiffEq.DEOptions{Float64,Float64,Float64,Float64,DiffEqBase.#ODE_DEFAULT_NORM,DiffEqBase.CallbackSet{Tuple{},Tuple{}},DiffEqBase.#ODE_DEFAULT_ISOUTOFDOMAIN,DiffEqBase.#ODE_DEFAULT_PROG_MESSAGE,DiffEqBase.#ODE_DEFAULT_UNSTABLE_CHECK,DataStructures.BinaryHeap{Float64,DataStructures.LessThan},Void,Void},Array{Float64,1}},DiffEqBase.ConstantLagDDEProblem{Array{Float64,1},Float64,Array{Float64,1},true,#f,##1#2,Void,UniformScaling{Int64}},DiffEqBase.#ODE_DEFAULT_NORM,OrdinaryDiffEq.DEOptions{Float64,Float64,Float64,Float64,DiffEqBase.#ODE_DEFAULT_NORM,DiffEqBase.CallbackSet{Tuple{},Tuple{}},DiffEqBase.#ODE_DEFAULT_ISOUTOFDOMAIN,DiffEqBase.#ODE_DEFAULT_PROG_MESSAGE,DiffEqBase.#ODE_DEFAULT_UNSTABLE_CHECK,DataStructures.BinaryHeap{Float64,DataStructures.LessThan},Void,Void}}) at /home/david/.julia/v0.6/DelayDiffEq/src/integrator_interface.jl:39
 [11] solve!(::DelayDiffEq.DDEIntegrator{OrdinaryDiffEq.Tsit5,Array{Float64,1},Float64,Float64,Float64,Array{Float64,1},Float64,Float64,Array{Array{Float64,1},1},DiffEqBase.ODESolution{Float64,2,Array{Array{Float64,1},1},Void,Void,Array{Float64,1},Array{Array{Array{Float64,1},1},1},DiffEqBase.ConstantLagDDEProblem{Array{Float64,1},Float64,Array{Float64,1},true,#f,##1#2,Void,UniformScaling{Int64}},OrdinaryDiffEq.Tsit5,OrdinaryDiffEq.InterpolationData{DelayDiffEq.##13#17{DiffEqBase.ConstantLagDDEProblem{Array{Float64,1},Float64,Array{Float64,1},true,#f,##1#2,Void,UniformScaling{Int64}}},Array{Array{Float64,1},1},Array{Float64,1},Array{Array{Array{Float64,1},1},1},OrdinaryDiffEq.Tsit5Cache{Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}}}},Array{Float64,1},DelayDiffEq.##15#19{DiffEqBase.ConstantLagDDEProblem{Array{Float64,1},Float64,Array{Float64,1},true,#f,##1#2,Void,UniformScaling{Int64}}},Void,OrdinaryDiffEq.Tsit5Cache{Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}},OrdinaryDiffEq.ODEIntegrator{OrdinaryDiffEq.Tsit5,Array{Float64,1},Float64,Float64,Float64,Array{Array{Float64,1},1},DiffEqBase.ODESolution{Float64,2,Array{Array{Float64,1},1},Void,Void,Array{Float64,1},Array{Array{Array{Float64,1},1},1},DiffEqBase.ODEProblem{Array{Float64,1},Float64,true,#f,Void,UniformScaling{Int64}},OrdinaryDiffEq.Tsit5,OrdinaryDiffEq.InterpolationData{#f,Array{Array{Float64,1},1},Array{Float64,1},Array{Array{Array{Float64,1},1},1},OrdinaryDiffEq.Tsit5Cache{Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}}}},Array{Float64,1},#f,Void,OrdinaryDiffEq.Tsit5Cache{Array{Float64,1},Array{Float64,1},Array{Float64,1},Array{Float64,1},OrdinaryDiffEq.Tsit5ConstantCache{Float64,Float64}},OrdinaryDiffEq.DEOptions{Float64,Float64,Float64,Float64,DiffEqBase.#ODE_DEFAULT_NORM,DiffEqBase.CallbackSet{Tuple{},Tuple{}},DiffEqBase.#ODE_DEFAULT_ISOUTOFDOMAIN,DiffEqBase.#ODE_DEFAULT_PROG_MESSAGE,DiffEqBase.#ODE_DEFAULT_UNSTABLE_CHECK,DataStructures.BinaryHeap{Float64,DataStructures.LessThan},Void,Void},Array{Float64,1}},DiffEqBase.ConstantLagDDEProblem{Array{Float64,1},Float64,Array{Float64,1},true,#f,##1#2,Void,UniformScaling{Int64}},DiffEqBase.#ODE_DEFAULT_NORM,OrdinaryDiffEq.DEOptions{Float64,Float64,Float64,Float64,DiffEqBase.#ODE_DEFAULT_NORM,DiffEqBase.CallbackSet{Tuple{},Tuple{}},DiffEqBase.#ODE_DEFAULT_ISOUTOFDOMAIN,DiffEqBase.#ODE_DEFAULT_PROG_MESSAGE,DiffEqBase.#ODE_DEFAULT_UNSTABLE_CHECK,DataStructures.BinaryHeap{Float64,DataStructures.LessThan},Void,Void}}) at /home/david/.julia/v0.6/DelayDiffEq/src/solve.jl:136
 [12] #solve#23(::Array{Any,1}, ::Function, ::DiffEqBase.ConstantLagDDEProblem{Array{Float64,1},Float64,Array{Float64,1},true,#f,##1#2,Void,UniformScaling{Int64}}, ::DelayDiffEq.MethodOfSteps{OrdinaryDiffEq.Tsit5,Void,Void,Void,false}, ::Array{Array{Float64,1},1}, ::Array{Float64,1}, ::Array{Any,1}) at /home/david/.julia/v0.6/DelayDiffEq/src/solve.jl:164
 [13] solve(::DiffEqBase.ConstantLagDDEProblem{Array{Float64,1},Float64,Array{Float64,1},true,#f,##1#2,Void,UniformScaling{Int64}}, ::DelayDiffEq.MethodOfSteps{OrdinaryDiffEq.Tsit5,Void,Void,Void,false}) at /home/david/.julia/v0.6/DelayDiffEq/src/solve.jl:163
```
This is fixed by the proposed change.