### PR TITLE
Remove restriction on types of absolute and relative tolerances

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -39,9 +39,9 @@ function perform_step!(integrator::DDEIntegrator)
       perform_step!(integrator,integrator.cache)
 
       if typeof(integrator.resid) <: AbstractArray
-        integrator.resid .= (integrator.u .- integrator.u_cache)./(integrator.picardabstol .+ max.(abs.(integrator.u),abs.(integrator.u_cache))*integrator.picardreltol)
+        integrator.resid .= (integrator.u .- integrator.u_cache)./(integrator.picardabstol .+ max.(abs.(integrator.u),abs.(integrator.u_cache)).*integrator.picardreltol)
       else
-        integrator.resid = (integrator.u .- integrator.u_cache)./(integrator.picardabstol .+ max.(abs.(integrator.u),abs.(integrator.u_cache))*integrator.picardreltol)
+        integrator.resid = (integrator.u .- integrator.u_cache)./(integrator.picardabstol .+ max.(abs.(integrator.u),abs.(integrator.u_cache)).*integrator.picardreltol)
       end
 
       picardEEst = integrator.picardnorm(integrator.resid)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -113,7 +113,7 @@ function init{uType,tType,isinplace,algType<:AbstractMethodOfStepsAlgorithm,lTyp
                              typeof(integrator.opts)}(
       sol,prob,integrator.u,integrator.k,integrator.t,integrator.dt,
       dde_f2,integrator.uprev,integrator.tprev,u_cache,
-      eltype(integrator.u)(picardabstol_internal),uEltypeNoUnits(picardreltol_internal),
+      picardabstol_internal,picardreltol_internal,
       resid,picardnorm,alg.max_picard_iters,
       integrator.alg,integrator.rate_prototype,integrator.notsaveat_idxs,integrator.dtcache,
       integrator.dtchangeable,integrator.dtpropose,integrator.tdir,

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -67,21 +67,16 @@ function init{uType,tType,isinplace,algType<:AbstractMethodOfStepsAlgorithm,lTyp
   if dt == zero(dt) && integrator.opts.adaptive
     ode_prob = ODEProblem(dde_f2,prob.u0,prob.tspan)
     dt = tType(OrdinaryDiffEq.ode_determine_initdt(prob.u0,prob.tspan[1],
-              integrator.tdir,min(prob.lags...),integrator.opts.abstol,
+              integrator.tdir,minimum(prob.lags),integrator.opts.abstol,
               integrator.opts.reltol,integrator.opts.internalnorm,
               ode_prob,OrdinaryDiffEq.alg_order(alg)))
   end
   integrator.dt = dt
 
   if typeof(alg.picardabstol) <: Void
-    picardabstol_internal = integrator.opts.abstol
+    picardabstol_internal = map(eltype(uType),integrator.opts.abstol)
   else
-    picardabstol_internal = alg.picardabstol
-  end
-  if typeof(alg.picardreltol) <: Void
-    picardreltol_internal = integrator.opts.reltol
-  else
-    picardreltol_internal = alg.picardreltol
+    picardabstol_internal = map(eltype(uType),alg.picardabstol)
   end
   if typeof(alg.picardnorm) <: Void
     picardnorm = integrator.opts.internalnorm
@@ -90,12 +85,17 @@ function init{uType,tType,isinplace,algType<:AbstractMethodOfStepsAlgorithm,lTyp
 
   uEltypeNoUnits = typeof(recursive_one(integrator.u))
 
+  if typeof(alg.picardreltol) <: Void
+    picardreltol_internal = map(uEltypeNoUnits,integrator.opts.reltol)
+  else
+    picardreltol_internal = map(uEltypeNoUnits,alg.picardreltol)
+  end
   if typeof(integrator.u) <: AbstractArray
     resid = similar(integrator.u,uEltypeNoUnits)
     u_cache = similar(integrator.u)
   else
-    resid = uEltypeNoUnits(1)
-    u_cache = one(uType)
+    resid = one(uEltypeNoUnits)
+    u_cache = oneunit(eltype(uType))
   end
 
   dde_int = DDEIntegrator{typeof(integrator.alg),

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,3 @@
 DiffEqDevTools
 DiffEqCallbacks
+Unitful

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,3 +5,4 @@ using Base.Test
 @time @testset "Constrained Timestep" begin include("constrained.jl") end
 @time @testset "Unconstrained Timestep" begin include("unconstrained.jl") end
 @time @testset "Events" begin include("events.jl") end
+@time @testset "Units" begin include("units.jl") end

--- a/test/units.jl
+++ b/test/units.jl
@@ -1,0 +1,83 @@
+using Unitful, DelayDiffEq, DiffEqBase, OrdinaryDiffEq, Base.Test
+
+lags = [.2u"s"]
+
+# Scalar problem, not in-place
+f = function (t,u,h)
+  out = (-h(t-.2u"s") + u) / 1.0u"s"
+end
+h = (t) -> 0.0u"N"
+
+prob = ConstantLagDDEProblem(f,h,1.0u"N",lags,(0.0u"s",100.0u"s"))
+
+# Unconstrained algorithm without explicit absolut or relative tolerance
+alg = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100)
+solve(prob,alg)
+
+# Unconstrained algorithm without units
+alg = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
+sol = solve(prob,alg)
+
+# Unconstrained algorithm with correct units
+alg2 = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=1e-9u"mN",picardreltol=1e-12)
+sol2 = solve(prob,alg2)
+
+@test sol.t == sol2.t && sol.u == sol2.u
+
+# Unconstrained algorithm with incorrect units for absolute tolerance
+alg = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=1e-12u"s",picardreltol=1e-12)
+@test_throws Unitful.DimensionError solve(prob,alg)
+
+# Unconstrained algorithm with units for relative tolerance
+alg = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12u"N")
+@test_throws Unitful.DimensionError solve(prob,alg)
+
+# Constrained algorithm without explicit absolute or relative tolerance
+alg = MethodOfSteps(Tsit5(),constrained=true,max_picard_iters=100)
+solve(prob,alg)
+
+# Constrained algorithm without units
+alg = MethodOfSteps(Tsit5(),constrained=true,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
+sol = solve(prob,alg)
+
+# Constrained algorithm with correct units
+alg2 = MethodOfSteps(Tsit5(),constrained=true,max_picard_iters=100,picardabstol=1e-9u"mN",picardreltol=1e-12)
+sol2 = solve(prob,alg2)
+
+@test sol.t == sol2.t && sol.u == sol2.u
+
+# Vector problem, in-place
+f = function (t,u,h,du)
+  du[1] = (-h(t-.2u"s")[1] + u[1]) / 1.0u"s"
+end
+h = (t) -> [0.0u"N"]
+
+prob = ConstantLagDDEProblem(f,h,[1.0u"N"],lags,(0.0u"s",100.0u"s"))
+
+# Unconstrained algorithm without explicit absolute or relative tolerance
+alg = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100)
+solve(prob,alg)
+
+# Unconstrained algorithm without units
+alg = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
+sol = solve(prob,alg)
+
+# Unconstrained algorithm with correct units and both absolute and relative tolerance as vector
+alg2 = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=[1e-9u"mN"],picardreltol=[1e-12])
+sol2 = solve(prob,alg2)
+
+@test sol.t == sol2.t && sol.u == sol2.u
+
+# Constrained algorithm without explicit absolute or relative tolerance
+alg = MethodOfSteps(Tsit5(),constrained=true,max_picard_iters=100)
+solve(prob,alg)
+
+# Constrained algorithm without units
+alg = MethodOfSteps(Tsit5(),constrained=true,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
+sol = solve(prob,alg)
+
+# Constrained algorithm with correct units and both absolute and relative tolerance as vector
+alg2 = MethodOfSteps(Tsit5(),constrained=true,max_picard_iters=100,picardabstol=[1e-9u"mN"],picardreltol=[1e-12])
+sol2 = solve(prob,alg2)
+
+@test sol.t == sol2.t && sol.u == sol2.u


### PR DESCRIPTION
Hi!

This PR removes the restriction on the types of `picardabstol_internal` and `picardreltol_internal` in the constructor of a DDE integrator. As specified in the constructor already, both should be of type `typeof(picardabstol_internal)` and `typeof(picardreltol_internal)` anyway.

This is necessary to be able to use the `AutoAbstol` callback from DiffEqCallbacks.jl with element-wise absolute tolerances.