### PR TITLE
Fix duplicate time points in solution

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -10,7 +10,7 @@ function postamble!(integrator::DDEIntegrator)
   integrator.integrator.u = integrator.u
   integrator.integrator.k = integrator.k
   integrator.integrator.t = integrator.t
-  savevalues!(integrator.integrator)
+  OrdinaryDiffEq.postamble!(integrator.integrator)
 end
 
 function perform_step!(integrator::DDEIntegrator)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,3 +6,4 @@ using Base.Test
 @time @testset "Unconstrained Timestep" begin include("unconstrained.jl") end
 @time @testset "Events" begin include("events.jl") end
 @time @testset "Units" begin include("units.jl") end
+@time @testset "Unique Times" begin include("unique_times.jl") end

--- a/test/unique_times.jl
+++ b/test/unique_times.jl
@@ -1,0 +1,17 @@
+using DelayDiffEq, DiffEqBase, OrdinaryDiffEq, Base.Test
+
+lags = [.2]
+
+f = function (t,u,h,du)
+  du[1] = -h(t-.2)[1] + u[1]
+end
+h = (t) -> [0.0]
+
+prob = ConstantLagDDEProblem(f,h,[1.0],lags,(0.0,100.0))
+
+for constrained in (false,true)
+  alg = MethodOfSteps(Tsit5(),constrained=constrained)
+  sol = solve(prob,alg)
+
+  @test allunique(sol.t)
+end


### PR DESCRIPTION
Hi!

This fixes duplicate final time points in the solution of the DDE solver. There's still a problem with initial discontinuities that occur after the final time point of `tspan`, but I guess that can be fixed by altering the definition of `tstops_internal` in OrdinaryDiffEq. I'll check if my assumption is correct ;)