### PR TITLE
Fix wrongly defined lags in unconstrained.jl

### DIFF
--- a/test/discont_tree_test.jl
+++ b/test/discont_tree_test.jl
@@ -1,4 +1,4 @@
-using DelayDiffEq, OrdinaryDiffEq, Base.Test
+using DelayDiffEq, OrdinaryDiffEq, DataStructures, Base.Test
 
 lags = [1//5, 1//2]
 alg = BS3()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,3 @@
-using DelayDiffEq, DiffEqBase, OrdinaryDiffEq, DataStructures
 using Base.Test
 
 @time @testset "Discontinuity Tree Test" begin include("discont_tree_test.jl") end

--- a/test/unconstrained.jl
+++ b/test/unconstrained.jl
@@ -111,7 +111,7 @@ println("Standard tests complete. Onto idxs tests")
 # Idxs
 
 f = function (t,u,h,du)
-  du[1] = -h(t-.2, Val{0}, 1) + u[1]
+  du[1] = -h(t-0.2, Val{0}, 1) + u[1]
 end
 
 h = function (t,idxs=nothing)
@@ -122,14 +122,14 @@ h = function (t,idxs=nothing)
   end
 end
 
-prob = ConstantLagDDEProblem(f, h, [1.0], lags, (0.0, 100.0))
+prob = ConstantLagDDEProblem(f, h, [1.0], [0.2], (0.0, 100.0))
 
 alg1 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
                      fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
 @time sol1 = solve(prob, alg1)
 
 f = function (t,u,h,du)
-  h(du, t-.2)
+  h(du, t-0.2)
   du[1] = -du[1]
   du[1] += u[1]
 end
@@ -144,7 +144,7 @@ h = function (out,t,idxs=nothing)
   out[1] = 0.0
 end
 
-prob = ConstantLagDDEProblem(f, h, [1.0], lags, (0.0, 100.0))
+prob = ConstantLagDDEProblem(f, h, [1.0], [0.2], (0.0, 100.0))
 
 alg1 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
                      fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)

--- a/test/units.jl
+++ b/test/units.jl
@@ -1,14 +1,12 @@
 using Unitful, DelayDiffEq, OrdinaryDiffEq, Base.Test
 
-lags = [.2u"s"]
-
 # Scalar problem, not in-place
 f = function (t,u,h)
-    out = (-h(t-.2u"s") + u) / 1.0u"s"
+    out = (-h(t-0.2u"s") + u) / 1.0u"s"
 end
 h = (t) -> 0.0u"N"
 
-prob = ConstantLagDDEProblem(f, h, 1.0u"N", lags, (0.0u"s", 100.0u"s"))
+prob = ConstantLagDDEProblem(f, h, 1.0u"N", [0.2u"s"], (0.0u"s", 100.0u"s"))
 
 # Unconstrained algorithm without units
 alg = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
@@ -46,11 +44,11 @@ sol2 = solve(prob, alg)
 
 # Vector problem, in-place
 f = function (t,u,h,du)
-    du[1] = (-h(t-.2u"s")[1] + u[1]) / 1.0u"s"
+    du[1] = (-h(t-0.2u"s")[1] + u[1]) / 1.0u"s"
 end
 h = (t) -> [0.0u"N"]
 
-prob = ConstantLagDDEProblem(f, h, [1.0u"N"], lags, (0.0u"s", 100.0u"s"))
+prob = ConstantLagDDEProblem(f, h, [1.0u"N"], [0.2u"s"], (0.0u"s", 100.0u"s"))
 
 # Unconstrained algorithm without units
 alg = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,


### PR DESCRIPTION
In `unconstrained.jl` `lags` was not defined, so the tests wrongly used `lags = [1//5, 1//2]` from `discont_tree_test.jl`. This did not cause any trouble because there are no error bound for the affected example.

Tests will fail because both MuladdMacro and DiffEqBase export `@muladd`. I would suggest tagging a new version of DiffEqBase, which then can be added as lower bound to DelayDiffEq (and also OrdinaryDiffEq, and StochasticDiffEq, I guess).