### PR TITLE
Use DiffEqProblemLibrary and add tests

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,4 @@
 DiffEqDevTools
 DiffEqCallbacks
+DiffEqProblemLibrary
 Unitful

--- a/test/constrained.jl
+++ b/test/constrained.jl
@@ -1,132 +1,63 @@
-using DelayDiffEq, DiffEqBase, OrdinaryDiffEq, Base.Test
+using DelayDiffEq, DiffEqBase, OrdinaryDiffEq, DiffEqProblemLibrary, Base.Test
 
-lags = [1]
-f = function (t,u,h)
-    - h(t-1)
-end
-h = (t) -> 0.0
+# Check that numerical solutions approximate analytical solutions,
+# independent of problem structure
 
-function (p::typeof(f))(::Type{Val{:analytic}}, t, u0)
-    t = t-1
-    if t<0
-        return u0
-    elseif t<1
-        return u0 - t*u0
-    elseif t<2
-        return 0.5*(3u0 -4*t*u0 + t^2 * u0)
-    elseif t<3
-        return 1/6*(17u0 -24t*u0 + 9t^2*u0 -t^3 * u0)
-    elseif t<4
-        return 1/24*(149u0 - 204*t*u0 + 90t^2*u0 - 16t^3*u0 + t^4*u0)
-    elseif t<5
-        return 1/120*(1769u0 - 2300t*u0 + 1090t^2*u0 - 240t^3*u0 + 25t^4*u0 - t^5*u0)
-    elseif t<6
-        return 1/720*(26239u0 - 32550t*u0 + 15915t^2*u0 - 3940t^3*u0 + 525t^4*u0 - 36t^5*u0 + t^6*u0)
-    elseif t<7
-        return (463609u0 - 554442t*u0 + 274701t^2*u0 - 72940t^3*u0 + 11235t^4*u0 - 1008t^5*u0 + 49t^6*u0 - t^7*u0)/5040
-    elseif t<8
-        return (9473673u0 - 11023880t*u0 + 5491780t^2*u0 - 1524712t^3*u0 + 257950t^4*u0 - 27272t^5*u0 + 1764t^6*u0 - 64t^7*u0 + t^8*u0)/40320
-    elseif t<9
-        return (219480785u0 - 250209864t*u0 + 124923492t^2*u0 - 35742504t^3*u0 +6450318t^4*u0 - 761544t^5*u0 + 58884t^6*u0 - 2880t^7*u0 + 81t^8*u0 - t^9*u0)/362880
-    elseif t<=10
-        return (219480785*u0 - 250209864*t*u0 + 124923492*t^2*u0 - 35742504t^3*u0 + 6450318t^4*u0 - 761544t^5*u0 + 58884t^6*u0 - 2880t^7*u0 + 81t^8*u0 - t^9*u0)/362880
-    else
-        error("This analytical solution is only valid on [-infty,11]")
-    end
-end
-
-
-prob = ConstantLagDDEProblem(f, h, 1.0, lags, (0.0, 10.0); iip=DiffEqBase.isinplace(f, 4))
 alg = MethodOfSteps(BS3(); constrained=true)
+u₀ = 1.0
 
+# Single constant delay
+
+## Not in-place function with scalar history function
+
+prob = prob_dde_1delay_scalar_notinplace(u₀)
 dde_int = init(prob, alg; dt=0.1)
 sol = solve!(dde_int)
 
-@test maximum(sol.errors[:final]) < 1e-4
+@test sol.errors[:l∞] < 3e-5
+@test sol.errors[:final] < 2e-5
+@test sol.errors[:l2] < 2e-5
 
-h = (t) -> [0.0]
-prob = ConstantLagDDEProblem(f, h, [1.0], lags, (0.0, 10.0); iip=DiffEqBase.isinplace(f, 4))
+## Not in-place function with vectorized history function
+
+prob = prob_dde_1delay_notinplace(u₀)
+dde_int = init(prob, alg; dt=0.1)
+sol2 = solve!(dde_int)
+
+@test sol.t == sol2.t && sol.u == sol2[1, :]
+
+## In-place function
+
+prob = prob_dde_1delay(u₀)
+dde_int = init(prob, alg; dt=0.1)
+sol2 = solve!(dde_int)
+
+@test sol.t == sol2.t && sol.u == sol2[1, :]
+
+# Two constant delays
+
+## Not in-place function with scalar history function
+
+prob = prob_dde_2delays_scalar_notinplace(u₀)
 dde_int = init(prob, alg; dt=0.1)
 sol = solve!(dde_int)
 
-@test maximum(sol.errors[:l2]) < 1e-4
+@test sol.errors[:l∞] < 5e-6
+@test sol.errors[:final] < 2e-6
+@test sol.errors[:l2] < 3e-6
 
-f = function (t,u,h,du)
-    du[1] = - h(t-1)[1]
-end
-h = (t) -> [0.0]
-function (p::typeof(f))(::Type{Val{:analytic}}, t, u0)
-    t = t-1
-    if t<0
-        return u0
-    elseif t<1
-        return u0 - t*u0
-    elseif t<2
-        return 0.5*(3u0 -4*t*u0 + t^2 * u0)
-    elseif t<3
-        return 1/6*(17u0 -24t*u0 + 9t^2*u0 -t^3 * u0)
-    elseif t<4
-        return 1/24*(149u0 - 204*t*u0 + 90t^2*u0 - 16t^3*u0 + t^4*u0)
-    elseif t<5
-        return 1/120*(1769u0 - 2300t*u0 + 1090t^2*u0 - 240t^3*u0 + 25t^4*u0 - t^5*u0)
-    elseif t<6
-        return 1/720*(26239u0 - 32550t*u0 + 15915t^2*u0 - 3940t^3*u0 + 525t^4*u0 - 36t^5*u0 + t^6*u0)
-    elseif t<7
-        return (463609u0 - 554442t*u0 + 274701t^2*u0 - 72940t^3*u0 + 11235t^4*u0 - 1008t^5*u0 + 49t^6*u0 - t^7*u0)/5040
-    elseif t<8
-        return (9473673u0 - 11023880t*u0 + 5491780t^2*u0 - 1524712t^3*u0 + 257950t^4*u0 - 27272t^5*u0 + 1764t^6*u0 - 64t^7*u0 + t^8*u0)/40320
-    elseif t<9
-        return (219480785u0 - 250209864t*u0 + 124923492t^2*u0 - 35742504t^3*u0 +6450318t^4*u0 - 761544t^5*u0 + 58884t^6*u0 - 2880t^7*u0 + 81t^8*u0 - t^9*u0)/362880
-    elseif t<=10
-        return (219480785*u0 - 250209864*t*u0 + 124923492*t^2*u0 - 35742504t^3*u0 + 6450318t^4*u0 - 761544t^5*u0 + 58884t^6*u0 - 2880t^7*u0 + 81t^8*u0 - t^9*u0)/362880
-    else
-        error("This analytical solution is only valid on [-infty,11]")
-    end
-end
-prob = ConstantLagDDEProblem(f, h, [1.0], lags, (0.0, 10.0); iip=DiffEqBase.isinplace(f, 4))
+## Not in-place function with vectorized history function
+
+prob = prob_dde_2delays_notinplace(u₀)
 dde_int = init(prob, alg; dt=0.1)
-sol = solve!(dde_int)
+sol2 = solve!(dde_int)
 
-@test maximum(sol.errors[:l∞]) < 1e-4
+@test sol.t == sol2.t && sol.u == sol2[1, :]
 
-lags = [1//3, 1//5]
-f = function (t,u,h)
-    - h(t-1/3) - h(t-1/5)
-end
-h = (t) -> 0.0
+## In-place function
 
-function (p::typeof(f))(::Type{Val{:analytic}}, t, u0)
-    if t<1/5
-        return u0
-    elseif t<1/3
-        return (1/5)*(6u0 - 5t*u0)
-    elseif t<2/5
-        return (1/15)*(23u0 - 30t*u0)
-    elseif t<8/15
-        return (1/150)*(242u0 - 360t*u0 + 75t^2*u0)
-    elseif t<3/5
-        return (1/450)*(854u0 - 1560t*u0 + 675t^2*u0)
-    elseif t<2/3
-        return (4351u0 - 8205t*u0 + 4050t^2*u0 - 375t^3*u0)/2250
-    elseif t<11/15
-        return (1/750)*(1617u0 - 3235t*u0 + 1725t^2*u0 - 125t^3*u0)
-    elseif t<4/5
-        return (7942u0 - 17280t*u0 + 11475t^2*u0 - 2250t^3*u0)/3375
-    elseif t<13/15
-        return (319984u0 - 702720t*u0 + 480600t^2*u0 - 108000t^3u0 + 5625*t^4u0)/135000
-    elseif t<14/15
-        return (40436u0 - 94980t*u0 + 72900t^2*u0 - 19500t^3*u0 + 625t^4*u0)/15000
-    elseif t<=1
-        return (685796u0 - 1670388t*u0 + 1392660t^2*u0 - 467100t^3*u0 + 50625t^4*u0)/243000
-    else
-        error("This analytical solution is only valid on [-infty,1]")
-    end
-end
-
-prob = ConstantLagDDEProblem(f, h, 1.0, lags, (0.0, 1.0); iip=DiffEqBase.isinplace(f, 4))
-alg = MethodOfSteps(BS3(); constrained=true)
-
+prob = prob_dde_2delays(u₀)
 dde_int = init(prob, alg; dt=0.1)
-sol = solve!(dde_int)
+sol2 = solve!(dde_int)
 
-@test maximum(sol.errors[:final]) < 1e-5
+@test sol.t == sol2.t && sol.u == sol2[1, :]

--- a/test/events.jl
+++ b/test/events.jl
@@ -1,12 +1,7 @@
-using DelayDiffEq, DiffEqBase, OrdinaryDiffEq, Base.Test, DiffEqDevTools, DiffEqCallbacks
+using DelayDiffEq, DiffEqBase, OrdinaryDiffEq, DiffEqProblemLibrary, DiffEqDevTools,
+      DiffEqCallbacks, Base.Test
 
-lags = [1]
-f = function (t,u,h)
-    du = - h(t-1)
-end
-h = (t) -> 0.0
-
-prob = ConstantLagDDEProblem(f, h, 1.0, lags, (0.0, 10.0); iip=DiffEqBase.isinplace(f, 4))
+prob = prob_dde_1delay_scalar_notinplace(1.0)
 alg = MethodOfSteps(Tsit5(); constrained=false)
 
 # continuous callback

--- a/test/unconstrained.jl
+++ b/test/unconstrained.jl
@@ -29,8 +29,7 @@ sol2 = solve(prob, alg)
 prob = prob_dde_1delay(u₀)
 sol2 = solve(prob, alg)
 
-# Test does not pass!
-# @test sol.t == sol2.t && sol.u == sol2[1, :]
+@test_broken sol.t == sol2.t && sol.u == sol2[1, :]
 
 ## Two constant delays
 
@@ -55,8 +54,7 @@ sol2 = solve(prob, alg)
 prob = prob_dde_2delays(u₀)
 sol = solve(prob, alg)
 
-# Test does not pass!
-# @test sol.t == sol2.t && sol.u == sol2[1, :]
+@test_broken sol.t == sol2.t && sol.u == sol2[1, :]
 
 # Problems with long time span
 

--- a/test/unique_times.jl
+++ b/test/unique_times.jl
@@ -1,17 +1,10 @@
-using DelayDiffEq, DiffEqBase, OrdinaryDiffEq, Base.Test
+using DelayDiffEq, DiffEqBase, OrdinaryDiffEq, DiffEqProblemLibrary, Base.Test
 
-lags = [.2]
-
-f = function (t,u,h,du)
-    du[1] = -h(t-.2)[1] + u[1]
-end
-h = (t) -> [0.0]
-
-prob = ConstantLagDDEProblem(f, h, [1.0], lags, (0.0, 100.0))
+prob = prob_dde_1delay_long
 
 for constrained in (false, true)
     alg = MethodOfSteps(Tsit5(), constrained=constrained)
-    sol = solve(prob,alg)
+    sol = solve(prob, alg)
 
     @test allunique(sol.t)
 end

--- a/test/units.jl
+++ b/test/units.jl
@@ -69,7 +69,8 @@ alg = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
                     fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
 sol = solve(prob, alg)
 
-# Unconstrained algorithm with correct units and both absolute and relative tolerance as vector
+# Unconstrained algorithm with correct units and both absolute and relative tolerance as
+# vector
 alg2 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
                      fixedpoint_abstol=[1e-9u"mN"], fixedpoint_reltol=[1e-12])
 sol2 = solve(prob, alg2)
@@ -85,7 +86,8 @@ alg = MethodOfSteps(Tsit5(), constrained=true, max_fixedpoint_iters=100,
                     fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
 sol = solve(prob, alg)
 
-# Constrained algorithm with correct units and both absolute and relative tolerance as vector
+# Constrained algorithm with correct units and both absolute and relative tolerance as
+# vector
 alg2 = MethodOfSteps(Tsit5(), constrained=true, max_fixedpoint_iters=100,
                      fixedpoint_abstol=[1e-9u"mN"], fixedpoint_reltol=[1e-12])
 sol2 = solve(prob, alg2)


### PR DESCRIPTION
Hi!

Already shortly after https://github.com/JuliaDiffEq/DiffEqProblemLibrary.jl/pull/9 was merged I wanted to open this PR in order to use `DiffEqProblemLibrary.jl` in the tests. However, by adding some additional tests I discovered that the unconstrained algorithm computes different solutions for in-place and not in-place functions. I tried to fix this problem, but without success yet. I'll open an issue regarding this problem, the failing tests are commented out in this PR.