### PR TITLE
Enable SDIRK integrators

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,9 +1,11 @@
 julia 0.6
 DiffEqBase 1.21.0
-OrdinaryDiffEq 2.17.0
+OrdinaryDiffEq 2.18.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
 Combinatorics
 Compat 0.17.0
 Reexport
 MuladdMacro
+ForwardDiff
+NLsolve

--- a/src/DelayDiffEq.jl
+++ b/src/DelayDiffEq.jl
@@ -5,7 +5,7 @@ module DelayDiffEq
 using Reexport
 @reexport using OrdinaryDiffEq
 
-using DataStructures, RecursiveArrayTools, Combinatorics, MuladdMacro
+using DataStructures, RecursiveArrayTools, Combinatorics, MuladdMacro, ForwardDiff, NLsolve
 
 import OrdinaryDiffEq: initialize!, perform_step!, loopfooter!, loopheader!, alg_order,
                        handle_tstop!, ODEIntegrator, savevalues!,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -26,7 +26,7 @@ julia> compute_discontinuity_tree([1//2, 1//3], BS3(), 1)
 ```
 """
 function compute_discontinuity_tree(lags, alg, start_val,end_val,neutral)
-  isempty(lags) && return eltype(lags)[] 
+  isempty(lags) && return eltype(lags)[]
   if !neutral
     start_val + unique(vcat((sum.(collect(with_replacement_combinations(lags, i))) for i in
                              1:alg_order(alg))...))
@@ -39,3 +39,102 @@ function compute_discontinuity_tree(lags, alg, start_val,end_val,neutral)
                              1:mult)...))
   end
 end
+
+"""
+    build_linked_cache(cache, alg, u, uprev, uprev2, f, t, dt)
+
+Create cache for algorithm `alg` from existing cache `cache` with updated `u`, `uprev`,
+`uprev2`, `f`, `t`, and `dt`.
+"""
+@generated function build_linked_cache(cache, alg, u, uprev, uprev2, f, t, dt)
+    assignments = [assign_expr(Val{name}(), fieldtype(cache, name), cache)
+                   for name in fieldnames(cache) if name ∉ [:u, :uprev, :uprev2, :t, :dt]]
+
+    :($(assignments...); $(DiffEqBase.parameterless_type(cache))($(fieldnames(cache)...)))
+end
+
+"""
+    assign_expr(::Val{name}, ::Type{T}, ::Type{cache})
+
+Create expression that extracts field `name` of type `T` from cache of type `cache`
+to variable `name`.
+
+Hereby u, uprev, uprev2, and function f are updated, if required.
+"""
+assign_expr(::Val{name}, ::Type, ::Type) where {name} =
+    :($name = getfield(cache, $(Meta.quot(name))))
+
+# update uhold
+assign_expr(::Val{:uhold}, ::Type,
+            ::Type{<:Union{OrdinaryDiffEq.GenericImplicitEulerCache,
+                           OrdinaryDiffEq.GenericTrapezoidCache,
+                           OrdinaryDiffEq.GenericIIF1Cache,
+                           OrdinaryDiffEq.GenericIIF2Cache}}) =
+                               :(uhold = vec(u))
+
+# update matrix exponential
+assign_expr(::Val{:expA}, ::Type, ::Type) =
+    :(A = f.f1; expA = expm(A*dt))
+assign_expr(::Val{:phi1}, ::Type, ::Type{<:OrdinaryDiffEq.NorsettEulerCache}) =
+    :(phi1 = ((expA-I)/A))
+
+# update derivative wrappers
+assign_expr(::Val{name}, ::Type{<:OrdinaryDiffEq.TimeDerivativeWrapper}, ::Type) where name =
+    :($name = OrdinaryDiffEq.TimeDerivativeWrapper(f, u))
+assign_expr(::Val{name}, ::Type{<:OrdinaryDiffEq.UDerivativeWrapper}, ::Type) where name =
+    :($name = OrdinaryDiffEq.UDerivativeWrapper(f, getfield(cache, t)))
+assign_expr(::Val{name}, ::Type{<:OrdinaryDiffEq.TimeGradientWrapper}, ::Type) where name =
+    :($name = OrdinaryDiffEq.TimeGradientWrapper(
+        OrdinaryDiffEq.VectorF(f, size(u)),
+        uprev,
+        getfield(cache, $(Meta.quot(name))).fx1))
+assign_expr(::Val{name}, ::Type{<:OrdinaryDiffEq.UJacobianWrapper}, ::Type) where name =
+    :($name = OrdinaryDiffEq.UJacobianWrapper(
+        OrdinaryDiffEq.VectorFReturn(f, size(u)),
+        t,
+        vec(uprev),
+        getfield(cache, $(Meta.quot(name))).fx1))
+
+# create new config of Jacobian
+assign_expr(::Val{name}, ::Type{ForwardDiff.JacobianConfig{T,V,N,D}},
+            ::Type) where {name,T,V,N,D} =
+                :($name = ForwardDiff.JacobianConfig(uf, vec(du1), vec(uprev),
+                                                     ForwardDiff.Chunk{$N}()))
+
+# update implicit RHS
+function assign_expr(::Val{name}, ::Type{<:OrdinaryDiffEq.ImplicitRHS}, ::Type) where name
+    nameq = Meta.quot(name)
+    :($name = OrdinaryDiffEq.ImplicitRHS(
+        f,
+        getfield(cache, $nameq).C,
+        t, t, t,
+        getfield(cache, $nameq).dual_cache))
+end
+assign_expr(::Val{name}, ::Type{<:OrdinaryDiffEq.ImplicitRHS_Scalar}, ::Type) where name =
+    :($name = OrdinaryDiffEq.ImplicitRHS_Scalar(
+        f,
+        getfield(cache, $(Meta.quot(name))).C,
+        t, t, t))
+function assign_expr(::Val{name}, ::Type{<:OrdinaryDiffEq.RHS_IIF}, ::Type) where name
+    nameq = Meta.quot(name)
+    :($name = OrdinaryDiffEq.RHS_IIF(
+        f,
+        getfield(cache, $nameq).tmp,
+        t, t,
+        getfield(cache, $nameq).dual_cache,
+        getfield(cache, $nameq).a))
+end
+function assign_expr(::Val{name}, ::Type{<:OrdinaryDiffEq.RHS_IIF_Scalar},
+                     ::Type) where name
+    nameq = Meta.quot(name)
+    :($name = OrdinaryDiffEq.RHS_IIF_Scalar(
+        f,
+        t, t,
+        getfield(cache, $nameq).tmp,
+        getfield(cache, $nameq).a))
+end
+
+# create new NLsolve differentiable function
+assign_expr(::Val{name}, ::Type{<:NLsolve.DifferentiableMultivariateFunction},
+            ::Type) where name =
+                :($name = alg.nlsolve(Val{:init},rhs,uhold))

--- a/test/rosenbrock_integrators.jl
+++ b/test/rosenbrock_integrators.jl
@@ -1,0 +1,19 @@
+using DelayDiffEq, DiffEqProblemLibrary, Base.Test
+
+prob = prob_dde_1delay(1.0)
+
+# ODE algorithms
+algs = [Rosenbrock23(), Rosenbrock32(), ROS3P(), Rodas3(),
+        RosShamp4(), Veldd4(), Velds4(), GRK4T(), GRK4A(),
+        Ros4LStab(), Rodas4(), Rodas42(), Rodas4P(), Rodas5()]
+
+names = ["Rosenbrock23", "Rosenbrock32", "ROS3P", "Rodas3",
+         "RosShamp4", "Veldd4", "Velds4", "GRK4T", "GRK4A",
+         "Ros4LStab", "Rodas4", "Rodas42", "Rodas4P", "Rodas5"]
+
+for (alg, name) in zip(algs, names)
+    print("testing ", name, "... ")
+    step_alg = MethodOfSteps(alg)
+    solve(prob, step_alg)
+    @time solve(prob, step_alg)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,3 +11,4 @@ using Base.Test
 @time @testset "Residual Control" begin include("residual_control.jl") end
 @time @testset "Lazy Interpolants" begin include("lazy_interpolants.jl") end
 @time @testset "SDIRK Integrators" begin include("sdirk_integrators.jl") end
+@time @testset "Rosenbrock Integrators" begin include("rosenbrock_integrators.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,3 +10,4 @@ using Base.Test
 @time @testset "Unique Times" begin include("unique_times.jl") end
 @time @testset "Residual Control" begin include("residual_control.jl") end
 @time @testset "Lazy Interpolants" begin include("lazy_interpolants.jl") end
+@time @testset "SDIRK Integrators" begin include("sdirk_integrators.jl") end

--- a/test/sdirk_integrators.jl
+++ b/test/sdirk_integrators.jl
@@ -1,0 +1,25 @@
+using DelayDiffEq, DiffEqProblemLibrary, Base.Test
+
+prob = prob_dde_1delay(1.0)
+
+# ODE algorithms
+algs = [GenericImplicitEuler(), GenericTrapezoid(),
+        ImplicitEuler(), ImplicitMidpoint(), Trapezoid(),
+        TRBDF2(), SDIRK2(), SSPSDIRK2(),
+        Kvaerno3(), KenCarp3(),
+        Cash4(), Hairer4(), Hairer42(), Kvaerno4(), KenCarp4(),
+        Kvaerno5(), KenCarp5()]
+
+names = ["GenericImplicitEuler", "GenericTrapezoid",
+         "ImplicitEuler", "ImplicitMidpoint", "Trapezoid",
+         "TRBDF2", "SDIRK2", "SSPSDIRK2",
+         "Kvaerno3", "KenCarp3",
+         "Cash4", "Hairer4", "Hairer42", "Kvaerno4", "KenCarp4",
+         "Kvaerno5", "KenCarp5"]
+
+for (alg, name) in zip(algs, names)
+    println("testing $name...")
+    step_alg = MethodOfSteps(alg)
+    sol = solve(prob, step_alg)
+    @time solve(prob, step_alg)
+end

--- a/test/sdirk_integrators.jl
+++ b/test/sdirk_integrators.jl
@@ -20,5 +20,6 @@ names = ["GenericImplicitEuler", "GenericTrapezoid",
 for (alg, name) in zip(algs, names)
     println("testing $name...")
     step_alg = MethodOfSteps(alg)
-    sol = solve(prob, step_alg)
+    solve(prob, step_alg)
+    @time solve(prob, step_alg)
 end

--- a/test/sdirk_integrators.jl
+++ b/test/sdirk_integrators.jl
@@ -18,7 +18,7 @@ names = ["GenericImplicitEuler", "GenericTrapezoid",
          "Kvaerno5", "KenCarp5"]
 
 for (alg, name) in zip(algs, names)
-    println("testing $name...")
+    print("testing ", name, "... ")
     step_alg = MethodOfSteps(alg)
     solve(prob, step_alg)
     @time solve(prob, step_alg)

--- a/test/sdirk_integrators.jl
+++ b/test/sdirk_integrators.jl
@@ -21,5 +21,4 @@ for (alg, name) in zip(algs, names)
     println("testing $name...")
     step_alg = MethodOfSteps(alg)
     sol = solve(prob, step_alg)
-    @time solve(prob, step_alg)
 end


### PR DESCRIPTION
This enables SDIRK integrators. Currently they do not work since the derivative wrappers, created during creation of the ODE integrator, wrap function `prob.f` which requires 4 arguments. Hence I created an additional cache which wraps function `dde_f` of the DDE integrator with 3 arguments.

By the way, Euler methods are very slow which is caused by the incorrect implementation of divided differences IMO. Changing line
https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/blob/master/src/integrators/sdirk_integrators.jl#L230
to
```julia
@. tmp = r*abs((u - uprev)/dt1 - (uprev - uprev2)/dt2)
```
(which corresponds to the definition of divided differences, I guess) reduces both timings and allocations to similar values as in other SDIRK methods.