### PR TITLE
Do not return SubArrays in solution

### DIFF
--- a/test/save_idxs.jl
+++ b/test/save_idxs.jl
@@ -1,43 +1,84 @@
 using DelayDiffEq, Base.Test
 
-f = function (t,u,h,du)
+f_inplace = function (t,u,h,du)
     du[1] = - h(t-1/5)[1] + u[1]
     du[2] = - h(t-1/3)[2] - h(t-1/5)[2]
 end
-prob = ConstantLagDDEProblem(f, t->zeros(2), ones(2), [1/5, 1/3], (0.0, 100.0))
+prob_inplace = DDEProblem(f_inplace, t->zeros(2), ones(2), (0.0, 100.0), [1/5, 1/3])
+
+f_notinplace = function(t,u,h)
+    [-h(t-1/5)[1] + u[1]; -h(t-1/3)[2] - h(t-1/5)[2]]
+end
+prob_notinplace = DDEProblem(f_notinplace, t->zeros(2), ones(2), (0.0, 100.0), [1/5, 1/3])
+
 alg = MethodOfSteps(BS3())
 
-# save all components (without keyword argument)
-dde_int = init(prob, alg)
-sol = solve!(dde_int)
+for (prob, dense, save_start, save_everystep, saveat) in
+    Iterators.product((prob_inplace, prob_notinplace),
+                      (true, false),
+                      (true, false),
+                      (true, false),
+                      (Float64[], [25.0, 50.0, 100.0]))
 
-## solution and solution of ODE integrator contain all components
-@test length(sol.u[1]) == 2
-@test sol.u == dde_int.sol.u
+    # save all components (without keyword argument)
+    dde_int = init(prob, alg; save_start=save_start, saveat=saveat, dense=dense)
+    sol = solve!(dde_int)
 
-# save all components (with keyword argument)
-dde_int2 = init(prob, alg; save_idxs=[1, 2])
-sol2 = solve!(dde_int2)
+    ## solution and solution of ODE integrator contain all components
+    @test length(sol.u[1]) == 2
+    @test length(dde_int.sol.u[1]) == 2
 
-## solution and solution of ODE integrator contain all components
-@test length(sol2.u[1]) == 2
-@test sol2.u == dde_int2.sol.u
+    ## interpolation
+    @test sol(25:100, idxs=2) == [u[1] for u in sol(25:100, idxs=[2])]
 
-## solution equals solution without keyword arguments
-@test sol.t == sol2.t && sol.u == sol2.u
+    # save all components (with keyword argument)
+    dde_int2 = init(prob, alg; save_idxs=[1, 2], save_start=save_start, saveat=saveat,
+                    dense=dense)
+    sol2 = solve!(dde_int2)
 
-# save only second component
-dde_int3 = init(prob, alg; save_idxs=[2])
-sol3 = solve!(dde_int3)
+    ## solution and solution of ODE integrator contain all components
+    @test length(sol2.u[1]) == 2
+    @test length(dde_int2.sol.u[1]) == 2
 
-## solution contains only second component
-@test length(sol3.u[1]) == 1
+    ## solution equals solution without keyword arguments
+    @test sol.t == sol2.t && sol.u == sol2.u
 
-## solution equals second component of ODE integrator
-@test sol3[1, :] == dde_int3.sol[2, :]
+    ## interpolation
+    @test sol(25:100, idxs=2) == sol2(25:100, idxs=2)
+    @test sol(25:100, idxs=[2]) == sol2(25:100, idxs=[2])
 
-## solution equals second component of complete solution
-@test sol.t == sol3.t && sol[2, :] == sol3[1, :]
+    # save only second component
+    dde_int3 = init(prob, alg; save_idxs=[2], save_start=save_start, saveat=saveat,
+                    dense=dense)
+    sol3 = solve!(dde_int3)
 
-## interpolation of solution equals second component of interpolation of complete solution
-@test sol(0:100, idxs=2) == sol3(0:100, idxs=1)
+    ## solution contains only second component
+    @test length(sol3.u[1]) == 1
+
+    ## solution of ODE integrator contains both components
+    @test length(dde_int3.sol.u[1]) == 2
+
+    ## solution equals second component of complete solution
+    @test sol.t == sol3.t && sol[2, :] == sol3[1, :]
+
+    ## interpolation of solution equals second component of interpolation of complete solution
+    @test sol(25:100, idxs=2) == sol3(25:100, idxs=1)
+    @test sol(25:100, idxs=[2]) == sol3(25:100, idxs=[1])
+
+    # save only second component, scalar index
+    dde_int4 = init(prob, alg; save_idxs=2, save_start=save_start, saveat=saveat,
+                    dense=dense)
+    sol4 = solve!(dde_int4)
+
+    ## solution is only vector of floats
+    @test typeof(sol4.u) == Vector{Float64}
+
+    ## solution of ODE integrator contains both components
+    @test length(dde_int4.sol.u[1]) == 2
+
+    ## solution equals second component of complete solution
+    @test sol.t == sol4.t && sol[2, :] == sol4.u
+
+    ## interpolation of solution equals second component of interpolation of complete solution
+    @test sol(25:100, idxs=2) == sol4(25:100, idxs=1)
+end


### PR DESCRIPTION
This also fixes the problem described in https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/180 for DelayDiffEq. Furthermore, interpolation and plotting seems to be broken for solutions that are returned as `SubArray` and I could not see an easy fix. Moreover, I fear that it might cause additional problems I am not aware of yet. So even though I would like to keep allocations down to a minimum, I guess we should rather not return `SubArrays`. Additionally, currently sometimes regular arrays and sometimes `SubArrays` are returned which seems inconsistent.