### PR TITLE
Lazy interpolants

### DIFF
--- a/src/DelayDiffEq.jl
+++ b/src/DelayDiffEq.jl
@@ -9,7 +9,7 @@ using DataStructures, RecursiveArrayTools, Combinatorics, MuladdMacro
 
 import OrdinaryDiffEq: initialize!, perform_step!, loopfooter!, loopheader!, alg_order,
                        handle_tstop!, ODEIntegrator, savevalues!,
-                       handle_callback_modifiers!, @tight_loop_macros
+                       handle_callback_modifiers!
 
 import DiffEqBase: solve, solve!, init, resize!, u_cache, user_cache, du_cache, full_cache,
                    deleteat!, terminate!, u_modified!, get_proposed_dt, set_proposed_dt!

--- a/src/DelayDiffEq.jl
+++ b/src/DelayDiffEq.jl
@@ -9,7 +9,7 @@ using DataStructures, RecursiveArrayTools, Combinatorics, MuladdMacro
 
 import OrdinaryDiffEq: initialize!, perform_step!, loopfooter!, loopheader!, alg_order,
                        handle_tstop!, ODEIntegrator, savevalues!,
-                       handle_callback_modifiers!
+                       handle_callback_modifiers!, @tight_loop_macros
 
 import DiffEqBase: solve, solve!, init, resize!, u_cache, user_cache, du_cache, full_cache,
                    deleteat!, terminate!, u_modified!, get_proposed_dt, set_proposed_dt!

--- a/src/history_function.jl
+++ b/src/history_function.jl
@@ -6,7 +6,7 @@ interface for retrieving values at any time point with varying accuracy.
 
 Before the initial time point of solution `sol` values are calculated by history function
 `h`, for time points in the time span of `sol` interpolated values of `sol` are returned,
-and after the final time point of `sol` an inter- or extrapolation of the current state 
+and after the final time point of `sol` an inter- or extrapolation of the current state
 of integrator `integrator` is retrieved.
 """
 struct HistoryFunction{F1,F2,F3} <: Function

--- a/src/integrator_utils.jl
+++ b/src/integrator_utils.jl
@@ -250,16 +250,10 @@ function update_ode_integrator!(integrator::DDEIntegrator)
         integrator.integrator.uprev = integrator.uprev
     end
 
-    # add additional interpolation steps
-    OrdinaryDiffEq.ode_addsteps!(integrator)
-
     # copy interpolation data (fsalfirst overwritten at the end of apply_step!, which also
     # updates k[1] when using chaches for which k[1] points to fsalfirst)
-    recursivecopy!(integrator.integrator.k, view(integrator.k, 1:integrator.kshortsize))
-    @tight_loop_macros for i in integrator.kshortsize+1:length(integrator.k)
-        @inbounds copyat_or_push!(integrator.integrator.k, i, integrator.k[i], Val{false})
-    end
+    recursivecopy!(integrator.integrator.k, integrator.k)
 
-    # remove additional interpolation steps
-    resize!(integrator.k, integrator.kshortsize)
+    # add additional interpolation steps
+    OrdinaryDiffEq.ode_addsteps!(integrator.integrator, integrator.f)
 end

--- a/test/lazy_interpolants.jl
+++ b/test/lazy_interpolants.jl
@@ -1,0 +1,31 @@
+using DelayDiffEq, DiffEqProblemLibrary, Base.Test
+
+# in-place problem
+prob = prob_dde_1delay(1.0)
+
+# Vern7
+sol = solve(prob, MethodOfSteps(Vern7()))
+
+@test sol.errors[:l∞] < 4.0e-4
+@test sol.errors[:final] < 3.5e-7
+@test sol.errors[:l2] < 1.8e-4
+
+# Vern9
+sol2 = solve(prob, MethodOfSteps(Vern9()))
+
+@test sol2.errors[:l∞] < 1.5e-3
+@test sol2.errors[:final] < 3.8e-6
+@test sol2.errors[:l2] < 6.2e-4
+
+# not in-place problem
+prob = prob_dde_1delay_scalar_notinplace(1.0)
+
+# Vern7
+sol_scalar = solve(prob, MethodOfSteps(Vern7()))
+
+@test sol.t == sol_scalar.t && sol[1, :] == sol_scalar.u
+
+# Vern9
+sol2_scalar = solve(prob, MethodOfSteps(Vern9()))
+
+@test sol2.t == sol2_scalar.t && sol2[1, :] == sol2_scalar.u

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,3 +9,4 @@ using Base.Test
 @time @testset "Units" begin include("units.jl") end
 @time @testset "Unique Times" begin include("unique_times.jl") end
 @time @testset "Residual Control" begin include("residual_control.jl") end
+@time @testset "Lazy Interpolants" begin include("lazy_interpolants.jl") end


### PR DESCRIPTION
These changes enable the use of methods with lazy interpolants such as Verner methods. Fixes https://github.com/JuliaDiffEq/DelayDiffEq.jl/issues/16.