### PR TITLE
Reexport OrdinaryDiffEq

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
 julia 0.6
-DiffEqBase 1.16.0
 OrdinaryDiffEq 2.13.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0

--- a/src/DelayDiffEq.jl
+++ b/src/DelayDiffEq.jl
@@ -3,9 +3,9 @@ __precompile__()
 module DelayDiffEq
 
 using Reexport
-@reexport using DiffEqBase
+@reexport using OrdinaryDiffEq
 
-using OrdinaryDiffEq, DataStructures, RecursiveArrayTools, Combinatorics, MuladdMacro
+using DataStructures, RecursiveArrayTools, Combinatorics, MuladdMacro
 
 import OrdinaryDiffEq: initialize!, perform_step!, loopfooter!, loopheader!, alg_order,
                        handle_tstop!, ODEIntegrator, savevalues!,

--- a/test/constrained.jl
+++ b/test/constrained.jl
@@ -1,4 +1,4 @@
-using DelayDiffEq, OrdinaryDiffEq, DiffEqProblemLibrary, Base.Test
+using DelayDiffEq, DiffEqProblemLibrary, Base.Test
 
 # Check that numerical solutions approximate analytical solutions,
 # independent of problem structure

--- a/test/discont_tree_test.jl
+++ b/test/discont_tree_test.jl
@@ -1,4 +1,4 @@
-using DelayDiffEq, OrdinaryDiffEq, DataStructures, Base.Test
+using DelayDiffEq, DataStructures, Base.Test
 
 lags = [1//5, 1//2]
 alg = BS3()

--- a/test/events.jl
+++ b/test/events.jl
@@ -1,4 +1,4 @@
-using DelayDiffEq, OrdinaryDiffEq, DiffEqProblemLibrary, DiffEqDevTools,
+using DelayDiffEq, DiffEqProblemLibrary, DiffEqDevTools,
       DiffEqCallbacks, Base.Test
 
 prob = prob_dde_1delay_scalar_notinplace(1.0)

--- a/test/save_idxs.jl
+++ b/test/save_idxs.jl
@@ -1,4 +1,4 @@
-using DelayDiffEq, OrdinaryDiffEq, Base.Test
+using DelayDiffEq, Base.Test
 
 f = function (t,u,h,du)
     du[1] = - h(t-1/5)[1] + u[1]

--- a/test/saveat.jl
+++ b/test/saveat.jl
@@ -1,4 +1,4 @@
-using DelayDiffEq, OrdinaryDiffEq, DiffEqProblemLibrary, Base.Test
+using DelayDiffEq, DiffEqProblemLibrary, Base.Test
 
 prob = prob_dde_1delay_long
 alg = MethodOfSteps(Tsit5())

--- a/test/unconstrained.jl
+++ b/test/unconstrained.jl
@@ -1,4 +1,4 @@
-using DelayDiffEq, OrdinaryDiffEq, DiffEqProblemLibrary, Base.Test
+using DelayDiffEq, DiffEqProblemLibrary, Base.Test
 
 # Check that numerical solutions approximate analytical solutions,
 # independent of problem structure

--- a/test/unique_times.jl
+++ b/test/unique_times.jl
@@ -1,4 +1,4 @@
-using DelayDiffEq, OrdinaryDiffEq, DiffEqProblemLibrary, Base.Test
+using DelayDiffEq, DiffEqProblemLibrary, Base.Test
 
 prob = prob_dde_1delay_long
 

--- a/test/units.jl
+++ b/test/units.jl
@@ -1,4 +1,4 @@
-using Unitful, DelayDiffEq, OrdinaryDiffEq, Base.Test
+using Unitful, DelayDiffEq, Base.Test
 
 # Scalar problem, not in-place
 f = function (t,u,h)


### PR DESCRIPTION
I guess it might be convenient to reexport OrdinaryDiffEq. Since MethodOfSteps requires an ODE algorithm I always had to import OrdinaryDiffEq explicitly.