### PR TITLE
WIP: Integration of Anderson acceleration of fixed-point iteration

### DIFF
--- a/src/DelayDiffEq.jl
+++ b/src/DelayDiffEq.jl
@@ -9,7 +9,7 @@ using OrdinaryDiffEq, DataStructures, RecursiveArrayTools, Combinatorics
 
 using Compat
 
-using Base.Test
+using NLsolve
 
 import OrdinaryDiffEq: initialize!, perform_step!, loopfooter!,
        loopheader!, alg_order, handle_tstop!, ODEIntegrator, savevalues!,
@@ -22,6 +22,9 @@ import DiffEqBase: solve, solve!, init, resize!, u_cache, user_cache,
 import OrdinaryDiffEq: Rosenbrock23Cache, Rosenbrock32Cache,
                        ImplicitEulerCache, TrapezoidCache
 
+import NLsolve: AbstractDifferentiableMultivariateFunction
+
+include("iteration_function.jl")
 include("integrator_type.jl")
 include("integrator_interface.jl")
 include("history_function.jl")

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -3,15 +3,17 @@
 
 immutable MethodOfSteps{algType,AType,RType,NType,constrained} <: AbstractMethodOfStepsAlgorithm{constrained}
   alg::algType
-  picardabstol::AType
-  picardreltol::RType
-  picardnorm::NType
-  max_picard_iters::Int
+  fixedpoint_abstol::AType
+  fixedpoint_reltol::RType
+  max_fixedpoint_iters::Int
+  picardnorm::NType # anderson acceleration with nlsolve always uses infinite norm of residuals
+  m::Int # controls history size of anderson acceleration (m=0 corresponds to simple fixed-point iteration)
 end
 
 Base.@pure MethodOfSteps(alg;constrained=false,
-                             picardabstol = nothing,
-                             picardreltol = nothing,
-                             picardnorm   = nothing,
-                             max_picard_iters = 10) =
-                             MethodOfSteps{typeof(alg),typeof(picardabstol),typeof(picardreltol),typeof(picardnorm),constrained}(alg,picardabstol,picardreltol,picardnorm,max_picard_iters)
+                             fixedpoint_abstol = nothing,
+                             fixedpoint_reltol = nothing,
+                             max_fixedpoint_iters = 10,
+                             picardnorm = nothing,
+                             m = 0) =
+                             MethodOfSteps{typeof(alg),typeof(fixedpoint_abstol),typeof(fixedpoint_reltol),typeof(picardnorm),constrained}(alg,fixedpoint_abstol,fixedpoint_reltol,max_fixedpoint_iters,picardnorm,m)

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -1,67 +1,102 @@
 function savevalues!(integrator::DDEIntegrator,force_save=false)
+  # update ODE integrator with values of DDE integrator
   integrator.integrator.u = integrator.u
   integrator.integrator.k = integrator.k
   integrator.integrator.t = integrator.t
+
+  # add steps for interpolation when needed
   OrdinaryDiffEq.ode_addsteps!(integrator.integrator,integrator.f)
+
+  # update solution of ODE integrator
   savevalues!(integrator.integrator,force_save)
 end
 
 function postamble!(integrator::DDEIntegrator)
+  # update ODE integrator with values of DDE integrator
   integrator.integrator.u = integrator.u
   integrator.integrator.k = integrator.k
   integrator.integrator.t = integrator.t
+
+  # clean up solution of ODE integrator
   OrdinaryDiffEq.postamble!(integrator.integrator)
 end
 
 function perform_step!(integrator::DDEIntegrator)
   integrator.tprev = integrator.t # this is necessary to extrapolate from the current interval
+
+  # update ODE integrator with values of DDE integrator
   integrator.integrator.uprev = integrator.uprev
   integrator.integrator.tprev = integrator.tprev
   integrator.integrator.fsalfirst = integrator.fsalfirst
   integrator.integrator.t = integrator.t
   integrator.integrator.dt = integrator.dt
 
-  # if dt>max lag, then it's explicit so use Picard iteration
+  # if dt>min lag, then it's explicit so use fixed-point iteration
   if integrator.dt >minimum(integrator.prob.lags)
-
-    # the is done to correct the extrapolation
-    t_prev_cache = integrator.tprev
+    # this is done to correct the extrapolation
     t_cache = integrator.t
-    uprev_cache = integrator.uprev
-
-    numiters = 1
-    while true
-      if typeof(integrator.u) <: AbstractArray
-        copy!(integrator.u_cache,integrator.u)
-      else
-        integrator.u_cache = integrator.u
-      end
-      perform_step!(integrator,integrator.cache)
-
-      if typeof(integrator.resid) <: AbstractArray
-        integrator.resid .= (integrator.u .- integrator.u_cache)./(integrator.picardabstol .+ max.(abs.(integrator.u),abs.(integrator.u_cache)).*integrator.picardreltol)
-      else
-        integrator.resid = (integrator.u .- integrator.u_cache)./(integrator.picardabstol .+ max.(abs.(integrator.u),abs.(integrator.u_cache)).*integrator.picardreltol)
-      end
-
-      picardEEst = integrator.picardnorm(integrator.resid)
-      if picardEEst < 1 || numiters > integrator.max_picard_iters
-        break
-      end
-      if numiters == 1
-        integrator.integrator.tprev = integrator.t
-        integrator.integrator.t = integrator.t+integrator.dt
-        integrator.integrator.uprev = integrator.u
-      end
-      integrator.integrator.u = integrator.u
-      integrator.integrator.k = integrator.k
-      numiters += 1
+    tprev_cache = integrator.tprev
+    if typeof(integrator.uprev_cache) <: AbstractArray
+      copy!(integrator.uprev_cache,integrator.uprev)
+    else
+      integrator.uprev_cache = integrator.uprev
     end
-    integrator.t = t_cache
-    integrator.integrator.t = t_cache
-    integrator.tprev = t_prev_cache
-    integrator.uprev = uprev_cache
 
+    if eltype(integrator.u) <: Real # not possible to use nlsolve with units (yet)
+      integrator.first_iteration = true # first iteration step needs special updates
+
+      # execute Anderson acceleration of fixed-point iteration
+      if typeof(integrator.u) <: Vector
+        nlsolve(integrator.iterator,integrator.u;
+	        method=:anderson,m=integrator.m,iterations=integrator.max_fixedpoint_iters,xtol=0,ftol=1)
+      else
+        nlsolve(integrator.iterator,vec(collect(integrator.u));
+	        method=:anderson,m=integrator.m,iterations=integrator.max_fixedpoint_iters,xtol=0,ftol=1)
+      end
+    else # simple Picard iteration for units
+      for i in 1:integrator.max_fixedpoint_iters
+        # update cache of u
+        if typeof(integrator.u) <: AbstractArray
+          copy!(integrator.u_cache,integrator.u)
+        else
+          integrator.u_cache = integrator.u
+        end
+
+        perform_step!(integrator,integrator.cache)
+
+	# calculate residuals
+        if typeof(integrator.resid) <: AbstractArray
+          @. integrator.resid = (integrator.u - integrator.u_cache)/
+            @muladd(integrator.fixedpoint_abstol + max(abs(integrator.u),abs(integrator.u_cache))*integrator.fixedpoint_reltol)
+        else
+          integrator.resid = @. (integrator.u - integrator.u_cache)/
+            (integrator.fixedpoint_abstol + max(abs(integrator.u),abs(integrator.u_cache))*integrator.fixedpoint_reltol)
+        end
+
+	# special updates of ODE integrator in first iteration step
+        if i == 1
+          integrator.integrator.tprev = integrator.t
+          integrator.integrator.t = integrator.t+integrator.dt
+          integrator.integrator.uprev = integrator.u
+        end
+
+	# update ODE integrator with values of DDE integrator
+        integrator.integrator.u = integrator.u
+        integrator.integrator.k = integrator.k
+
+	# stop fixed-point iteration when residuals are small
+	integrator.picardnorm(integrator.resid) < 1 && break
+      end
+    end
+    
+    # reset to cached values
+    integrator.t = t_cache
+    integrator.tprev = tprev_cache
+    if typeof(integrator.uprev) <: AbstractArray
+      copy!(integrator.uprev,integrator.uprev_cache)
+    else
+      integrator.uprev = integrator.uprev_cache
+    end
   else # no iterations
     perform_step!(integrator,integrator.cache)
   end

--- a/src/iteration_function.jl
+++ b/src/iteration_function.jl
@@ -1,0 +1,41 @@
+# nlsolve optimizes subtypes of AbstractDifferentiableMultivariateFunction
+mutable struct IterationFunction{I<:AbstractDDEIntegrator} <: AbstractDifferentiableMultivariateFunction
+  integrator::I
+  f!::IterationFunction{I} # Anderson acceleration needs field f!
+
+  function IterationFunction{I}(integrator::I) where I <:AbstractDDEIntegrator
+    f = new(integrator)
+    f.f! = f
+  end
+end
+
+function (f::IterationFunction)(x,fvec)
+  integrator = f.integrator  
+
+  # update u
+  if typeof(integrator.u) <: AbstractArray
+    copy!(integrator.u,x)
+  else
+    integrator.u = x[1] # x is always a vector
+  end
+
+  perform_step!(integrator,integrator.cache)
+
+  # update output vector of residuals
+  # in contrast to picard iteration we can not use integrator.resid
+  # as output vector for different fixed-point iterations
+  @. fvec = (integrator.u - x)/
+    @muladd(integrator.fixedpoint_abstol + max(abs(integrator.u),abs(x))*integrator.fixedpoint_reltol)
+ 
+  # special updates of ODE integrator after the first iteration necessary
+  if integrator.first_iteration
+    integrator.integrator.tprev = integrator.t
+    integrator.integrator.t = integrator.t+integrator.dt
+    integrator.integrator.uprev = integrator.u
+    integrator.first_iteration = false
+  end
+
+  # update ODE integrator with values of DDE integrator
+  integrator.integrator.u = integrator.u
+  integrator.integrator.k = integrator.k
+end

--- a/test/unconstrained.jl
+++ b/test/unconstrained.jl
@@ -14,16 +14,16 @@ h = (t) -> 0.0
 
 prob = ConstantLagDDEProblem(f,h,1.0,lags,(0.0,100.0))
 
-alg1 = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
+alg1 = MethodOfSteps(Tsit5(),constrained=false,max_fixedpoint_iters=100,fixedpoint_abstol=1e-12,fixedpoint_reltol=1e-12)
 sol1 = solve(prob,alg1)
 
-alg2 = MethodOfSteps(DP8(),constrained=false,max_picard_iters=10,picardabstol=1e-8,picardreltol=1e-10)
+alg2 = MethodOfSteps(DP8(),constrained=false,max_fixedpoint_iters=10,fixedpoint_abstol=1e-8,fixedpoint_reltol=1e-10)
 sol2 = solve(prob,alg2)
 
-alg3 = MethodOfSteps(Tsit5(),constrained=true,max_picard_iters=10,picardabstol=1e-8,picardreltol=1e-10)
+alg3 = MethodOfSteps(Tsit5(),constrained=true,max_fixedpoint_iters=10,fixedpoint_abstol=1e-8,fixedpoint_reltol=1e-10)
 sol3 = solve(prob,alg3)
 
-alg4 = MethodOfSteps(DP5(),constrained=false,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
+alg4 = MethodOfSteps(DP5(),constrained=false,max_fixedpoint_iters=100,fixedpoint_abstol=1e-12,fixedpoint_reltol=1e-12)
 sol4 = solve(prob,alg4)
 
 @test abs(sol1[end] - sol2[end]) < 1e-3
@@ -38,16 +38,16 @@ h = (t) -> 0.0
 
 prob = ConstantLagDDEProblem(f,h,1.0,lags,(0.0,10.0);iip=DiffEqBase.isinplace(f,4))
 
-alg1 = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
+alg1 = MethodOfSteps(Tsit5(),constrained=false,max_fixedpoint_iters=100,fixedpoint_abstol=1e-12,fixedpoint_reltol=1e-12)
 sol1 = solve(prob,alg1)
 
-alg2 = MethodOfSteps(DP8(),constrained=false,max_picard_iters=10,picardabstol=1e-8,picardreltol=1e-10)
+alg2 = MethodOfSteps(DP8(),constrained=false,max_fixedpoint_iters=10,fixedpoint_abstol=1e-8,fixedpoint_reltol=1e-10)
 sol2 = solve(prob,alg2)
 
-alg3 = MethodOfSteps(Tsit5(),constrained=true,max_picard_iters=10,picardabstol=1e-8,picardreltol=1e-10)
+alg3 = MethodOfSteps(Tsit5(),constrained=true,max_fixedpoint_iters=10,fixedpoint_abstol=1e-8,fixedpoint_reltol=1e-10)
 sol3 = solve(prob,alg3)
 
-alg4 = MethodOfSteps(DP5(),constrained=false,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
+alg4 = MethodOfSteps(DP5(),constrained=false,max_fixedpoint_iters=100,fixedpoint_abstol=1e-12,fixedpoint_reltol=1e-12)
 sol4 = solve(prob,alg4)
 
 @test abs(sol1[end] - sol2[end]) < 1e-3
@@ -72,7 +72,7 @@ end
 
 prob = ConstantLagDDEProblem(f,h,[1.0],lags,(0.0,100.0))
 
-alg1 = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
+alg1 = MethodOfSteps(Tsit5(),constrained=false,max_fixedpoint_iters=100,fixedpoint_abstol=1e-12,fixedpoint_reltol=1e-12)
 @time sol1 = solve(prob,alg1)
 
 f = function (t,u,h,du)
@@ -94,5 +94,5 @@ end
 
 prob = ConstantLagDDEProblem(f,h,[1.0],lags,(0.0,100.0))
 
-alg1 = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
+alg1 = MethodOfSteps(Tsit5(),constrained=false,max_fixedpoint_iters=100,fixedpoint_abstol=1e-12,fixedpoint_reltol=1e-12)
 @time sol1 = solve(prob,alg1)

--- a/test/units.jl
+++ b/test/units.jl
@@ -11,37 +11,37 @@ h = (t) -> 0.0u"N"
 prob = ConstantLagDDEProblem(f,h,1.0u"N",lags,(0.0u"s",100.0u"s"))
 
 # Unconstrained algorithm without explicit absolut or relative tolerance
-alg = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100)
+alg = MethodOfSteps(Tsit5(),constrained=false,max_fixedpoint_iters=100)
 solve(prob,alg)
 
 # Unconstrained algorithm without units
-alg = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
+alg = MethodOfSteps(Tsit5(),constrained=false,max_fixedpoint_iters=100,fixedpoint_abstol=1e-12,fixedpoint_reltol=1e-12)
 sol = solve(prob,alg)
 
 # Unconstrained algorithm with correct units
-alg2 = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=1e-9u"mN",picardreltol=1e-12)
+alg2 = MethodOfSteps(Tsit5(),constrained=false,max_fixedpoint_iters=100,fixedpoint_abstol=1e-9u"mN",fixedpoint_reltol=1e-12)
 sol2 = solve(prob,alg2)
 
 @test sol.t == sol2.t && sol.u == sol2.u
 
 # Unconstrained algorithm with incorrect units for absolute tolerance
-alg = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=1e-12u"s",picardreltol=1e-12)
+alg = MethodOfSteps(Tsit5(),constrained=false,max_fixedpoint_iters=100,fixedpoint_abstol=1e-12u"s",fixedpoint_reltol=1e-12)
 @test_throws Unitful.DimensionError solve(prob,alg)
 
 # Unconstrained algorithm with units for relative tolerance
-alg = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12u"N")
+alg = MethodOfSteps(Tsit5(),constrained=false,max_fixedpoint_iters=100,fixedpoint_abstol=1e-12,fixedpoint_reltol=1e-12u"N")
 @test_throws Unitful.DimensionError solve(prob,alg)
 
 # Constrained algorithm without explicit absolute or relative tolerance
-alg = MethodOfSteps(Tsit5(),constrained=true,max_picard_iters=100)
+alg = MethodOfSteps(Tsit5(),constrained=true,max_fixedpoint_iters=100)
 solve(prob,alg)
 
 # Constrained algorithm without units
-alg = MethodOfSteps(Tsit5(),constrained=true,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
+alg = MethodOfSteps(Tsit5(),constrained=true,max_fixedpoint_iters=100,fixedpoint_abstol=1e-12,fixedpoint_reltol=1e-12)
 sol = solve(prob,alg)
 
 # Constrained algorithm with correct units
-alg2 = MethodOfSteps(Tsit5(),constrained=true,max_picard_iters=100,picardabstol=1e-9u"mN",picardreltol=1e-12)
+alg2 = MethodOfSteps(Tsit5(),constrained=true,max_fixedpoint_iters=100,fixedpoint_abstol=1e-9u"mN",fixedpoint_reltol=1e-12)
 sol2 = solve(prob,alg2)
 
 @test sol.t == sol2.t && sol.u == sol2.u
@@ -55,29 +55,29 @@ h = (t) -> [0.0u"N"]
 prob = ConstantLagDDEProblem(f,h,[1.0u"N"],lags,(0.0u"s",100.0u"s"))
 
 # Unconstrained algorithm without explicit absolute or relative tolerance
-alg = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100)
+alg = MethodOfSteps(Tsit5(),constrained=false,max_fixedpoint_iters=100)
 solve(prob,alg)
 
 # Unconstrained algorithm without units
-alg = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
+alg = MethodOfSteps(Tsit5(),constrained=false,max_fixedpoint_iters=100,fixedpoint_abstol=1e-12,fixedpoint_reltol=1e-12)
 sol = solve(prob,alg)
 
 # Unconstrained algorithm with correct units and both absolute and relative tolerance as vector
-alg2 = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=[1e-9u"mN"],picardreltol=[1e-12])
+alg2 = MethodOfSteps(Tsit5(),constrained=false,max_fixedpoint_iters=100,fixedpoint_abstol=[1e-9u"mN"],fixedpoint_reltol=[1e-12])
 sol2 = solve(prob,alg2)
 
 @test sol.t == sol2.t && sol.u == sol2.u
 
 # Constrained algorithm without explicit absolute or relative tolerance
-alg = MethodOfSteps(Tsit5(),constrained=true,max_picard_iters=100)
+alg = MethodOfSteps(Tsit5(),constrained=true,max_fixedpoint_iters=100)
 solve(prob,alg)
 
 # Constrained algorithm without units
-alg = MethodOfSteps(Tsit5(),constrained=true,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
+alg = MethodOfSteps(Tsit5(),constrained=true,max_fixedpoint_iters=100,fixedpoint_abstol=1e-12,fixedpoint_reltol=1e-12)
 sol = solve(prob,alg)
 
 # Constrained algorithm with correct units and both absolute and relative tolerance as vector
-alg2 = MethodOfSteps(Tsit5(),constrained=true,max_picard_iters=100,picardabstol=[1e-9u"mN"],picardreltol=[1e-12])
+alg2 = MethodOfSteps(Tsit5(),constrained=true,max_fixedpoint_iters=100,fixedpoint_abstol=[1e-9u"mN"],fixedpoint_reltol=[1e-12])
 sol2 = solve(prob,alg2)
 
 @test sol.t == sol2.t && sol.u == sol2.u


### PR DESCRIPTION
This is a first draft trying to integrate Anderson acceleration. Unfortunately (currently) NLsolve accepts only vectors of real numbers, so I had to keep the simple Picard iteration for compatibility with Unitful.jl. Locally the tests passed already, however it is not benchmarked yet. I also tried to improve readability by adding some comments.