### PR TITLE
Naming changes, comments, and consistent formatting

### DIFF
--- a/src/DelayDiffEq.jl
+++ b/src/DelayDiffEq.jl
@@ -4,23 +4,17 @@ module DelayDiffEq
 
 using Reexport
 @reexport using DiffEqBase
-  
+
 using OrdinaryDiffEq, DataStructures, RecursiveArrayTools, Combinatorics
 
-using Compat
+import OrdinaryDiffEq: initialize!, perform_step!, loopfooter!, loopheader!, alg_order,
+                       handle_tstop!, ODEIntegrator, savevalues!, handle_callback_modifiers!
 
-using Base.Test
+import DiffEqBase: solve, solve!, init, resize!, u_cache, user_cache, du_cache, full_cache,
+                   deleteat!, terminate!, u_modified!, get_proposed_dt, set_proposed_dt!
 
-import OrdinaryDiffEq: initialize!, perform_step!, loopfooter!,
-       loopheader!, alg_order, handle_tstop!, ODEIntegrator, savevalues!,
-       handle_callback_modifiers!
-
-import DiffEqBase: solve, solve!, init, resize!, u_cache, user_cache,
-                   du_cache, full_cache, deleteat!, terminate!, u_modified!,
-                   get_proposed_dt, set_proposed_dt!
-
-import OrdinaryDiffEq: Rosenbrock23Cache, Rosenbrock32Cache,
-                       ImplicitEulerCache, TrapezoidCache
+import OrdinaryDiffEq: Rosenbrock23Cache, Rosenbrock32Cache, ImplicitEulerCache,
+                       TrapezoidCache
 
 include("integrator_type.jl")
 include("integrator_interface.jl")

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -1,2 +1,4 @@
 alg_order(alg::AbstractMethodOfStepsAlgorithm) = alg_order(alg.alg)
-isconstrained{constrained}(alg::AbstractMethodOfStepsAlgorithm{constrained}) = constrained
+
+isconstrained(alg::AbstractMethodOfStepsAlgorithm{constrained}) where constrained =
+    constrained

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -1,17 +1,41 @@
-@compat abstract type DelayDiffEqAlgorithm <: AbstractDDEAlgorithm end
-@compat abstract type AbstractMethodOfStepsAlgorithm{constrained} <: DelayDiffEqAlgorithm end
+abstract type DelayDiffEqAlgorithm <: AbstractDDEAlgorithm end
+abstract type AbstractMethodOfStepsAlgorithm{constrained} <: DelayDiffEqAlgorithm end
 
-immutable MethodOfSteps{algType,AType,RType,NType,constrained} <: AbstractMethodOfStepsAlgorithm{constrained}
-  alg::algType
-  picardabstol::AType
-  picardreltol::RType
-  picardnorm::NType
-  max_picard_iters::Int
+struct MethodOfSteps{algType,AType,RType,NType,constrained} <:
+    AbstractMethodOfStepsAlgorithm{constrained}
+
+    alg::algType
+    fixedpoint_abstol::AType
+    fixedpoint_reltol::RType
+    fixedpoint_norm::NType
+    max_fixedpoint_iters::Int
 end
 
-Base.@pure MethodOfSteps(alg;constrained=false,
-                             picardabstol = nothing,
-                             picardreltol = nothing,
-                             picardnorm   = nothing,
-                             max_picard_iters = 10) =
-                             MethodOfSteps{typeof(alg),typeof(picardabstol),typeof(picardreltol),typeof(picardnorm),constrained}(alg,picardabstol,picardreltol,picardnorm,max_picard_iters)
+"""
+    MethodOfSteps(alg; constrained::Bool=false, fixedpoint_abstol=nothing,
+                  fixedpoint_reltol=nothing, fixedpoint_norm=nothing,
+                  max_fixedpoint_iters::Int=10)
+
+Construct an algorithm that solves delay differential equations by the method of steps,
+where `alg` is an ODE algorithm from OrdinaryDiffEq.jl without lazy interpolation upon
+which the calculation of steps is based.
+
+If the algorithm is `constrained` only steps of size at most the minimal delay will be
+taken. If it is unconstrained, fixed-point iteration is applied for step sizes that exceed
+the minimal delay.
+
+The absolute and relative tolerance of the fixed-point iterations can be set by
+`fixedpoint_abstol` and `fixedpoint_reltol`, respectively, either as scalars or vectors.
+Based on these tolerances error estimates are calculated during the fixed-point iterations
+with a norm that may be specified as `fixedpoint_norm`. Fixed-point iterations are stopped
+if the error estimate is less than 1 or after the maximal number `max_fixedpoint_iters` of
+iteration steps.
+"""
+Base.@pure function MethodOfSteps(alg; constrained::Bool=false, fixedpoint_abstol=nothing,
+                                  fixedpoint_reltol=nothing, fixedpoint_norm=nothing,
+                                  max_fixedpoint_iters::Int=10)
+    MethodOfSteps{typeof(alg),typeof(fixedpoint_abstol),typeof(fixedpoint_reltol),
+                  typeof(fixedpoint_norm),constrained}(alg,fixedpoint_abstol,
+                                                       fixedpoint_reltol,
+                                                       fixedpoint_norm, max_fixedpoint_iters)
+end

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -1,4 +1,9 @@
+# update integrator when u is modified by callbacks
 @inline function handle_callback_modifiers!(integrator::DDEIntegrator)
-  integrator.reeval_fsal = true
-  push!(integrator.opts.d_discontinuities,compute_discontinuity_tree(integrator.sol.prob.lags,integrator.alg,integrator.t)...)
+    integrator.reeval_fsal = true # recalculate fsalfirst after applying step
+
+    # update heap of discontinuities
+    push!(integrator.opts.d_discontinuities,
+          compute_discontinuity_tree(integrator.sol.prob.lags, integrator.alg,
+                                     integrator.t)...)
 end

--- a/src/history_function.jl
+++ b/src/history_function.jl
@@ -1,33 +1,44 @@
-immutable HistoryFunction{F1,F2,F3} <: Function
-  h::F1
-  sol::F2
-  integrator::F3
+"""
+    HistoryFunction(h, sol, integrator)
+
+Wrap history function `h`, solution `sol`, and integrator `integrator` to create a common
+interface for retrieving values at any time point with varying accuracy.
+
+Before the initial time point of solution `sol` values are calculated by history function
+`h`, for time points in the time span of `sol` interpolated values of `sol` are returned,
+and after the final time point of `sol` an inter- or extrapolation of the current state 
+of integrator `integrator` is retrieved.
+"""
+struct HistoryFunction{F1,F2,F3} <: Function
+    h::F1
+    sol::F2
+    integrator::F3
 end
 
-function (f::HistoryFunction)(t,deriv::Type=Val{0},idxs=nothing)
-  @inbounds if t < f.sol.t[1]
-    if typeof(idxs) <: Void
-      return f.h(t)
+function (f::HistoryFunction)(t, deriv::Type=Val{0}, idxs=nothing)
+    @inbounds if t < f.sol.t[1]
+        if typeof(idxs) <: Void
+            return f.h(t)
+        else
+            return f.h(t, idxs)
+        end
+    elseif t <= f.sol.t[end] # Put equals back
+        return f.sol.interp(t, idxs, deriv)
     else
-      return f.h(t,idxs)
+        return OrdinaryDiffEq.current_interpolant(t, f.integrator, idxs, deriv)
     end
-  elseif t <= f.sol.t[end] # Put equals back
-    return f.sol.interp(t,idxs,deriv)
-  else
-    return OrdinaryDiffEq.current_interpolant(t,f.integrator,idxs,deriv)
-  end
 end
 
-function (f::HistoryFunction)(val,t,deriv::Type=Val{0},idxs=nothing)
-  @inbounds if t < f.sol.t[1]
-    if typeof(idxs) <: Void
-      return f.h(val,t)
+function (f::HistoryFunction)(val, t, deriv::Type=Val{0}, idxs=nothing)
+    @inbounds if t < f.sol.t[1]
+        if typeof(idxs) <: Void
+            return f.h(val, t)
+        else
+            return f.h(val, t, idxs)
+        end
+    elseif t <= f.sol.t[end] # Put equals back
+        return f.sol.interp(val, t, idxs, deriv)
     else
-      return f.h(val,t,idxs)
+        return OrdinaryDiffEq.current_interpolant!(val, t, f.integrator, idxs, deriv)
     end
-  elseif t <= f.sol.t[end] # Put equals back
-    return f.sol.interp(val,t,idxs,deriv)
-  else
-    return OrdinaryDiffEq.current_interpolant!(val,t,f.integrator,idxs,deriv)
-  end
 end

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -1,137 +1,217 @@
-function savevalues!(integrator::DDEIntegrator,force_save=false)
-  integrator.integrator.u = integrator.u
-  integrator.integrator.k = integrator.k
-  integrator.integrator.t = integrator.t
-  OrdinaryDiffEq.ode_addsteps!(integrator.integrator,integrator.f)
-  savevalues!(integrator.integrator,force_save)
+"""
+    savevalues!(integrator::DDEIntegrator, force_save=false)
+
+Update solution of `integrator`, if necessary or forced by `force_save`.
+"""
+function savevalues!(integrator::DDEIntegrator, force_save=false)
+    # update ODE integrator
+    integrator.integrator.u = integrator.u
+    integrator.integrator.k = integrator.k
+    integrator.integrator.t = integrator.t
+
+    # add steps for interpolation to ODE integrator when needed
+    OrdinaryDiffEq.ode_addsteps!(integrator.integrator, integrator.f)
+
+    # update solution of ODE integrator
+    savevalues!(integrator.integrator, force_save)
 end
 
+"""
+    postamble!(integrator::DDEIntegrator)
+
+Clean up solution of `integrator`.
+"""
 function postamble!(integrator::DDEIntegrator)
-  integrator.integrator.u = integrator.u
-  integrator.integrator.k = integrator.k
-  integrator.integrator.t = integrator.t
-  OrdinaryDiffEq.postamble!(integrator.integrator)
+    # update ODE integrator
+    integrator.integrator.u = integrator.u
+    integrator.integrator.k = integrator.k
+    integrator.integrator.t = integrator.t
+
+    # clean up solution of ODE integrator
+    OrdinaryDiffEq.postamble!(integrator.integrator)
 end
 
+"""
+    perform_step!(integrator::DDEIntegrator)
+
+Calculate next step of `integrator`.
+"""
 function perform_step!(integrator::DDEIntegrator)
-  integrator.tprev = integrator.t # this is necessary to extrapolate from the current interval
-  integrator.integrator.uprev = integrator.uprev
-  integrator.integrator.tprev = integrator.tprev
-  integrator.integrator.fsalfirst = integrator.fsalfirst
-  integrator.integrator.t = integrator.t
-  integrator.integrator.dt = integrator.dt
+    # update previous time to extrapolate from current interval
+    integrator.tprev = integrator.t
 
-  # if dt>max lag, then it's explicit so use Picard iteration
-  if integrator.dt >minimum(integrator.prob.lags)
+    # update ODE integrator
+    integrator.integrator.uprev = integrator.uprev
+    integrator.integrator.tprev = integrator.tprev
+    integrator.integrator.fsalfirst = integrator.fsalfirst
+    integrator.integrator.t = integrator.t
+    integrator.integrator.dt = integrator.dt
 
-    # the is done to correct the extrapolation
-    t_prev_cache = integrator.tprev
-    t_cache = integrator.t
-    uprev_cache = integrator.uprev
+    # if dt is greater than the minimal lag, then it's explicit so use fixed-point iteration
+    if integrator.dt > minimum(integrator.prob.lags)
 
-    numiters = 1
-    while true
-      if typeof(integrator.u) <: AbstractArray
-        copy!(integrator.u_cache,integrator.u)
-      else
-        integrator.u_cache = integrator.u
-      end
-      perform_step!(integrator,integrator.cache)
+        # save these values to correct the extrapolation after the last iteration
+        tprev_cache = integrator.tprev
+        t_cache = integrator.t # same as tprev_cache?
+        uprev_cache = integrator.uprev
 
-      if typeof(integrator.resid) <: AbstractArray
-        integrator.resid .= (integrator.u .- integrator.u_cache)./(integrator.picardabstol .+ max.(abs.(integrator.u),abs.(integrator.u_cache)).*integrator.picardreltol)
-      else
-        integrator.resid = (integrator.u .- integrator.u_cache)./(integrator.picardabstol .+ max.(abs.(integrator.u),abs.(integrator.u_cache)).*integrator.picardreltol)
-      end
+        numiters = 1
+        while true
 
-      picardEEst = integrator.picardnorm(integrator.resid)
-      if picardEEst < 1 || numiters > integrator.max_picard_iters
-        break
-      end
-      if numiters == 1
-        integrator.integrator.tprev = integrator.t
-        integrator.integrator.t = integrator.t+integrator.dt
-        integrator.integrator.uprev = integrator.u
-      end
-      integrator.integrator.u = integrator.u
-      integrator.integrator.k = integrator.k
-      numiters += 1
+            # save u to calculate residuals (u is overwritten in calculation of next step)
+            if typeof(integrator.u) <: AbstractArray
+                copy!(integrator.u_cache, integrator.u)
+            else
+                integrator.u_cache = integrator.u
+            end
+
+            # calculate next step
+            perform_step!(integrator, integrator.cache)
+
+            # calculate residuals
+            if typeof(integrator.resid) <: AbstractArray
+                @. integrator.resid = (integrator.u - integrator.u_cache) /
+                    @muladd(integrator.fixedpoint_abstol + max(abs(integrator.u),
+                                                               abs(integrator.u_cache)) *
+                            integrator.fixedpoint_reltol)
+            else
+                integrator.resid = @. (integrator.u - integrator.u_cache) /
+                    @muladd(integrator.fixedpoint_abstol + max(abs(integrator.u),
+                                                               abs(integrator.u_cache)) *
+                            integrator.fixedpoint_reltol)
+            end
+
+            # stop fixed-point iteration when residuals are small or maximal number of steps is exceeded
+            fixedpointEEst = integrator.fixedpoint_norm(integrator.resid)
+            if fixedpointEEst < 1 || numiters > integrator.max_fixedpoint_iters
+                break
+            end
+
+            # special updates of ODE integrator after the first iteration step
+            # to use interpolation of ODE integrator in the next iterations
+            # when evaluating the history function
+            if numiters == 1
+                integrator.integrator.tprev = integrator.t
+                integrator.integrator.t = integrator.t + integrator.dt
+                integrator.integrator.uprev = integrator.u
+            end
+
+            # update ODE integrator
+            integrator.integrator.u = integrator.u
+            integrator.integrator.k = integrator.k
+
+            numiters += 1
+        end
+
+        # reset values of DDE integrator after last iteration
+        integrator.t = t_cache
+        integrator.tprev = tprev_cache
+        integrator.uprev = uprev_cache
+
+        # update current time of ODE integrator
+        integrator.integrator.t = t_cache
+    else # no iterations
+        perform_step!(integrator, integrator.cache)
     end
-    integrator.t = t_cache
-    integrator.integrator.t = t_cache
-    integrator.tprev = t_prev_cache
-    integrator.uprev = uprev_cache
 
-  else # no iterations
-    perform_step!(integrator,integrator.cache)
-  end
-
-  #integrator.u = integrator.integrator.u
-  #integrator.fsallast = integrator.integrator.fsallast
-  #if integrator.opts.adaptive
-  #  integrator.EEst = integrator.integrator.EEst
-  #end
+    #integrator.u = integrator.integrator.u
+    #integrator.fsallast = integrator.integrator.fsallast
+    #if integrator.opts.adaptive
+    #  integrator.EEst = integrator.integrator.EEst
+    #end
 end
 
-function initialize!(dde_int::DDEIntegrator)
-  initialize!(dde_int,dde_int.cache,dde_int.f)
-  initialize!(dde_int.integrator,dde_int.cache,dde_int.f)
+"""
+    initialize!(integrator::DDEIntegrator)
+
+Set initial values of `integrator`.
+"""
+function initialize!(integrator::DDEIntegrator)
+    initialize!(integrator, integrator.cache, integrator.f)
+
+    # set also initial values of ODE integrator
+    initialize!(integrator.integrator, integrator.cache, integrator.f)
 end
 
-@inline function u_modified!(integrator::DDEIntegrator,bool::Bool)
-  integrator.u_modified = bool
+"""
+    u_modified!(integrator::DDEIntegrator, bool::Bool)
+
+Signal `integrator` whether state vector `u` was modified by a callback.
+
+A modified `u` will lead to recalculations in order to prevent discontinuities.
+"""
+@inline function u_modified!(integrator::DDEIntegrator, bool::Bool)
+    integrator.u_modified = bool
 end
 
+"""
+    get_proposed_dt(integrator::DDEIntegrator)
+
+Get the time step that `integrator` will take after the current step.
+"""
 @inline get_proposed_dt(integrator::DDEIntegrator) = integrator.dtpropose
-@inline set_proposed_dt!(integrator::DDEIntegrator,dt) = (integrator.dtpropose = dt)
+
+"""
+    set_proposed_dt!(integrator::DDEIntegrator, dt)
+
+Set the time step that `integrator` will take after the current step to `dt.
+"""
+@inline set_proposed_dt!(integrator::DDEIntegrator, dt) = (integrator.dtpropose = dt)
 
 user_cache(integrator::DDEIntegrator) = user_cache(integrator)
 u_cache(integrator::DDEIntegrator) = u_cache(integrator.cache)
 du_cache(integrator::DDEIntegrator)= du_cache(integrator.cache)
-full_cache(integrator::DDEIntegrator) = chain(u_cache(integrator),du_cache(integrator.cache))
+full_cache(integrator::DDEIntegrator) = chain(u_cache(integrator), du_cache(integrator.cache))
 
-resize!(integrator::DDEIntegrator,i::Int) = resize!(integrator,integrator.cache,i)
-function resize!(integrator::DDEIntegrator,cache,i)
-  for c in full_cache(integrator)
-    resize!(c,i)
-  end
+resize!(integrator::DDEIntegrator, i::Int) = resize!(integrator, integrator.cache, i)
+function resize!(integrator::DDEIntegrator, cache, i)
+    for c in full_cache(integrator)
+        resize!(c, i)
+    end
 end
 
-function resize!(integrator::DDEIntegrator,cache::Union{Rosenbrock23Cache,Rosenbrock32Cache},i)
-  for c in full_cache(integrator)
-    resize!(c,i)
-  end
-  for c in vecu_cache(integrator.cache)
-    resize!(c,i)
-  end
-  Jvec = vec(cache.J)
-  cache.J = reshape(resize!(Jvec,i*i),i,i)
-  Wvec = vec(cache.W)
-  cache.W = reshape(resize!(Wvec,i*i),i,i)
+function resize!(integrator::DDEIntegrator, cache::Union{Rosenbrock23Cache,
+                                                         Rosenbrock32Cache}, i)
+    for c in full_cache(integrator)
+        resize!(c, i)
+    end
+    for c in vecu_cache(integrator.cache)
+        resize!(c, i)
+    end
+    Jvec = vec(cache.J)
+    cache.J = reshape(resize!(Jvec, i*i), i, i)
+    Wvec = vec(cache.W)
+    cache.W = reshape(resize!(Wvec, i*i), i, i)
 end
 
-function resize!(integrator::DDEIntegrator,cache::Union{ImplicitEulerCache,TrapezoidCache},i)
-  for c in full_cache(integrator)
-    resize!(c,i)
-  end
-  for c in vecu_cache(integrator.cache)
-    resize!(c,i)
-  end
-  for c in dual_cache(integrator.cache)
-    resize!(c.du,i)
-    resize!(c.dual_du,i)
-  end
-  if alg_autodiff(integrator.alg)
-    cache.adf = autodiff_setup(cache.rhs,cache.uhold,integrator.alg)
-  end
+function resize!(integrator::DDEIntegrator, cache::Union{ImplicitEulerCache,TrapezoidCache},
+                 i)
+    for c in full_cache(integrator)
+        resize!(c, i)
+    end
+    for c in vecu_cache(integrator.cache)
+        resize!(c, i)
+    end
+    for c in dual_cache(integrator.cache)
+        resize!(c.du, i)
+        resize!(c.dual_du, i)
+    end
+    if alg_autodiff(integrator.alg)
+        cache.adf = autodiff_setup(cache.rhs, cache.uhold, integrator.alg)
+    end
 end
 
-function deleteat!(integrator::DDEIntegrator,i::Int)
-  for c in full_cache(integrator)
-    deleteat!(c,i)
-  end
+function deleteat!(integrator::DDEIntegrator, i::Int)
+    for c in full_cache(integrator)
+        deleteat!(c, i)
+    end
 end
 
+"""
+    terminate!(integrator::DDEIntegrator)
+
+Stop further calculations of `integrator`.
+"""
 function terminate!(integrator::DDEIntegrator)
-  integrator.opts.tstops.valtree = typeof(integrator.opts.tstops.valtree)()
+    integrator.opts.tstops.valtree = typeof(integrator.opts.tstops.valtree)()
 end

--- a/src/integrator_type.jl
+++ b/src/integrator_type.jl
@@ -1,67 +1,76 @@
-type DDEIntegrator{algType<:OrdinaryDiffEqAlgorithm,uType,tType,absType,relType,residType,tTypeNoUnits,tdirType,ksEltype,SolType,rateType,F,ProgressType,CacheType,IType,ProbType,NType,O} <: AbstractDDEIntegrator
-  sol::SolType
-  prob::ProbType
-  u::uType
-  k::ksEltype
-  t::tType
-  dt::tType
-  f::F
-  uprev::uType
-  tprev::tType
-  u_cache::uType
-  picardabstol::absType
-  picardreltol::relType
-  resid::residType # This would have to resize for resizing DDE to work
-  picardnorm::NType
-  max_picard_iters::Int
-  alg::algType
-  rate_prototype::rateType
-  notsaveat_idxs::Vector{Int}
-  dtcache::tType
-  dtchangeable::Bool
-  dtpropose::tType
-  tdir::tdirType
-  EEst::tTypeNoUnits
-  qold::tTypeNoUnits
-  q11::tTypeNoUnits
-  iter::Int
-  saveiter::Int
-  saveiter_dense::Int
-  prog::ProgressType
-  cache::CacheType
-  kshortsize::Int
-  just_hit_tstop::Bool
-  accept_step::Bool
-  isout::Bool
-  reeval_fsal::Bool
-  u_modified::Bool
-  opts::O
-  integrator::IType
-  fsalfirst::rateType
-  fsallast::rateType
+mutable struct DDEIntegrator{algType<:OrdinaryDiffEqAlgorithm,uType,tType,absType,relType,
+                             residType,tTypeNoUnits,tdirType,ksEltype,SolType,rateType,F,
+                             ProgressType,CacheType,IType,ProbType,NType,O} <:
+                                 AbstractDDEIntegrator
 
-  (::Type{DDEIntegrator{algType,uType,tType,absType,relType,
-                   residType,tTypeNoUnits,tdirType,ksEltype,SolType,rateType,F,
-                   ProgressType,CacheType,IType,ProbType,NType,O}}){
-                   algType,uType,tType,absType,
-                   relType,residType,tTypeNoUnits,tdirType,ksEltype,SolType,rateType,F,ProgressType,
-                  CacheType,IType,ProbType,NType,O}(sol,prob,u,k,t,dt,f,uprev,tprev,u_cache,
-      picardabstol,picardreltol,resid,picardnorm,max_picard_iters,
-      alg,rate_prototype,notsaveat_idxs,dtcache,dtchangeable,dtpropose,tdir,
-      EEst,qold,q11,
-      iter,saveiter,saveiter_dense,prog,cache,
-      kshortsize,just_hit_tstop,accept_step,isout,reeval_fsal,u_modified,
-      integrator,opts) = new{algType,uType,tType,absType,relType,residType,tTypeNoUnits,tdirType,
-      ksEltype,SolType,rateType,F,ProgressType,CacheType,IType,ProbType,NType,O}(
-      sol,prob,u,k,t,dt,f,uprev,tprev,u_cache,
-      picardabstol,picardreltol,resid,picardnorm,max_picard_iters,
-      alg,rate_prototype,notsaveat_idxs,dtcache,dtchangeable,dtpropose,tdir,
-      EEst,qold,q11,
-      iter,saveiter,saveiter_dense,prog,cache,
-      kshortsize,just_hit_tstop,accept_step,isout,reeval_fsal,u_modified,integrator,opts) # Leave off fsalfirst and last
+    sol::SolType
+    prob::ProbType
+    u::uType
+    k::ksEltype
+    t::tType
+    dt::tType
+    f::F
+    uprev::uType
+    tprev::tType
+    u_cache::uType
+    fixedpoint_abstol::absType
+    fixedpoint_reltol::relType
+    resid::residType # This would have to resize for resizing DDE to work
+    fixedpoint_norm::NType
+    max_fixedpoint_iters::Int
+    alg::algType
+    rate_prototype::rateType
+    notsaveat_idxs::Vector{Int}
+    dtcache::tType
+    dtchangeable::Bool
+    dtpropose::tType
+    tdir::tdirType
+    EEst::tTypeNoUnits
+    qold::tTypeNoUnits
+    q11::tTypeNoUnits
+    iter::Int
+    saveiter::Int
+    saveiter_dense::Int
+    prog::ProgressType
+    cache::CacheType
+    kshortsize::Int
+    just_hit_tstop::Bool
+    accept_step::Bool
+    isout::Bool
+    reeval_fsal::Bool
+    u_modified::Bool
+    opts::O
+    integrator::IType
+    fsalfirst::rateType
+    fsallast::rateType
+
+    # incomplete initialization without fsalfirst and fsallast
+    function DDEIntegrator{algType,uType,tType,absType,relType,residType,tTypeNoUnits,
+                           tdirType,ksEltype,SolType,rateType,F,ProgressType,CacheType,
+                           IType,ProbType,NType,O}(
+                               sol,prob,u,k,t,dt,f,uprev,tprev,u_cache,fixedpoint_abstol,
+                               fixedpoint_reltol,resid,fixedpoint_norm,max_fixedpoint_iters,
+                               alg,rate_prototype,notsaveat_idxs,dtcache,dtchangeable,
+                               dtpropose,tdir,EEst,qold,q11,iter,saveiter,saveiter_dense,
+                               prog,cache,kshortsize,just_hit_tstop,accept_step,isout,
+                               reeval_fsal,u_modified,opts,integrator) where
+        {algType<:OrdinaryDiffEqAlgorithm,uType,tType,absType,relType,residType,
+         tTypeNoUnits,tdirType,ksEltype,SolType,rateType,F,ProgressType,CacheType,IType,
+         ProbType,NType,O}
+
+        new(sol,prob,u,k,t,dt,f,uprev,tprev,u_cache,fixedpoint_abstol,fixedpoint_reltol,
+            resid,fixedpoint_norm,max_fixedpoint_iters,alg,rate_prototype,notsaveat_idxs,
+            dtcache,dtchangeable,dtpropose,tdir,EEst,qold,q11,iter,saveiter,saveiter_dense,
+            prog,cache,kshortsize,just_hit_tstop,accept_step,isout,reeval_fsal,u_modified,
+            opts,integrator)
+    end
 end
 
-function (integrator::DDEIntegrator)(t,deriv::Type=Val{0};idxs=nothing)
-  OrdinaryDiffEq.current_interpolant(t,integrator,idxs,deriv)
+function (integrator::DDEIntegrator)(t, deriv::Type=Val{0}; idxs=nothing)
+    OrdinaryDiffEq.current_interpolant(t, integrator, idxs, deriv)
 end
-(integrator::DDEIntegrator)(val::AbstractArray,t::Union{Number,AbstractArray},deriv::Type=Val{0};idxs=nothing) = OrdinaryDiffEq.current_interpolant!(val,t,integrator,idxs,deriv)
+
+function (integrator::DDEIntegrator)(val::AbstractArray, t::Union{Number,AbstractArray},
+                                     deriv::Type=Val{0}; idxs=nothing)
+    OrdinaryDiffEq.current_interpolant!(val, t, integrator, idxs, deriv)
+end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1,165 +1,199 @@
-function init{uType,tType,isinplace,algType<:AbstractMethodOfStepsAlgorithm,lType}(
-  prob::AbstractDDEProblem{uType,tType,lType,isinplace},
-  alg::algType,timeseries_init=uType[],ts_init=tType[],ks_init=[];
-  d_discontinuities = tType[],
-  dtmax=tType(7*minimum(prob.lags)),
-  dt = tType(0),
-  kwargs...)
+function init(prob::AbstractDDEProblem{uType,tType,lType,isinplace}, alg::algType,
+              timeseries_init=uType[], ts_init=tType[], ks_init=[];
+              d_discontinuities=tType[], dtmax=tType(7*minimum(prob.lags)), dt=zero(tType),
+              kwargs...) where {uType,tType,isinplace,
+                                algType<:AbstractMethodOfStepsAlgorithm,lType}
 
-  # Add to the discontinuties vector the lag locations
-  d_discontinuities = [d_discontinuities;compute_discontinuity_tree(prob.lags,alg,prob.tspan[1])]
+    # add lag locations to discontinuities vector
+    d_discontinuities = [d_discontinuities; compute_discontinuity_tree(prob.lags, alg,
+                                                                       prob.tspan[1])]
 
-  # If it's constrained, then no Picard iteration, and thus `dtmax` should match max lag size
-  if isconstrained(alg)
-    dtmax = min(dtmax,prob.lags...)
-  end
-
-  tTypeNoUnits   = typeof(recursive_one(prob.tspan[1]))
-
-  # Bootstrap the Integrator Using An ODEProblem
-  ode_prob = ODEProblem(prob.f,prob.u0,prob.tspan;iip=isinplace)
-  integrator = init(ode_prob,alg.alg;dt=1,initialize_integrator=false,
-                    d_discontinuities=d_discontinuities,
-                    dtmax=dtmax,
-                    kwargs...)
-  h = HistoryFunction(prob.h,integrator.sol,integrator)
-  if isinplace
-    dde_f = (t,u,du) -> prob.f(t,u,h,du)
-  else
-    dde_f = (t,u) -> prob.f(t,u,h)
-  end
-
-  if typeof(alg.alg) <: OrdinaryDiffEqCompositeAlgorithm
-    id = OrdinaryDiffEq.CompositeInterpolationData(integrator.sol.interp,dde_f)
-  else
-    id = OrdinaryDiffEq.InterpolationData(integrator.sol.interp,dde_f)
-  end
-
-  if typeof(alg.alg) <: OrdinaryDiffEqCompositeAlgorithm
-    sol = build_solution(prob,
-                         integrator.sol.alg,
-                         integrator.sol.t,
-                         integrator.sol.u,
-                         dense=integrator.sol.dense,
-                         k=integrator.sol.k,
-                         interp=id,
-                         alg_choice=integrator.sol.alg_choice,
-                         calculate_error = false)
-  else
-    sol = build_solution(prob,
-                         integrator.sol.alg,
-                         integrator.sol.t,
-                         integrator.sol.u,
-                         dense=integrator.sol.dense,
-                         k=integrator.sol.k,
-                         interp=id,
-                         calculate_error = false)
-  end
-
-
-  h2 = HistoryFunction(prob.h,sol,integrator)
-  if isinplace
-    dde_f2 = (t,u,du) -> prob.f(t,u,h2,du)
-  else
-    dde_f2 = (t,u) -> prob.f(t,u,h2)
-  end
-
-  if dt == zero(dt) && integrator.opts.adaptive
-    ode_prob = ODEProblem(dde_f2,prob.u0,prob.tspan)
-    dt = tType(OrdinaryDiffEq.ode_determine_initdt(prob.u0,prob.tspan[1],
-              integrator.tdir,minimum(prob.lags),integrator.opts.abstol,
-              integrator.opts.reltol,integrator.opts.internalnorm,
-              ode_prob,OrdinaryDiffEq.alg_order(alg)))
-  end
-  integrator.dt = dt
-
-  if typeof(alg.picardabstol) <: Void
-    picardabstol_internal = map(eltype(uType),integrator.opts.abstol)
-  else
-    picardabstol_internal = map(eltype(uType),alg.picardabstol)
-  end
-  if typeof(alg.picardnorm) <: Void
-    picardnorm = integrator.opts.internalnorm
-  end
-
-
-  uEltypeNoUnits = typeof(recursive_one(integrator.u))
-
-  if typeof(alg.picardreltol) <: Void
-    picardreltol_internal = map(uEltypeNoUnits,integrator.opts.reltol)
-  else
-    picardreltol_internal = map(uEltypeNoUnits,alg.picardreltol)
-  end
-  if typeof(integrator.u) <: AbstractArray
-    resid = similar(integrator.u,uEltypeNoUnits)
-    u_cache = similar(integrator.u)
-  else
-    resid = one(uEltypeNoUnits)
-    u_cache = oneunit(eltype(uType))
-  end
-
-  dde_int = DDEIntegrator{typeof(integrator.alg),
-                             uType,tType,
-                             typeof(picardabstol_internal),
-                             typeof(picardreltol_internal),
-                             typeof(resid),
-                             tTypeNoUnits,typeof(integrator.tdir),
-                             typeof(integrator.k),typeof(sol),
-                             typeof(integrator.rate_prototype),
-                             typeof(dde_f2),typeof(integrator.prog),
-                             typeof(integrator.cache),
-                             typeof(integrator),typeof(prob),
-                             typeof(picardnorm),
-                             typeof(integrator.opts)}(
-      sol,prob,integrator.u,integrator.k,integrator.t,integrator.dt,
-      dde_f2,integrator.uprev,integrator.tprev,u_cache,
-      picardabstol_internal,picardreltol_internal,
-      resid,picardnorm,alg.max_picard_iters,
-      integrator.alg,integrator.rate_prototype,integrator.notsaveat_idxs,integrator.dtcache,
-      integrator.dtchangeable,integrator.dtpropose,integrator.tdir,
-      integrator.EEst,integrator.qold,integrator.q11,
-      integrator.iter,integrator.saveiter,
-      integrator.saveiter_dense,integrator.prog,integrator.cache,
-      integrator.kshortsize,integrator.just_hit_tstop,integrator.accept_step,
-      integrator.isout,
-      integrator.reeval_fsal,integrator.u_modified,integrator.opts,integrator) # Leave off fsalfirst and last
-
-  initialize!(dde_int)
-  initialize!(integrator.opts.callback,integrator.t,integrator.u,dde_int)
-  dde_int
-end
-
-function solve!(dde_int::DDEIntegrator)
-  @inbounds while !isempty(dde_int.opts.tstops)
-    while dde_int.tdir*dde_int.t < dde_int.tdir*top(dde_int.opts.tstops)
-      loopheader!(dde_int)
-      perform_step!(dde_int)
-      loopfooter!(dde_int)
-      if isempty(dde_int.opts.tstops)
-        break
-      end
+    # no fixed-point iterations for constrained algorithms,
+    # and thus `dtmax` should match minimal lag
+    if isconstrained(alg)
+        dtmax = min(dtmax,prob.lags...)
     end
-    handle_tstop!(dde_int)
-  end
 
-  postamble!(dde_int)
-  if has_analytic(dde_int.prob.f)
-    u_analytic = [dde_int.prob.f(Val{:analytic},t,dde_int.sol[1]) for t in dde_int.sol.t]
-    errors = Dict{Symbol,eltype(dde_int.u)}()
-    sol = build_solution(dde_int.sol::AbstractODESolution,u_analytic,errors)
-    calculate_solution_errors!(sol;fill_uanalytic=false,timeseries_errors=dde_int.opts.timeseries_errors,dense_errors=dde_int.opts.dense_errors)
-    sol.retcode = :Success
-    return sol
-  else
-    dde_int.sol.retcode = :Success
-    return dde_int.sol
-  end
+    # bootstrap the integrator using an ODE problem, but do not initialize it since
+    # ODE solvers only accept functions f(t,u,du) or f(t,u) without history function
+    ode_prob = ODEProblem(prob.f, prob.u0, prob.tspan; iip=isinplace)
+    integrator = init(ode_prob, alg.alg; dt=1, initialize_integrator=false,
+                      d_discontinuities=d_discontinuities, dtmax=dtmax, kwargs...)
+
+    # create new solution based on this integrator with an interpolation function of the
+    # expected form f(t,u,du) or f(t,u) which already includes information about the
+    # history function of the DDE problem, the current solution of the integrator, and
+    # the extrapolation of the integrator for the future
+    interp_h = HistoryFunction(prob.h, integrator.sol, integrator)
+    if isinplace
+        interp_f = (t,u,du) -> prob.f(t,u,interp_h,du)
+    else
+        interp_f = (t,u) -> prob.f(t,u,interp_h)
+    end
+
+    if typeof(alg.alg) <: OrdinaryDiffEqCompositeAlgorithm
+        interp_data = OrdinaryDiffEq.CompositeInterpolationData(integrator.sol.interp,
+                                                                interp_f)
+    else
+        interp_data = OrdinaryDiffEq.InterpolationData(integrator.sol.interp,
+                                                       interp_f)
+    end
+
+    if typeof(alg.alg) <: OrdinaryDiffEqCompositeAlgorithm
+        sol = build_solution(prob, integrator.sol.alg, integrator.sol.t, integrator.sol.u,
+                             dense=integrator.sol.dense, k=integrator.sol.k,
+                             interp=interp_data, alg_choice=integrator.sol.alg_choice,
+                             calculate_error = false)
+    else
+        sol = build_solution(prob, integrator.sol.alg, integrator.sol.t, integrator.sol.u,
+                             dense=integrator.sol.dense, k=integrator.sol.k,
+                             interp=interp_data, calculate_error = false)
+    end
+
+    # use this improved solution together with the given history function and the integrator
+    # to create a problem function of the DDE with all available history information that is
+    # of the form f(t,u,du) or f(t,u) such that ODE algorithms can be applied
+    dde_h = HistoryFunction(prob.h, sol, integrator)
+    if isinplace
+        dde_f = (t,u,du) -> prob.f(t,u,dde_h,du)
+    else
+        dde_f = (t,u) -> prob.f(t,u,dde_h)
+    end
+
+    # if time step is not set and ODE integrator has adaptive step size,
+    # let ODE problem with same parameters and newly created function with history support
+    # calculate initial time step
+    if dt == zero(dt) && integrator.opts.adaptive
+        ode_prob = ODEProblem(dde_f, prob.u0, prob.tspan)
+        dt = tType(OrdinaryDiffEq.ode_determine_initdt(prob.u0, prob.tspan[1],
+                                                       integrator.tdir, minimum(prob.lags),
+                                                       integrator.opts.abstol,
+                                                       integrator.opts.reltol,
+                                                       integrator.opts.internalnorm,
+                                                       ode_prob,
+                                                       OrdinaryDiffEq.alg_order(alg)))
+    end
+    integrator.dt = dt
+
+    # absolut tolerance for fixed-point iterations has to be of same type as elements of u
+    # in particular important for calculations with units
+    if typeof(alg.fixedpoint_abstol) <: Void
+        fixedpoint_abstol_internal = map(eltype(uType), integrator.opts.abstol)
+    else
+        fixedpoint_abstol_internal = map(eltype(uType), alg.fixedpoint_abstol)
+    end
+
+    # use norm of ODE integrator if no norm for fixed-point iterations is specified
+    if typeof(alg.fixedpoint_norm) <: Void
+        fixedpoint_norm = integrator.opts.internalnorm
+    end
+
+    # derive unitless types
+    uEltypeNoUnits = typeof(recursive_one(integrator.u))
+    tTypeNoUnits = typeof(recursive_one(prob.tspan[1]))
+
+    # relative tolerance for fixed-point iterations has to be of same type as elements of u
+    # without units
+    # in particular important for calculations with units
+    if typeof(alg.fixedpoint_reltol) <: Void
+        fixedpoint_reltol_internal = map(uEltypeNoUnits, integrator.opts.reltol)
+    else
+        fixedpoint_reltol_internal = map(uEltypeNoUnits, alg.fixedpoint_reltol)
+    end
+
+    # create containers for residuals and to cache u with correct dimensions and types
+    # in particular for calculations with units residuals have to be unitless
+    if typeof(integrator.u) <: AbstractArray
+        resid = similar(integrator.u, uEltypeNoUnits)
+        u_cache = similar(integrator.u)
+    else
+        resid = one(uEltypeNoUnits)
+        u_cache = oneunit(eltype(uType))
+    end
+
+    # create DDE integrator combining the new defined problem function with history
+    # information, the improved solution, the parameters of the ODE integrator, and
+    # parameters of fixed-point iteration
+    # do not initialize fsalfirst and fsallast
+    dde_int = DDEIntegrator{typeof(integrator.alg),uType,tType,
+                            typeof(fixedpoint_abstol_internal),
+                            typeof(fixedpoint_reltol_internal),typeof(resid),tTypeNoUnits,
+                            typeof(integrator.tdir),typeof(integrator.k),typeof(sol),
+                            typeof(integrator.rate_prototype),typeof(dde_f),
+                            typeof(integrator.prog),typeof(integrator.cache),
+                            typeof(integrator),typeof(prob),typeof(fixedpoint_norm),
+                            typeof(integrator.opts)}(
+                                sol, prob, integrator.u, integrator.k, integrator.t,
+                                integrator.dt, dde_f, integrator.uprev, integrator.tprev,
+                                u_cache, fixedpoint_abstol_internal,
+                                fixedpoint_reltol_internal, resid, fixedpoint_norm,
+                                alg.max_fixedpoint_iters, integrator.alg,
+                                integrator.rate_prototype, integrator.notsaveat_idxs,
+                                integrator.dtcache, integrator.dtchangeable,
+                                integrator.dtpropose, integrator.tdir, integrator.EEst,
+                                integrator.qold, integrator.q11, integrator.iter,
+                                integrator.saveiter, integrator.saveiter_dense,
+                                integrator.prog, integrator.cache, integrator.kshortsize,
+                                integrator.just_hit_tstop, integrator.accept_step,
+                                integrator.isout, integrator.reeval_fsal,
+                                integrator.u_modified, integrator.opts, integrator)
+
+    # set up additional initial values of newly created DDE integrator
+    # (such as fsalfirst) and its callbacks
+    initialize!(dde_int)
+    initialize!(integrator.opts.callback, integrator.t, integrator.u, dde_int)
+
+    dde_int
 end
 
-function solve{uType,tType,isinplace,algType<:AbstractMethodOfStepsAlgorithm,lType}(
-  prob::AbstractDDEProblem{uType,tType,lType,isinplace},
-  alg::algType,timeseries_init=uType[],ts_init=tType[],ks_init=[];kwargs...)
+function solve!(integrator::DDEIntegrator)
+    # step over all stopping time points, similar to solving with ODE integrators
+    @inbounds while !isempty(integrator.opts.tstops)
+        while integrator.tdir * integrator.t < integrator.tdir * top(integrator.opts.tstops)
+            # apply step or adapt step size
+            loopheader!(integrator)
 
-  integrator = init(prob,alg,timeseries_init,ts_init,ks_init;kwargs...)
-  solve!(integrator)
+            # calculate next step
+            perform_step!(integrator)
+
+            # calculate proposed next step size, handle callbacks, and update solution
+            loopfooter!(integrator)
+
+            if isempty(integrator.opts.tstops)
+                break
+            end
+        end
+
+        # remove hit or passed stopping time points
+        handle_tstop!(integrator)
+    end
+
+    # clean up solution
+    postamble!(integrator)
+
+    # calculate and add errors to solution if analytic solution to problem exists
+    # can not use same mechanism as for ODE problems since analytic solutions for DDE depend
+    # on initial value u0
+    if has_analytic(integrator.prob.f)
+        u_analytic = [integrator.prob.f(Val{:analytic}, t, integrator.sol[1])
+                      for t in integrator.sol.t]
+        errors = Dict{Symbol,eltype(integrator.u)}()
+        sol = build_solution(integrator.sol::AbstractODESolution, u_analytic, errors)
+        calculate_solution_errors!(sol; fill_uanalytic=false,
+                                   timeseries_errors=integrator.opts.timeseries_errors,
+                                   dense_errors=integrator.opts.dense_errors)
+        sol.retcode = :Success
+        return sol
+    else
+        integrator.sol.retcode = :Success
+        return integrator.sol
+    end
+end
+
+function solve(prob::AbstractDDEProblem{uType,tType,lType,isinplace}, alg::algType,
+               timeseries_init=uType[], ts_init=tType[], ks_init=[]; kwargs...) where
+    {uType,tType,isinplace,algType<:AbstractMethodOfStepsAlgorithm,lType}
+
+    integrator = init(prob, alg, timeseries_init, ts_init, ks_init; kwargs...)
+    solve!(integrator)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,31 @@
+"""
+    compute_discontinuity_tree(lags, alg, start_val)
+
+Compute time points of discontinuities for delays `lags` up to the order of algorithm `alg`,
+starting at initial time point `start_val`.
+
+# Examples
+
+```jldoctest
+julia> compute_discontinuity_tree([1//2], BS3(), 1)
+3-element Array{Rational{Int64},1}:
+ 3//2
+ 2//1
+ 5//2
+
+julia> compute_discontinuity_tree([1//2, 1//3], BS3(), 1)
+8-element Array{Rational{Int64},1}:
+  3//2
+  4//3
+  2//1
+ 11//6
+  5//3
+  5//2
+  7//3
+ 13//6
+```
+"""
 function compute_discontinuity_tree(lags, alg, start_val)
-           start_val + unique(vcat((sum.(collect(with_replacement_combinations(lags, i))) for i in 1:alg_order(alg))...))
-       end
+    start_val + unique(vcat((sum.(collect(with_replacement_combinations(lags, i))) for i in
+                             1:alg_order(alg))...))
+end

--- a/test/constrained.jl
+++ b/test/constrained.jl
@@ -2,131 +2,131 @@ using DelayDiffEq, DiffEqBase, OrdinaryDiffEq, Base.Test
 
 lags = [1]
 f = function (t,u,h)
-  - h(t-1)
+    - h(t-1)
 end
 h = (t) -> 0.0
 
-function (p::typeof(f))(::Type{Val{:analytic}},t,u0)
-  t = t-1
-  if t<0
-    return u0
-  elseif t<1
-    return u0 - t*u0
-  elseif t<2
-    return 0.5*(3u0 -4*t*u0 + t^2 * u0)
-  elseif t<3
-    return 1/6*(17u0 -24t*u0 + 9t^2*u0 -t^3 * u0)
-  elseif t<4
-    return 1/24*(149u0 - 204*t*u0 + 90t^2*u0 - 16t^3*u0 + t^4*u0)
-  elseif t<5
-    return 1/120*(1769u0 - 2300t*u0 + 1090t^2*u0 - 240t^3*u0 + 25t^4*u0 - t^5*u0)
-  elseif t<6
-    return 1/720*(26239u0 - 32550t*u0 + 15915t^2*u0 - 3940t^3*u0 + 525t^4*u0 - 36t^5*u0 + t^6*u0)
-  elseif t<7
-    return (463609u0 - 554442t*u0 + 274701t^2*u0 - 72940t^3*u0 + 11235t^4*u0 - 1008t^5*u0 + 49t^6*u0 - t^7*u0)/5040
-  elseif t<8
-    return (9473673u0 - 11023880t*u0 + 5491780t^2*u0 - 1524712t^3*u0 + 257950t^4*u0 - 27272t^5*u0 + 1764t^6*u0 - 64t^7*u0 + t^8*u0)/40320
-  elseif t<9
-    return (219480785u0 - 250209864t*u0 + 124923492t^2*u0 - 35742504t^3*u0 +6450318t^4*u0 - 761544t^5*u0 + 58884t^6*u0 - 2880t^7*u0 + 81t^8*u0 - t^9*u0)/362880
-  elseif t<=10
-    return (219480785*u0 - 250209864*t*u0 + 124923492*t^2*u0 - 35742504t^3*u0 + 6450318t^4*u0 - 761544t^5*u0 + 58884t^6*u0 - 2880t^7*u0 + 81t^8*u0 - t^9*u0)/362880
-  else
-    error("This analytical solution is only valid on [-infty,11]")
-  end
+function (p::typeof(f))(::Type{Val{:analytic}}, t, u0)
+    t = t-1
+    if t<0
+        return u0
+    elseif t<1
+        return u0 - t*u0
+    elseif t<2
+        return 0.5*(3u0 -4*t*u0 + t^2 * u0)
+    elseif t<3
+        return 1/6*(17u0 -24t*u0 + 9t^2*u0 -t^3 * u0)
+    elseif t<4
+        return 1/24*(149u0 - 204*t*u0 + 90t^2*u0 - 16t^3*u0 + t^4*u0)
+    elseif t<5
+        return 1/120*(1769u0 - 2300t*u0 + 1090t^2*u0 - 240t^3*u0 + 25t^4*u0 - t^5*u0)
+    elseif t<6
+        return 1/720*(26239u0 - 32550t*u0 + 15915t^2*u0 - 3940t^3*u0 + 525t^4*u0 - 36t^5*u0 + t^6*u0)
+    elseif t<7
+        return (463609u0 - 554442t*u0 + 274701t^2*u0 - 72940t^3*u0 + 11235t^4*u0 - 1008t^5*u0 + 49t^6*u0 - t^7*u0)/5040
+    elseif t<8
+        return (9473673u0 - 11023880t*u0 + 5491780t^2*u0 - 1524712t^3*u0 + 257950t^4*u0 - 27272t^5*u0 + 1764t^6*u0 - 64t^7*u0 + t^8*u0)/40320
+    elseif t<9
+        return (219480785u0 - 250209864t*u0 + 124923492t^2*u0 - 35742504t^3*u0 +6450318t^4*u0 - 761544t^5*u0 + 58884t^6*u0 - 2880t^7*u0 + 81t^8*u0 - t^9*u0)/362880
+    elseif t<=10
+        return (219480785*u0 - 250209864*t*u0 + 124923492*t^2*u0 - 35742504t^3*u0 + 6450318t^4*u0 - 761544t^5*u0 + 58884t^6*u0 - 2880t^7*u0 + 81t^8*u0 - t^9*u0)/362880
+    else
+        error("This analytical solution is only valid on [-infty,11]")
+    end
 end
 
 
-prob = ConstantLagDDEProblem(f,h,1.0,lags,(0.0,10.0);iip=DiffEqBase.isinplace(f,4))
-alg = MethodOfSteps(BS3();constrained=true)
+prob = ConstantLagDDEProblem(f, h, 1.0, lags, (0.0, 10.0); iip=DiffEqBase.isinplace(f, 4))
+alg = MethodOfSteps(BS3(); constrained=true)
 
-dde_int = init(prob,alg;dt=0.1)
+dde_int = init(prob, alg; dt=0.1)
 sol = solve!(dde_int)
 
 @test maximum(sol.errors[:final]) < 1e-4
 
 h = (t) -> [0.0]
-prob = ConstantLagDDEProblem(f,h,[1.0],lags,(0.0,10.0);iip=DiffEqBase.isinplace(f,4))
-dde_int = init(prob,alg;dt=0.1)
+prob = ConstantLagDDEProblem(f, h, [1.0], lags, (0.0, 10.0); iip=DiffEqBase.isinplace(f, 4))
+dde_int = init(prob, alg; dt=0.1)
 sol = solve!(dde_int)
 
 @test maximum(sol.errors[:l2]) < 1e-4
 
 f = function (t,u,h,du)
-  du[1] = - h(t-1)[1]
+    du[1] = - h(t-1)[1]
 end
 h = (t) -> [0.0]
-function (p::typeof(f))(::Type{Val{:analytic}},t,u0)
-  t = t-1
-  if t<0
-    return u0
-  elseif t<1
-    return u0 - t*u0
-  elseif t<2
-    return 0.5*(3u0 -4*t*u0 + t^2 * u0)
-  elseif t<3
-    return 1/6*(17u0 -24t*u0 + 9t^2*u0 -t^3 * u0)
-  elseif t<4
-    return 1/24*(149u0 - 204*t*u0 + 90t^2*u0 - 16t^3*u0 + t^4*u0)
-  elseif t<5
-    return 1/120*(1769u0 - 2300t*u0 + 1090t^2*u0 - 240t^3*u0 + 25t^4*u0 - t^5*u0)
-  elseif t<6
-    return 1/720*(26239u0 - 32550t*u0 + 15915t^2*u0 - 3940t^3*u0 + 525t^4*u0 - 36t^5*u0 + t^6*u0)
-  elseif t<7
-    return (463609u0 - 554442t*u0 + 274701t^2*u0 - 72940t^3*u0 + 11235t^4*u0 - 1008t^5*u0 + 49t^6*u0 - t^7*u0)/5040
-  elseif t<8
-    return (9473673u0 - 11023880t*u0 + 5491780t^2*u0 - 1524712t^3*u0 + 257950t^4*u0 - 27272t^5*u0 + 1764t^6*u0 - 64t^7*u0 + t^8*u0)/40320
-  elseif t<9
-    return (219480785u0 - 250209864t*u0 + 124923492t^2*u0 - 35742504t^3*u0 +6450318t^4*u0 - 761544t^5*u0 + 58884t^6*u0 - 2880t^7*u0 + 81t^8*u0 - t^9*u0)/362880
-  elseif t<=10
-    return (219480785*u0 - 250209864*t*u0 + 124923492*t^2*u0 - 35742504t^3*u0 + 6450318t^4*u0 - 761544t^5*u0 + 58884t^6*u0 - 2880t^7*u0 + 81t^8*u0 - t^9*u0)/362880
-  else
-    error("This analytical solution is only valid on [-infty,11]")
-  end
+function (p::typeof(f))(::Type{Val{:analytic}}, t, u0)
+    t = t-1
+    if t<0
+        return u0
+    elseif t<1
+        return u0 - t*u0
+    elseif t<2
+        return 0.5*(3u0 -4*t*u0 + t^2 * u0)
+    elseif t<3
+        return 1/6*(17u0 -24t*u0 + 9t^2*u0 -t^3 * u0)
+    elseif t<4
+        return 1/24*(149u0 - 204*t*u0 + 90t^2*u0 - 16t^3*u0 + t^4*u0)
+    elseif t<5
+        return 1/120*(1769u0 - 2300t*u0 + 1090t^2*u0 - 240t^3*u0 + 25t^4*u0 - t^5*u0)
+    elseif t<6
+        return 1/720*(26239u0 - 32550t*u0 + 15915t^2*u0 - 3940t^3*u0 + 525t^4*u0 - 36t^5*u0 + t^6*u0)
+    elseif t<7
+        return (463609u0 - 554442t*u0 + 274701t^2*u0 - 72940t^3*u0 + 11235t^4*u0 - 1008t^5*u0 + 49t^6*u0 - t^7*u0)/5040
+    elseif t<8
+        return (9473673u0 - 11023880t*u0 + 5491780t^2*u0 - 1524712t^3*u0 + 257950t^4*u0 - 27272t^5*u0 + 1764t^6*u0 - 64t^7*u0 + t^8*u0)/40320
+    elseif t<9
+        return (219480785u0 - 250209864t*u0 + 124923492t^2*u0 - 35742504t^3*u0 +6450318t^4*u0 - 761544t^5*u0 + 58884t^6*u0 - 2880t^7*u0 + 81t^8*u0 - t^9*u0)/362880
+    elseif t<=10
+        return (219480785*u0 - 250209864*t*u0 + 124923492*t^2*u0 - 35742504t^3*u0 + 6450318t^4*u0 - 761544t^5*u0 + 58884t^6*u0 - 2880t^7*u0 + 81t^8*u0 - t^9*u0)/362880
+    else
+        error("This analytical solution is only valid on [-infty,11]")
+    end
 end
-prob = ConstantLagDDEProblem(f,h,[1.0],lags,(0.0,10.0);iip=DiffEqBase.isinplace(f,4))
-dde_int = init(prob,alg;dt=0.1)
+prob = ConstantLagDDEProblem(f, h, [1.0], lags, (0.0, 10.0); iip=DiffEqBase.isinplace(f, 4))
+dde_int = init(prob, alg; dt=0.1)
 sol = solve!(dde_int)
 
 @test maximum(sol.errors[:l∞]) < 1e-4
 
-lags = [1//3,1//5]
+lags = [1//3, 1//5]
 f = function (t,u,h)
-  - h(t-1/3) - h(t-1/5)
+    - h(t-1/3) - h(t-1/5)
 end
 h = (t) -> 0.0
 
-function (p::typeof(f))(::Type{Val{:analytic}},t,u0)
-  if t<1/5
-    return u0
-  elseif t<1/3
-    return (1/5)*(6u0 - 5t*u0)
-  elseif t<2/5
-    return (1/15)*(23u0 - 30t*u0)
-  elseif t<8/15
-    return (1/150)*(242u0 - 360t*u0 + 75t^2*u0)
-  elseif t<3/5
-    return (1/450)*(854u0 - 1560t*u0 + 675t^2*u0)
-  elseif t<2/3
-    return (4351u0 - 8205t*u0 + 4050t^2*u0 - 375t^3*u0)/2250
-  elseif t<11/15
-    return (1/750)*(1617u0 - 3235t*u0 + 1725t^2*u0 - 125t^3*u0)
-  elseif t<4/5
-    return (7942u0 - 17280t*u0 + 11475t^2*u0 - 2250t^3*u0)/3375
-  elseif t<13/15
-    return (319984u0 - 702720t*u0 + 480600t^2*u0 - 108000t^3u0 + 5625*t^4u0)/135000
-  elseif t<14/15
-    return (40436u0 - 94980t*u0 + 72900t^2*u0 - 19500t^3*u0 + 625t^4*u0)/15000
-  elseif t<=1
-    return (685796u0 - 1670388t*u0 + 1392660t^2*u0 - 467100t^3*u0 + 50625t^4*u0)/243000
-  else
-    error("This analytical solution is only valid on [-infty,1]")
-  end
+function (p::typeof(f))(::Type{Val{:analytic}}, t, u0)
+    if t<1/5
+        return u0
+    elseif t<1/3
+        return (1/5)*(6u0 - 5t*u0)
+    elseif t<2/5
+        return (1/15)*(23u0 - 30t*u0)
+    elseif t<8/15
+        return (1/150)*(242u0 - 360t*u0 + 75t^2*u0)
+    elseif t<3/5
+        return (1/450)*(854u0 - 1560t*u0 + 675t^2*u0)
+    elseif t<2/3
+        return (4351u0 - 8205t*u0 + 4050t^2*u0 - 375t^3*u0)/2250
+    elseif t<11/15
+        return (1/750)*(1617u0 - 3235t*u0 + 1725t^2*u0 - 125t^3*u0)
+    elseif t<4/5
+        return (7942u0 - 17280t*u0 + 11475t^2*u0 - 2250t^3*u0)/3375
+    elseif t<13/15
+        return (319984u0 - 702720t*u0 + 480600t^2*u0 - 108000t^3u0 + 5625*t^4u0)/135000
+    elseif t<14/15
+        return (40436u0 - 94980t*u0 + 72900t^2*u0 - 19500t^3*u0 + 625t^4*u0)/15000
+    elseif t<=1
+        return (685796u0 - 1670388t*u0 + 1392660t^2*u0 - 467100t^3*u0 + 50625t^4*u0)/243000
+    else
+        error("This analytical solution is only valid on [-infty,1]")
+    end
 end
 
-prob = ConstantLagDDEProblem(f,h,1.0,lags,(0.0,1.0);iip=DiffEqBase.isinplace(f,4))
-alg = MethodOfSteps(BS3();constrained=true)
+prob = ConstantLagDDEProblem(f, h, 1.0, lags, (0.0, 1.0); iip=DiffEqBase.isinplace(f, 4))
+alg = MethodOfSteps(BS3(); constrained=true)
 
-dde_int = init(prob,alg;dt=0.1)
+dde_int = init(prob, alg; dt=0.1)
 sol = solve!(dde_int)
 
 @test maximum(sol.errors[:final]) < 1e-5

--- a/test/discont_tree_test.jl
+++ b/test/discont_tree_test.jl
@@ -1,9 +1,10 @@
 using DelayDiffEq, OrdinaryDiffEq, Base.Test
-lags = [1//5,1//2]
+
+lags = [1//5, 1//2]
 alg = BS3()
 start_val = 1
 
-disc_tree = sort(DelayDiffEq.compute_discontinuity_tree(lags,alg,start_val))
+disc_tree = sort(DelayDiffEq.compute_discontinuity_tree(lags, alg, start_val))
 
-true_val = sort(1 .+ [1//2,1//5,1//1,2//5,7//10,3//2,3//5,6//5,9//10])
+true_val = sort(1 .+ [1//2, 1//5, 1//1, 2//5, 7//10, 3//2, 3//5, 6//5, 9//10])
 @test disc_tree == true_val

--- a/test/events.jl
+++ b/test/events.jl
@@ -2,40 +2,43 @@ using DelayDiffEq, DiffEqBase, OrdinaryDiffEq, Base.Test, DiffEqDevTools, DiffEq
 
 lags = [1]
 f = function (t,u,h)
-  du = - h(t-1)
+    du = - h(t-1)
 end
 h = (t) -> 0.0
 
+prob = ConstantLagDDEProblem(f, h, 1.0, lags, (0.0, 10.0); iip=DiffEqBase.isinplace(f, 4))
+alg = MethodOfSteps(Tsit5(); constrained=false)
 
-prob = ConstantLagDDEProblem(f,h,1.0,lags,(0.0,10.0);iip=DiffEqBase.isinplace(f,4))
-alg = MethodOfSteps(Tsit5();constrained=false)
+# continuous callback
 
 condition = function (t,u,integrator) # Event when event_f(t,u,k) == 0
-  t - 2.60
+    t - 2.60
 end
 
 affect! = function (integrator)
-  integrator.u = -integrator.u
+    integrator.u = -integrator.u
 end
 
-cb = ContinuousCallback(condition,affect!)
+cb = ContinuousCallback(condition, affect!)
 
-sol1 = solve(prob,alg,callback=cb)
+sol1 = solve(prob, alg, callback=cb)
 
-sol2 = solve(prob,alg,callback=cb,dtmax=0.01)
+sol2 = solve(prob, alg, callback=cb, dtmax=0.01)
 
-sol3 = appxtrue(sol1,sol2)
+sol3 = appxtrue(sol1, sol2)
 
 @test sol3.errors[:L2] < 4e-3
 @test sol3.errors[:L∞] < 8e-3
 
+# discrete callback
+
 cb = AutoAbstol()
 
-sol1 = solve(prob,alg,callback=cb)
+sol1 = solve(prob, alg, callback=cb)
 
-sol2 = solve(prob,alg,callback=cb,dtmax=0.01)
+sol2 = solve(prob, alg, callback=cb, dtmax=0.01)
 
-sol3 = appxtrue(sol1,sol2)
+sol3 = appxtrue(sol1, sol2)
 
 @test sol3.errors[:L2] < 3e-2
 @test sol3.errors[:L∞] < 7e-2

--- a/test/unconstrained.jl
+++ b/test/unconstrained.jl
@@ -2,53 +2,56 @@ using DelayDiffEq, DiffEqBase, OrdinaryDiffEq, Base.Test
 
 lags = [.2]
 
-f = function (t,u,h,du)
-  du[1] = -h(t-.2)[1] + u[1]
-end
-h = (t) -> [0.0]
-
 f = function (t,u,h)
   out = -h(t-.2) + u
 end
 h = (t) -> 0.0
 
-prob = ConstantLagDDEProblem(f,h,1.0,lags,(0.0,100.0))
+prob = ConstantLagDDEProblem(f, h, 1.0, lags, (0.0, 100.0))
 
-alg1 = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
-sol1 = solve(prob,alg1)
+alg1 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                     fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
+sol1 = solve(prob, alg1)
 
-alg2 = MethodOfSteps(DP8(),constrained=false,max_picard_iters=10,picardabstol=1e-8,picardreltol=1e-10)
-sol2 = solve(prob,alg2)
+alg2 = MethodOfSteps(DP8(), constrained=false, max_fixedpoint_iters=10,
+                     fixedpoint_abstol=1e-8, fixedpoint_reltol=1e-10)
+sol2 = solve(prob, alg2)
 
-alg3 = MethodOfSteps(Tsit5(),constrained=true,max_picard_iters=10,picardabstol=1e-8,picardreltol=1e-10)
-sol3 = solve(prob,alg3)
+alg3 = MethodOfSteps(Tsit5(), constrained=true, max_fixedpoint_iters=10,
+                     fixedpoint_abstol=1e-8, fixedpoint_reltol=1e-10)
+sol3 = solve(prob, alg3)
 
-alg4 = MethodOfSteps(DP5(),constrained=false,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
-sol4 = solve(prob,alg4)
+alg4 = MethodOfSteps(DP5(), constrained=false, max_fixedpoint_iters=100,
+                     fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
+sol4 = solve(prob, alg4)
 
 @test abs(sol1[end] - sol2[end]) < 1e-3
 @test abs(sol1[end] - sol3[end]) < 1e-3
 @test abs(sol1[end] - sol4[end]) < 1e-3
 
-lags = [1//3,1//5]
+lags = [1//3, 1//5]
 f = function (t,u,h)
-  - h(t-1/3) - h(t-1/5)
+  -h(t-1/3) - h(t-1/5)
 end
 h = (t) -> 0.0
 
-prob = ConstantLagDDEProblem(f,h,1.0,lags,(0.0,10.0);iip=DiffEqBase.isinplace(f,4))
+prob = ConstantLagDDEProblem(f, h, 1.0, lags, (0.0, 10.0); iip=DiffEqBase.isinplace(f,4))
 
-alg1 = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
-sol1 = solve(prob,alg1)
+alg1 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                     fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
+sol1 = solve(prob, alg1)
 
-alg2 = MethodOfSteps(DP8(),constrained=false,max_picard_iters=10,picardabstol=1e-8,picardreltol=1e-10)
-sol2 = solve(prob,alg2)
+alg2 = MethodOfSteps(DP8(), constrained=false, max_fixedpoint_iters=10,
+                     fixedpoint_abstol=1e-8, fixedpoint_reltol=1e-10)
+sol2 = solve(prob, alg2)
 
-alg3 = MethodOfSteps(Tsit5(),constrained=true,max_picard_iters=10,picardabstol=1e-8,picardreltol=1e-10)
-sol3 = solve(prob,alg3)
+alg3 = MethodOfSteps(Tsit5(), constrained=true, max_fixedpoint_iters=10,
+                     fixedpoint_abstol=1e-8, fixedpoint_reltol=1e-10)
+sol3 = solve(prob, alg3)
 
-alg4 = MethodOfSteps(DP5(),constrained=false,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
-sol4 = solve(prob,alg4)
+alg4 = MethodOfSteps(DP5(), constrained=false, max_fixedpoint_iters=100,
+                     fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
+sol4 = solve(prob, alg4)
 
 @test abs(sol1[end] - sol2[end]) < 1e-3
 @test abs(sol1[end] - sol3[end]) < 1e-3
@@ -59,7 +62,7 @@ println("Standard tests complete. Onto idxs tests")
 ## Idxs
 
 f = function (t,u,h,du)
-  du[1] = -h(t-.2,Val{0},1) + u[1]
+  du[1] = -h(t-.2, Val{0}, 1) + u[1]
 end
 
 h = function (t,idxs=nothing)
@@ -70,13 +73,14 @@ h = function (t,idxs=nothing)
   end
 end
 
-prob = ConstantLagDDEProblem(f,h,[1.0],lags,(0.0,100.0))
+prob = ConstantLagDDEProblem(f, h, [1.0], lags, (0.0, 100.0))
 
-alg1 = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
-@time sol1 = solve(prob,alg1)
+alg1 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                     fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
+@time sol1 = solve(prob, alg1)
 
 f = function (t,u,h,du)
-  h(du,t-.2)
+  h(du, t-.2)
   du[1] = -du[1]
   du[1] += u[1]
 end
@@ -92,7 +96,8 @@ h = function (out,t,idxs=nothing)
 end
 
 
-prob = ConstantLagDDEProblem(f,h,[1.0],lags,(0.0,100.0))
+prob = ConstantLagDDEProblem(f, h, [1.0], lags, (0.0, 100.0))
 
-alg1 = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
-@time sol1 = solve(prob,alg1)
+alg1 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                     fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
+@time sol1 = solve(prob, alg1)

--- a/test/unique_times.jl
+++ b/test/unique_times.jl
@@ -3,15 +3,15 @@ using DelayDiffEq, DiffEqBase, OrdinaryDiffEq, Base.Test
 lags = [.2]
 
 f = function (t,u,h,du)
-  du[1] = -h(t-.2)[1] + u[1]
+    du[1] = -h(t-.2)[1] + u[1]
 end
 h = (t) -> [0.0]
 
-prob = ConstantLagDDEProblem(f,h,[1.0],lags,(0.0,100.0))
+prob = ConstantLagDDEProblem(f, h, [1.0], lags, (0.0, 100.0))
 
-for constrained in (false,true)
-  alg = MethodOfSteps(Tsit5(),constrained=constrained)
-  sol = solve(prob,alg)
+for constrained in (false, true)
+    alg = MethodOfSteps(Tsit5(), constrained=constrained)
+    sol = solve(prob,alg)
 
-  @test allunique(sol.t)
+    @test allunique(sol.t)
 end

--- a/test/units.jl
+++ b/test/units.jl
@@ -4,80 +4,90 @@ lags = [.2u"s"]
 
 # Scalar problem, not in-place
 f = function (t,u,h)
-  out = (-h(t-.2u"s") + u) / 1.0u"s"
+    out = (-h(t-.2u"s") + u) / 1.0u"s"
 end
 h = (t) -> 0.0u"N"
 
-prob = ConstantLagDDEProblem(f,h,1.0u"N",lags,(0.0u"s",100.0u"s"))
+prob = ConstantLagDDEProblem(f, h, 1.0u"N", lags, (0.0u"s", 100.0u"s"))
 
 # Unconstrained algorithm without explicit absolut or relative tolerance
-alg = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100)
-solve(prob,alg)
+alg = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100)
+solve(prob, alg)
 
 # Unconstrained algorithm without units
-alg = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
-sol = solve(prob,alg)
+alg = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                    fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
+sol = solve(prob, alg)
 
 # Unconstrained algorithm with correct units
-alg2 = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=1e-9u"mN",picardreltol=1e-12)
-sol2 = solve(prob,alg2)
+alg2 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                     fixedpoint_abstol=1e-9u"mN", fixedpoint_reltol=1e-12)
+sol2 = solve(prob, alg2)
 
 @test sol.t == sol2.t && sol.u == sol2.u
 
 # Unconstrained algorithm with incorrect units for absolute tolerance
-alg = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=1e-12u"s",picardreltol=1e-12)
-@test_throws Unitful.DimensionError solve(prob,alg)
+alg = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                    fixedpoint_abstol=1e-12u"s", fixedpoint_reltol=1e-12)
+@test_throws Unitful.DimensionError solve(prob, alg)
 
 # Unconstrained algorithm with units for relative tolerance
-alg = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12u"N")
-@test_throws Unitful.DimensionError solve(prob,alg)
+alg = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                    fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12u"N")
+@test_throws Unitful.DimensionError solve(prob, alg)
 
 # Constrained algorithm without explicit absolute or relative tolerance
-alg = MethodOfSteps(Tsit5(),constrained=true,max_picard_iters=100)
-solve(prob,alg)
+alg = MethodOfSteps(Tsit5(), constrained=true, max_fixedpoint_iters=100)
+solve(prob, alg)
 
 # Constrained algorithm without units
-alg = MethodOfSteps(Tsit5(),constrained=true,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
-sol = solve(prob,alg)
+alg = MethodOfSteps(Tsit5(), constrained=true, max_fixedpoint_iters=100,
+                    fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
+sol = solve(prob, alg)
 
 # Constrained algorithm with correct units
-alg2 = MethodOfSteps(Tsit5(),constrained=true,max_picard_iters=100,picardabstol=1e-9u"mN",picardreltol=1e-12)
-sol2 = solve(prob,alg2)
+alg2 = MethodOfSteps(Tsit5(), constrained=true, max_fixedpoint_iters=100,
+                     fixedpoint_abstol=1e-9u"mN", fixedpoint_reltol=1e-12)
+sol2 = solve(prob, alg2)
 
 @test sol.t == sol2.t && sol.u == sol2.u
 
 # Vector problem, in-place
 f = function (t,u,h,du)
-  du[1] = (-h(t-.2u"s")[1] + u[1]) / 1.0u"s"
+    du[1] = (-h(t-.2u"s")[1] + u[1]) / 1.0u"s"
 end
 h = (t) -> [0.0u"N"]
 
-prob = ConstantLagDDEProblem(f,h,[1.0u"N"],lags,(0.0u"s",100.0u"s"))
+prob = ConstantLagDDEProblem(f, h, [1.0u"N"], lags, (0.0u"s", 100.0u"s"))
 
 # Unconstrained algorithm without explicit absolute or relative tolerance
-alg = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100)
-solve(prob,alg)
+alg = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100)
+solve(prob, alg)
 
 # Unconstrained algorithm without units
-alg = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
-sol = solve(prob,alg)
+alg = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                    fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
+sol = solve(prob, alg)
 
 # Unconstrained algorithm with correct units and both absolute and relative tolerance as vector
-alg2 = MethodOfSteps(Tsit5(),constrained=false,max_picard_iters=100,picardabstol=[1e-9u"mN"],picardreltol=[1e-12])
-sol2 = solve(prob,alg2)
+alg2 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                     fixedpoint_abstol=[1e-9u"mN"], fixedpoint_reltol=[1e-12])
+sol2 = solve(prob, alg2)
 
 @test sol.t == sol2.t && sol.u == sol2.u
 
 # Constrained algorithm without explicit absolute or relative tolerance
-alg = MethodOfSteps(Tsit5(),constrained=true,max_picard_iters=100)
-solve(prob,alg)
+alg = MethodOfSteps(Tsit5(), constrained=true, max_fixedpoint_iters=100)
+solve(prob, alg)
 
 # Constrained algorithm without units
-alg = MethodOfSteps(Tsit5(),constrained=true,max_picard_iters=100,picardabstol=1e-12,picardreltol=1e-12)
-sol = solve(prob,alg)
+alg = MethodOfSteps(Tsit5(), constrained=true, max_fixedpoint_iters=100,
+                    fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
+sol = solve(prob, alg)
 
 # Constrained algorithm with correct units and both absolute and relative tolerance as vector
-alg2 = MethodOfSteps(Tsit5(),constrained=true,max_picard_iters=100,picardabstol=[1e-9u"mN"],picardreltol=[1e-12])
-sol2 = solve(prob,alg2)
+alg2 = MethodOfSteps(Tsit5(), constrained=true, max_fixedpoint_iters=100,
+                     fixedpoint_abstol=[1e-9u"mN"], fixedpoint_reltol=[1e-12])
+sol2 = solve(prob, alg2)
 
 @test sol.t == sol2.t && sol.u == sol2.u


### PR DESCRIPTION
Hi!

I finally found the time to separate the naming changes and comments, together with some new additions, from https://github.com/JuliaDiffEq/DelayDiffEq.jl/pull/12. Moreover, I reformatted most parts of the code to follow the [Julia guidelines for code contributions](https://github.com/JuliaLang/julia/blob/master/CONTRIBUTING.md#general-formatting-guidelines-for-julia-code-contributions), since the same conventions, like e.g. line breaks after 92 characters, [should apply to docstrings](https://docs.julialang.org/en/stable/manual/documentation/) anyway.

Beside that, the only change to the code is the replacement of `type` with `struct` - or should these changes be moved to another PR?

I guess, the most comments are added to `integrator_interface.jl` and `solve.jl` - hopefully they can help for understanding the implementation.