### PR TITLE
Add support for saveat and save_idxs to MethodOfSteps algorithm

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -9,6 +9,9 @@ function savevalues!(integrator::DDEIntegrator, force_save=false)
     integrator.integrator.k = integrator.k
     integrator.integrator.t = integrator.t
 
+    # update solution of DDE integrator
+    invoke(savevalues!, Tuple{AbstractDDEIntegrator,Bool}, integrator, force_save)
+
     # add steps for interpolation to ODE integrator when needed
     OrdinaryDiffEq.ode_addsteps!(integrator.integrator, integrator.f)
 
@@ -26,6 +29,9 @@ function postamble!(integrator::DDEIntegrator)
     integrator.integrator.u = integrator.u
     integrator.integrator.k = integrator.k
     integrator.integrator.t = integrator.t
+
+    # clean up solution of DDE integrator
+    OrdinaryDiffEq.postamble!(integrator)
 
     # clean up solution of ODE integrator
     OrdinaryDiffEq.postamble!(integrator.integrator)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1,8 +1,9 @@
 function init(prob::AbstractDDEProblem{uType,tType,lType,isinplace}, alg::algType,
               timeseries_init=uType[], ts_init=tType[], ks_init=[];
               d_discontinuities=tType[], dtmax=tType(7*minimum(prob.lags)), dt=zero(tType),
-              kwargs...) where {uType,tType,isinplace,
-                                algType<:AbstractMethodOfStepsAlgorithm,lType}
+              saveat=tType[], tstops=tType[], save_idxs=nothing,
+              save_everystep=isempty(saveat), save_start=true, kwargs...) where
+    {uType,tType,isinplace,algType<:AbstractMethodOfStepsAlgorithm,lType}
 
     # add lag locations to discontinuities vector
     d_discontinuities = [d_discontinuities; compute_discontinuity_tree(prob.lags, alg,
@@ -16,6 +17,8 @@ function init(prob::AbstractDDEProblem{uType,tType,lType,isinplace}, alg::algTyp
 
     # bootstrap the integrator using an ODE problem, but do not initialize it since
     # ODE solvers only accept functions f(t,u,du) or f(t,u) without history function
+    # save every step and every index in the solution of the integrator, since they are
+    # required for evaluation of past values during integration
     ode_prob = ODEProblem(prob.f, prob.u0, prob.tspan; iip=isinplace)
     integrator = init(ode_prob, alg.alg; dt=1, initialize_integrator=false,
                       d_discontinuities=d_discontinuities, dtmax=dtmax, kwargs...)
@@ -32,60 +35,92 @@ function init(prob::AbstractDDEProblem{uType,tType,lType,isinplace}, alg::algTyp
     end
 
     if typeof(alg.alg) <: OrdinaryDiffEqCompositeAlgorithm
-        interp_data = OrdinaryDiffEq.CompositeInterpolationData(integrator.sol.interp,
-                                                                interp_f)
+        ode_interp_data = OrdinaryDiffEq.CompositeInterpolationData(integrator.sol.interp,
+                                                                    interp_f)
     else
-        interp_data = OrdinaryDiffEq.InterpolationData(integrator.sol.interp,
-                                                       interp_f)
+        ode_interp_data = OrdinaryDiffEq.InterpolationData(integrator.sol.interp, interp_f)
     end
 
     if typeof(alg.alg) <: OrdinaryDiffEqCompositeAlgorithm
-        sol = build_solution(prob, integrator.sol.alg, integrator.sol.t, integrator.sol.u,
-                             dense=integrator.sol.dense, k=integrator.sol.k,
-                             interp=interp_data, alg_choice=integrator.sol.alg_choice,
-                             calculate_error = false)
+        ode_sol = build_solution(prob, integrator.sol.alg, integrator.sol.t,
+                                 integrator.sol.u, dense=integrator.sol.dense,
+                                 k=integrator.sol.k, interp=ode_interp_data,
+                                 alg_choice=integrator.sol.alg_choice, calculate_error=false)
     else
-        sol = build_solution(prob, integrator.sol.alg, integrator.sol.t, integrator.sol.u,
-                             dense=integrator.sol.dense, k=integrator.sol.k,
-                             interp=interp_data, calculate_error = false)
+        ode_sol = build_solution(prob, integrator.sol.alg, integrator.sol.t,
+                                 integrator.sol.u, dense=integrator.sol.dense,
+                                 k=integrator.sol.k, interp=ode_interp_data,
+                                 calculate_error=false)
     end
 
     # use this improved solution together with the given history function and the integrator
     # to create a problem function of the DDE with all available history information that is
     # of the form f(t,u,du) or f(t,u) such that ODE algorithms can be applied
-    dde_h = HistoryFunction(prob.h, sol, integrator)
+    dde_h = HistoryFunction(prob.h, ode_sol, integrator)
     if isinplace
         dde_f = (t,u,du) -> prob.f(t,u,dde_h,du)
     else
         dde_f = (t,u) -> prob.f(t,u,dde_h)
     end
 
-    # if time step is not set and ODE integrator has adaptive step size,
-    # let ODE problem with same parameters and newly created function with history support
-    # calculate initial time step
-    if dt == zero(dt) && integrator.opts.adaptive
-        ode_prob = ODEProblem(dde_f, prob.u0, prob.tspan)
+    # use ODE problem to initialize prototype of DDE integrator
+    ode_prob = ODEProblem(dde_f, prob.u0, prob.tspan; iip=isinplace)
+    proto_int = init(ode_prob, alg.alg; dt=1, initialize_integrator=false,
+                     d_discontinuities=d_discontinuities, saveat=saveat, dtmax=dtmax,
+                     save_idxs=save_idxs, save_everystep=save_everystep,
+                     save_start=save_start, kwargs...)
+
+    # if time step is not set and prototype uses adaptive step sizes,
+    # let function with history support calculate initial time step
+    if dt == zero(dt) && proto_int.opts.adaptive
         dt = tType(OrdinaryDiffEq.ode_determine_initdt(prob.u0, prob.tspan[1],
-                                                       integrator.tdir, minimum(prob.lags),
-                                                       integrator.opts.abstol,
-                                                       integrator.opts.reltol,
-                                                       integrator.opts.internalnorm,
+                                                       proto_int.tdir, minimum(prob.lags),
+                                                       proto_int.opts.abstol,
+                                                       proto_int.opts.reltol,
+                                                       proto_int.opts.internalnorm,
                                                        ode_prob,
                                                        OrdinaryDiffEq.alg_order(alg)))
     end
-    integrator.dt = dt
+    proto_int.dt = dt
+
+    # create solution for DDE integrator, using solution of prototype and cache of ODE
+    # integrator
+    if typeof(alg.alg) <: OrdinaryDiffEqCompositeAlgorithm
+        CompositeInterpolationData(f,timeseries,ts,ks,alg_choice,notsaveat_idxs,dense,cache)
+        dde_interp_data = OrdinaryDiffEq.CompositeInterpolationData(
+            dde_f, proto_int.sol.interp.timeseries, proto_int.sol.interp.ts,
+            proto_int.sol.interp.ks, proto_int.sol.interp.alg_choice,
+            proto_int.sol.interp.notsaveat_idxs, proto_int.sol.interp.dense,
+            integrator.cache)
+    else
+        dde_interp_data = OrdinaryDiffEq.InterpolationData(
+            dde_f, proto_int.sol.interp.timeseries, proto_int.sol.interp.ts,
+            proto_int.sol.interp.ks, proto_int.sol.interp.notsaveat_idxs,
+            proto_int.sol.interp.dense, integrator.cache)
+    end
+
+    if typeof(alg.alg) <: OrdinaryDiffEqCompositeAlgorithm
+        dde_sol = build_solution(prob, proto_int.sol.alg, proto_int.sol.t, proto_int.sol.u,
+                                 dense=proto_int.sol.dense, k=proto_int.sol.k,
+                                 interp=dde_interp_data,
+                                 alg_choice=proto_int.alg_choice, calculate_error=false)
+    else
+        dde_sol = build_solution(prob, proto_int.sol.alg, proto_int.sol.t, proto_int.sol.u,
+                                 dense=proto_int.sol.dense, k=proto_int.sol.k,
+                                 interp=dde_interp_data, calculate_error=false)
+    end
 
     # absolut tolerance for fixed-point iterations has to be of same type as elements of u
     # in particular important for calculations with units
     if typeof(alg.fixedpoint_abstol) <: Void
-        fixedpoint_abstol_internal = map(eltype(uType), integrator.opts.abstol)
+        fixedpoint_abstol_internal = map(eltype(uType), proto_int.opts.abstol)
     else
         fixedpoint_abstol_internal = map(eltype(uType), alg.fixedpoint_abstol)
     end
 
     # use norm of ODE integrator if no norm for fixed-point iterations is specified
     if typeof(alg.fixedpoint_norm) <: Void
-        fixedpoint_norm = integrator.opts.internalnorm
+        fixedpoint_norm = proto_int.opts.internalnorm
     end
 
     # derive unitless types
@@ -96,7 +131,7 @@ function init(prob::AbstractDDEProblem{uType,tType,lType,isinplace}, alg::algTyp
     # without units
     # in particular important for calculations with units
     if typeof(alg.fixedpoint_reltol) <: Void
-        fixedpoint_reltol_internal = map(uEltypeNoUnits, integrator.opts.reltol)
+        fixedpoint_reltol_internal = map(uEltypeNoUnits, proto_int.opts.reltol)
     else
         fixedpoint_reltol_internal = map(uEltypeNoUnits, alg.fixedpoint_reltol)
     end
@@ -112,36 +147,36 @@ function init(prob::AbstractDDEProblem{uType,tType,lType,isinplace}, alg::algTyp
     end
 
     # create DDE integrator combining the new defined problem function with history
-    # information, the improved solution, the parameters of the ODE integrator, and
-    # parameters of fixed-point iteration
+    # information, the improved solution, parameters of the prototype, some initial values
+    # of the ODE integrator, and parameters for fixed-point iterations
     # do not initialize fsalfirst and fsallast
-    dde_int = DDEIntegrator{typeof(integrator.alg),uType,tType,
+    dde_int = DDEIntegrator{typeof(proto_int.alg),uType,tType,
                             typeof(fixedpoint_abstol_internal),
                             typeof(fixedpoint_reltol_internal),typeof(resid),tTypeNoUnits,
-                            typeof(integrator.tdir),typeof(integrator.k),typeof(sol),
-                            typeof(integrator.rate_prototype),typeof(dde_f),
-                            typeof(integrator.prog),typeof(integrator.cache),
+                            typeof(proto_int.tdir),typeof(integrator.k),typeof(dde_sol),
+                            typeof(proto_int.rate_prototype),typeof(dde_f),
+                            typeof(proto_int.prog),typeof(integrator.cache),
                             typeof(integrator),typeof(prob),typeof(fixedpoint_norm),
-                            typeof(integrator.opts)}(
-                                sol, prob, integrator.u, integrator.k, integrator.t,
-                                integrator.dt, dde_f, integrator.uprev, integrator.tprev,
+                            typeof(proto_int.opts)}(
+                                dde_sol, prob, integrator.u, integrator.k, proto_int.t,
+                                proto_int.dt, dde_f, integrator.uprev, proto_int.tprev,
                                 u_cache, fixedpoint_abstol_internal,
                                 fixedpoint_reltol_internal, resid, fixedpoint_norm,
-                                alg.max_fixedpoint_iters, integrator.alg,
-                                integrator.rate_prototype, integrator.notsaveat_idxs,
-                                integrator.dtcache, integrator.dtchangeable,
-                                integrator.dtpropose, integrator.tdir, integrator.EEst,
-                                integrator.qold, integrator.q11, integrator.iter,
-                                integrator.saveiter, integrator.saveiter_dense,
-                                integrator.prog, integrator.cache, integrator.kshortsize,
-                                integrator.just_hit_tstop, integrator.accept_step,
-                                integrator.isout, integrator.reeval_fsal,
-                                integrator.u_modified, integrator.opts, integrator)
+                                alg.max_fixedpoint_iters, proto_int.alg,
+                                proto_int.rate_prototype, proto_int.notsaveat_idxs,
+                                proto_int.dtcache, proto_int.dtchangeable,
+                                proto_int.dtpropose, proto_int.tdir, proto_int.EEst,
+                                proto_int.qold, proto_int.q11, proto_int.iter,
+                                proto_int.saveiter, proto_int.saveiter_dense,
+                                proto_int.prog, integrator.cache, proto_int.kshortsize,
+                                proto_int.just_hit_tstop, proto_int.accept_step,
+                                proto_int.isout, proto_int.reeval_fsal,
+                                proto_int.u_modified, proto_int.opts, integrator)
 
     # set up additional initial values of newly created DDE integrator
     # (such as fsalfirst) and its callbacks
     initialize!(dde_int)
-    initialize!(integrator.opts.callback, integrator.t, integrator.u, dde_int)
+    initialize!(integrator.opts.callback, proto_int.t, integrator.u, dde_int)
 
     dde_int
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,8 @@ using Base.Test
 @time @testset "Discontinuity Tree Test" begin include("discont_tree_test.jl") end
 @time @testset "Constrained Timestep" begin include("constrained.jl") end
 @time @testset "Unconstrained Timestep" begin include("unconstrained.jl") end
+@time @testset "Saveat Test" begin include("saveat.jl") end
+@time @testset "Save_idxs Test" begin include("save_idxs.jl") end
 @time @testset "Events" begin include("events.jl") end
 @time @testset "Units" begin include("units.jl") end
 @time @testset "Unique Times" begin include("unique_times.jl") end

--- a/test/save_idxs.jl
+++ b/test/save_idxs.jl
@@ -1,0 +1,46 @@
+using DelayDiffEq, OrdinaryDiffEq, DiffEqProblemLibrary, Base.Test
+
+f = function (t,u,h,du)
+    du[1] = - h(t-1/5)[1] + u[1]
+    du[2] = - h(t-1/3)[2] - h(t-1/5)[2]
+end
+prob = ConstantLagDDEProblem(f, t->zeros(2), ones(2), [1/5, 1/3], (0.0, 100.0))
+alg = MethodOfSteps(BS3())
+
+# save all components (without keyword argument)
+dde_int = init(prob, alg)
+sol = solve!(dde_int)
+
+## solution and both solutions of DDE and ODE integrator contain all components
+@test length(sol.u[1]) == 2
+@test sol.u == dde_int.sol.u
+@test sol.u == dde_int.integrator.sol.u
+
+# save all components (with keyword argument)
+dde_int2 = init(prob, alg; save_idxs=[1, 2])
+sol2 = solve!(dde_int2)
+
+## solution and both solutions of DDE and ODE integrator contain all components
+@test length(sol2.u[1]) == 2
+@test sol2.u == dde_int2.sol.u
+@test sol2.u == dde_int2.integrator.sol.u
+
+## solution equals solution without keyword arguments
+@test sol.t == sol2.t && sol.u == sol2.u
+
+# save only second component
+dde_int3 = init(prob, alg; save_idxs=[2])
+sol3 = solve!(dde_int3)
+
+## solution and solution of DDE integrator contain only second component
+@test length(sol3.u[1]) == 1
+@test sol3.u == dde_int3.sol.u
+
+## solution equals second component of solution of ODE integrator
+@test sol3[1, :] == dde_int3.integrator.sol[2, :]
+
+## solution equals second component of complete solution
+@test sol.t == sol3.t && sol[2, :] == sol3[1, :]
+
+## interpolation of solution equals second component of interpolation of complete solution
+@test sol(0:100, idxs=2) == sol3(0:100, idxs=1)

--- a/test/saveat.jl
+++ b/test/saveat.jl
@@ -1,0 +1,44 @@
+using DelayDiffEq, OrdinaryDiffEq, DiffEqProblemLibrary, Base.Test
+
+prob = prob_dde_1delay_long
+alg = MethodOfSteps(Tsit5())
+
+# save at every time step
+dde_int = init(prob, alg)
+sol = solve!(dde_int)
+
+## full solution equals both solution of DDE integrator and of ODE integrator
+@test sol.t == dde_int.sol.t && sol.u == dde_int.sol.u
+@test sol.t == dde_int.integrator.sol.t && sol.u == dde_int.integrator.sol.u
+
+# save only at a particular time point
+dde_int2 = init(prob, alg; saveat=[50.0])
+sol2 = solve!(dde_int2)
+
+## time steps of partial solution
+@test sol2.t == [0.0, 50.0, 100.0]
+
+## partial solution equals solution of DDE integrator
+@test sol2.t == dde_int2.sol.t && sol2.u == dde_int2.sol.u
+
+## solution of ODE integrator equals full solution
+@test sol.t == dde_int2.integrator.sol.t && sol.u == dde_int2.integrator.sol.u
+
+## partial solution equals interpolation of full solution
+@test sol(sol2.t).u == sol2.u
+
+# save only at a particular time point and exclude initial time point
+dde_int3 = init(prob, alg; saveat=[50.0], save_start=false)
+sol3 = solve!(dde_int3)
+
+## time steps of partial solution
+@test sol3.t == [50.0, 100.0]
+
+## partial solution equals solution of DDE integrator
+@test sol3.t == dde_int3.sol.t && sol3.u == dde_int3.sol.u
+
+## solution of ODE integrator equals full solution
+@test sol.t == dde_int3.integrator.sol.t && sol.u == dde_int3.integrator.sol.u
+
+## partial solution equals interpolation of full solution
+@test sol(sol3.t).u == sol3.u


### PR DESCRIPTION
Hi!

Currently the keyword `save_idxs` does usually not work with the MethodOfSteps algorithm. Often additional components are necessary during evaluation of the history function, and even the indices of included components do not match the indices in the original delay differential equations.

Thus I added an additional solution object to the DDE integrator such that it is possible to output only a selection of components. Internally for evaluations of the history function always a full solution is used. Of course, it is possible to extract the desired components after all iterations but it seemed more natural to me to take advantage of the implementations in OrdinaryDiffEq.jl (it is necessary to loosen the type restriction in `savevalues!` there!). With an iterator interface similar to OrdinaryDiffEq.jl the output solution would contain only the desired components in every step automatically.

I already included support for `saveat` as well: because of the usually sparse solutions with this option and hence increased number of fixed-point iterations the use of `saveat` can increase computation time dramatically at the moment. However, with this change computation time should not increase.

So, maybe this suggestion is helpful. I added some tests that lead to errors on the master branch.