### PR TITLE
Add interpolants and change order of interpolation updates

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.6
 DiffEqBase 1.21.0
-OrdinaryDiffEq 2.18.0
+OrdinaryDiffEq 2.19.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
 Combinatorics

--- a/src/DelayDiffEq.jl
+++ b/src/DelayDiffEq.jl
@@ -28,8 +28,6 @@ include("alg_utils.jl")
 include("solve.jl")
 include("utils.jl")
 
-export HistoryFunction
-
 export MethodOfSteps
 
 end # module

--- a/src/DelayDiffEq.jl
+++ b/src/DelayDiffEq.jl
@@ -8,8 +8,8 @@ using Reexport
 using DataStructures, RecursiveArrayTools, Combinatorics, MuladdMacro, ForwardDiff, NLsolve
 
 import OrdinaryDiffEq: initialize!, perform_step!, loopfooter!, loopheader!, alg_order,
-                       handle_tstop!, ODEIntegrator, savevalues!,
-                       handle_callback_modifiers!
+                       handle_tstop!, ODEIntegrator, savevalues!, postamble!,
+                       handle_callback_modifiers!, reeval_internals_due_to_modification!
 
 import DiffEqBase: solve, solve!, init, resize!, u_cache, user_cache, du_cache, full_cache,
                    deleteat!, terminate!, u_modified!, get_proposed_dt, set_proposed_dt!
@@ -20,16 +20,13 @@ import OrdinaryDiffEq: Rosenbrock23Cache, Rosenbrock32Cache, ImplicitEulerCache,
 include("integrator_type.jl")
 include("integrator_utils.jl")
 include("integrator_interface.jl")
+include("interpolants.jl")
 include("history_function.jl")
 include("algorithms.jl")
 include("callbacks.jl")
 include("alg_utils.jl")
 include("solve.jl")
 include("utils.jl")
-
-export init
-
-export initialize!, loopheader!, perform_step!, loopfooter!, handle_tstop!, postamble!
 
 export HistoryFunction
 

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -1,8 +1,8 @@
 # update integrator when u is modified by callbacks
-@inline function handle_callback_modifiers!(integrator::DDEIntegrator)
+function handle_callback_modifiers!(integrator::DDEIntegrator)
     integrator.reeval_fsal = true # recalculate fsalfirst after applying step
 
-    # update heap of discontinuities
+    # update heap of discontinuities and time stops
 
     if typeof(integrator.sol.prob) <: ConstantLagDDEProblem
         #warn("ConstantLagDDEProblem is deprecated. Use DDEProblem instead.")
@@ -13,7 +13,35 @@
         constant_lags = integrator.sol.prob.constant_lags
     end
 
-    push!(integrator.opts.d_discontinuities,
-          compute_discontinuity_tree(constant_lags, integrator.alg,
-                                     integrator.t,integrator.prob.tspan[2],neutral)...)
+    discontinuity_tree = compute_discontinuity_tree(constant_lags, integrator.alg,
+                                                    integrator.t, integrator.prob.tspan[2],
+                                                    neutral)
+    push!(integrator.opts.d_discontinuities, discontinuity_tree...)
+    push!(integrator.opts.tstops, discontinuity_tree...)
+end
+
+"""
+    reeval_internals_due_to_modification!(integrator::DDEIntegrator)
+
+Recalculate interpolation data and update ODE integrator after changes by callbacks.
+"""
+function reeval_internals_due_to_modification!(integrator::DDEIntegrator)
+    # update interpolation data of DDE integrator using old interpolation data
+    # of ODE integrator in evaluation of history function that was calculated in
+    # `perform_step!`
+    OrdinaryDiffEq.ode_addsteps!(integrator, integrator.f, Val{true}, Val{true}, Val{true})
+
+    # copy interpolation data to ODE integrator
+    recursivecopy!(integrator.integrator.k, integrator.k)
+
+    # move ODE integrator to new time interval of DDE integrator
+    integrator.integrator.t = integrator.t
+    integrator.integrator.dt = integrator.dt
+    if typeof(integrator.integrator.u) <: AbstractArray
+        recursivecopy!(integrator.integrator.u, integrator.u)
+    else
+        integrator.integrator.u = integrator.u
+    end
+
+    integrator.u_modified = false
 end

--- a/src/history_function.jl
+++ b/src/history_function.jl
@@ -9,7 +9,7 @@ Before the initial time point of solution `sol` values are calculated by history
 and after the final time point of `sol` an inter- or extrapolation of the current state
 of integrator `integrator` is retrieved.
 """
-struct HistoryFunction{F1,F2,F3} <: Function
+struct HistoryFunction{F1,F2,F3<:ODEIntegrator} <: Function
     h::F1
     sol::F2
     integrator::F3
@@ -30,6 +30,9 @@ function (f::HistoryFunction)(t, deriv::Type=Val{0}, idxs=nothing)
 
     # set boolean that indicates that history function was evaluated at time point past the
     # final time point of the current solution
+    # NOTE: does not interfere with usual use of isout since this integrator is only used
+    # for inter- and extrapolation of future values and saving of the solution but does not
+    # affect whether time steps are accepted
     integrator.isout = true
 
     # handle extrapolations in initial time step (otherwise dt = 0 should not occur)
@@ -53,6 +56,9 @@ function (f::HistoryFunction)(val, t, deriv::Type=Val{0}, idxs=nothing)
 
     # set boolean that indicates that history function was evaluated at time point past the
     # final time point of the current solution
+    # NOTE: does not interfere with usual use of isout since this integrator is only used
+    # for inter- and extrapolation of future values and saving of the solution but does not
+    # affect whether time steps are accepted
     integrator.isout = true
 
     # handle extrapolations in initial time step (otherwise dt = 0 should not occur)

--- a/src/history_function.jl
+++ b/src/history_function.jl
@@ -35,13 +35,7 @@ function (f::HistoryFunction)(t, deriv::Type=Val{0}, idxs=nothing)
     # handle extrapolations in initial time step (otherwise dt = 0 should not occur)
     integrator.dt == 0 && return constant_extrapolation(t, integrator, idxs, deriv)
 
-    if typeof(integrator.alg) <: Union{Vern6,Vern7,Vern8,Vern9} &&
-        length(integrator.k) == integrator.kshortsize
-        # use Hermite interpolant as fallback to avoid implicit calculation
-        return hermite_interpolant(t, integrator, idxs, deriv)
-    else
-        return OrdinaryDiffEq.current_interpolant(t, integrator, idxs, deriv)
-    end
+    return OrdinaryDiffEq.current_interpolant(t, integrator, idxs, deriv)
 end
 
 function (f::HistoryFunction)(val, t, deriv::Type=Val{0}, idxs=nothing)
@@ -64,11 +58,5 @@ function (f::HistoryFunction)(val, t, deriv::Type=Val{0}, idxs=nothing)
     # handle extrapolations in initial time step (otherwise dt = 0 should not occur)
     integrator.dt == 0 && return constant_extrapolation!(val, t, integrator, idxs, deriv)
 
-    if typeof(integrator.alg) <: Union{Vern6,Vern7,Vern8,Vern9} &&
-        length(integrator.k) == integrator.kshortsize
-        # use Hermite interpolant as fallback to avoid implicit calculation
-        return hermite_interpolant!(val, t, integrator, idxs, deriv)
-    else
-        return OrdinaryDiffEq.current_interpolant!(val, t, f.integrator, idxs, deriv)
-    end
+    return OrdinaryDiffEq.current_interpolant!(val, t, f.integrator, idxs, deriv)
 end

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -4,26 +4,53 @@
 Update solution of `integrator`, if necessary or forced by `force_save`.
 """
 function savevalues!(integrator::DDEIntegrator, force_save=false)
-    # update ODE integrator
-    update_ode_integrator!(integrator)
+    # update time of ODE integrator (can be slightly modified (< 10ϵ) because of time stops)
+    if integrator.integrator.t != integrator.t
+        if abs(integrator.t - integrator.integrator.t) >= 10eps(integrator.t)
+            error("unexpected time discrepancy detected")
+        end
 
-    # update solution of ODE integrator
-    savevalues!(integrator.integrator, force_save)
-
-    if typeof(integrator.sol.prob) <: ConstantLagDDEProblem
-        #warn("ConstantLagDDEProblem is deprecated. Use DDEProblem instead.")
-        neutral = false
-        constant_lags = integrator.sol.prob.lags
-    else
-        neutral = integrator.sol.prob.neutral
-        constant_lags = integrator.sol.prob.constant_lags
+        integrator.integrator.t = integrator.t
+        integrator.integrator.dt = integrator.integrator.t - integrator.integrator.tprev
     end
 
-    # delete part of ODE solution that is not required for DDE solution
-    !isempty(constant_lags) && reduce_solution!(integrator,
-                     # function values at later time points might be necessary for
-                     # calculation of next step, thus keep those interpolation data
-                     integrator.integrator.tprev - maximum(constant_lags))
+    # update solution
+    savevalues!(integrator.integrator, force_save)
+
+    # copy additional interpolation steps back from solution to reduced ODE integrator
+    # last entry of solution always equals last time point of integration
+    if length(integrator.sol.k[end]) > length(integrator.integrator.k)
+        @inbounds for i in integrator.kshortsize+1:length(integrator.sol.k[end])
+            copyat_or_push!(integrator.integrator.k, i, integrator.sol.k[end][i])
+        end
+    end
+
+    # update prev2_idx to indices of tprev and u(tprev) in solution
+    integrator.prev2_idx = integrator.prev_idx
+
+    # cache dt of interval [tprev, t] of ODE integrator since it can only be retrieved by
+    # a possibly incorrect subtraction
+    integrator.integrator.dtcache = integrator.integrator.dt
+
+    # reduce ODE solution
+    if !(typeof(integrator.saveat) <: Void)
+        # obtain constant lags
+        if typeof(integrator.prob) <: ConstantLagDDEProblem
+            #warn("ConstantLagDDEProblem is deprecated. Use DDEProblem instead.")
+            constant_lags = integrator.prob.lags
+        else
+            constant_lags = integrator.prob.constant_lags
+        end
+
+        # delete part of ODE solution that is not required for DDE solution
+        reduce_solution!(integrator,
+                         # function values at later time points might be necessary for
+                         # calculation of next step, thus keep those interpolation data
+                         integrator.t - maximum(constant_lags))
+    end
+
+    # prevent reset of ODE integrator to cached values in the calculation of the next step
+    integrator.integrator.accept_step = true
 end
 
 """
@@ -32,14 +59,12 @@ end
 Clean up solution of `integrator`.
 """
 function postamble!(integrator::DDEIntegrator)
-    # update ODE integrator
-    update_ode_integrator!(integrator)
-
     # clean up solution of ODE integrator
-    OrdinaryDiffEq.postamble!(integrator.integrator)
+    postamble!(integrator.integrator)
 
-    # delete part of ODE solution that is not required for DDE solution
-    reduce_solution!(integrator, integrator.integrator.sol.t[end])
+    # reduce solution if possible
+    !(typeof(integrator.saveat) <: Void) && reduce_solution!(integrator,
+                                                             integrator.sol.t[end])
 end
 
 """
@@ -48,77 +73,49 @@ end
 Calculate next step of `integrator`.
 """
 @muladd function perform_step!(integrator::DDEIntegrator)
-    # cache error estimate of integrator and interpolation data of interval [tprev, t]
-    # (maybe with already updated entry k[1] = fsalfirst == fsallast, if k[1] points to
-    # fsalfirst) to be able to reset the corresponding variables in case calculation results
-    # in numbers that are not finite
-    recursivecopy!(integrator.k_cache, integrator.k)
-    integrator.integrator.EEst = integrator.EEst
+    # reset ODE integrator to cached values if last step failed
+    if !integrator.integrator.accept_step
+        if typeof(integrator.u) <: AbstractArray
+            recursivecopy!(integrator.integrator.u, integrator.sol.u[end])
+        else
+            integrator.integrator.u = integrator.sol.u[end]
+        end
+        integrator.integrator.t = integrator.sol.t[end]
+        integrator.integrator.tprev = integrator.sol.t[integrator.prev2_idx]
+        integrator.integrator.dt = integrator.integrator.dtcache
 
-    # add additional interpolation steps
-    OrdinaryDiffEq.ode_addsteps!(integrator.integrator, integrator.f)
+        # u(tprev) is not modified hence we do not have to copy it
+        integrator.integrator.uprev = integrator.sol.u[integrator.prev2_idx]
+
+        # do not have to reset interpolation data in initial time step since always a
+        # constant extrapolation is used (and interpolation data of solution at initial
+        # time point is not complete!)
+        if length(integrator.sol.t) > 1
+            recursivecopy!(integrator.integrator.k, integrator.sol.k[end])
+        end
+    end
+
+    # reset boolean which indicates whether history function was evaluated at a time point
+    # past the final point of the current solution
+    integrator.integrator.isout = false
 
     # perform always at least one calculation
     perform_step!(integrator, integrator.cache)
 
-    if typeof(integrator.prob) <: ConstantLagDDEProblem
-        #warn("ConstantLagDDEProblem is deprecated. Use DDEProblem instead.")
-        neutral = false
-        constant_lags = integrator.prob.lags
-    else
-        neutral = integrator.prob.neutral
-        constant_lags = integrator.prob.constant_lags
-    end
+    # if the history function was evaluated at time points past the final time point of the
+    # solution, i.e. returned extrapolated values, continue with a fixed-point iteration
+    if integrator.integrator.isout
+        # update ODE integrator to next time interval together with correct interpolation
+        advance_ode_integrator!(integrator)
 
-    # if dt is greater than the minimal lag, then use a fixed-point iteration
-    if isempty(constant_lags) ||
-       (integrator.dt > minimum(constant_lags) && isfinite(integrator.EEst))
-
-        # update cached error estimate of integrator
-        integrator.integrator.EEst = integrator.EEst
-
-        # save dt, u(tprev) and interpolation data of interval [tprev, t] of ODE
-        # integrator since they are overwritten by fixed-point iteration
-        if typeof(integrator.uprev_cache) <: AbstractArray
-            recursivecopy!(integrator.uprev_cache, integrator.integrator.uprev)
-        else
-            integrator.uprev_cache = integrator.integrator.uprev
-        end
-        recursivecopy!(integrator.k_integrator_cache,
-                       view(integrator.integrator.k, 1:integrator.kshortsize))
-        integrator.integrator.dtcache = integrator.integrator.dt
-
-        # move ODE integrator to interval [t, t+dt] to use interpolation of ODE integrator
-        # in the next iterations when evaluating the history function
-        integrator.integrator.t = integrator.t + integrator.dt
-        integrator.integrator.tprev = integrator.t
-        integrator.integrator.dt = integrator.dt
-        if typeof(integrator.integrator.uprev) <: AbstractArray
-            recursivecopy!(integrator.integrator.uprev, integrator.uprev)
-        else
-            integrator.integrator.uprev = integrator.uprev
-        end
-
-        numiters=1
+        numiters = 1
 
         while true
-            # update value u(t+dt) and interpolation data of interval [t, t+dt] that are
-            # used for the interpolation of the history function in the next iteration
-            if typeof(integrator.u) <: AbstractArray
-                recursivecopy!(integrator.integrator.u, integrator.u)
-            else
-                integrator.integrator.u = integrator.u
-            end
-
-            # force update of additional interpolation steps
-            OrdinaryDiffEq.ode_addsteps!(integrator, integrator.f,
-                                         Val{false}, Val{true}, Val{true})
-            recursivecopy!(integrator.integrator.k, integrator.k)
-
             # calculate next step
             perform_step!(integrator, integrator.cache, true) # repeat_step=true
 
             # calculate residuals of fixed-point iteration
+            # TODO: replace with updated calculate_residuals
             if typeof(integrator.u) <: AbstractArray
                 @. integrator.resid = (integrator.u - integrator.integrator.u) /
                     (integrator.fixedpoint_abstol + max(abs(integrator.u),
@@ -130,65 +127,53 @@ Calculate next step of `integrator`.
                                                         abs(integrator.integrator.u)) *
                             integrator.fixedpoint_reltol)
             end
-            fixedpointEEst = integrator.fixedpoint_norm(integrator.resid)
 
-            # stop fixed-point iteration when error estimate of integrator or error estimate
-            # of fixed-point iteration are not finite
-            if !isfinite(fixedpointEEst) || !isfinite(integrator.EEst)
-                # assure that integrator is reset to cached values
-                integrator.EEst = max(fixedpointEEst, integrator.EEst)
-                break
-            end
-
-            # update cached value of error estimate of integrator with a combined error
+            # update error estimate of integrator with a combined error
             # estimate of both integrator and fixed-point iteration
             # this prevents acceptance of steps with poor performance in fixed-point
             # iteration
-            integrator.integrator.EEst = max(fixedpointEEst, integrator.EEst)
+            integrator.EEst = max(integrator.EEst,
+                                  integrator.fixedpoint_norm(integrator.resid))
+
+            # complete interpolation data of DDE integrator for time interval [t, t+dt]
+            # and copy it to ODE integrator
+            # has to be done before updates to ODE integrator, otherwise history function
+            # is incorrect
+            if typeof(integrator.cache) <: OrdinaryDiffEq.CompositeCache
+                OrdinaryDiffEq.ode_addsteps!(integrator.k, integrator.t, integrator.uprev,
+                                             integrator.u, integrator.dt, integrator.f,
+                                             integrator.cache.caches[integrator.cache.current],
+                                             Val{false}, Val{true}, Val{true})
+            else
+                OrdinaryDiffEq.ode_addsteps!(integrator.k, integrator.t, integrator.uprev,
+                                             integrator.u, integrator.dt, integrator.f,
+                                             integrator.cache, Val{false}, Val{true},
+                                             Val{true})
+            end
+            recursivecopy!(integrator.integrator.k, integrator.k)
+
+            # update value u(t+dt)
+            if typeof(integrator.u) <: AbstractArray
+                recursivecopy!(integrator.integrator.u, integrator.u)
+            else
+                integrator.integrator.u = integrator.u
+            end
 
             # stop fixed-point iteration when error estimate is small or maximal number of
             # steps is exceeded
-            if integrator.integrator.EEst <= 1 || numiters > integrator.max_fixedpoint_iters
-                # update error estimate with combined error estimate
-                integrator.EEst = integrator.integrator.EEst
+            if integrator.EEst <= 1 || numiters > integrator.max_fixedpoint_iters
                 break
             end
 
             numiters += 1
         end
-
-        # reset ODE integrator to interval [tprev, t] with corresponding values
-        # u(tprev) and u(t), and interpolation data k of this interval
-        integrator.integrator.t = integrator.t
-        integrator.integrator.tprev = integrator.tprev
-        integrator.integrator.dt = integrator.integrator.dtcache
-        if typeof(integrator.u) <: AbstractArray
-            recursivecopy!(integrator.integrator.u, integrator.uprev)
-            recursivecopy!(integrator.integrator.uprev, integrator.uprev_cache)
-        else
-            integrator.integrator.u = integrator.uprev
-            integrator.integrator.uprev = integrator.uprev_cache
-        end
-        recursivecopy!(view(integrator.integrator.k, 1:integrator.kshortsize),
-                       integrator.k_integrator_cache)
-
-        # remove additional interpolation steps
-        resize!(integrator.k, integrator.kshortsize)
+    else
+        # update ODE integrator to next time interval together with correct interpolation
+        advance_ode_integrator!(integrator)
     end
 
-    # remove additional interpolation steps
-    resize!(integrator.integrator.k, integrator.kshortsize)
-
-    # if error estimate of integrator is not a finite number reset it to last cached error
-    # estimate or 2, and reset interpolation data of integrator to interpolation data of
-    # interval [tprev, t] (maybe with updated entry k[1]) before calculation of current step
-    # then current step will not be accepted, time step dt will be decreased,
-    # and calculation of next step will be repeated starting with the same
-    # initial interpolation data
-    if !isfinite(integrator.EEst)
-        integrator.EEst = max(2, integrator.integrator.EEst) # EEst must be > 1
-        recursivecopy!(integrator.k, integrator.k_cache)
-    end
+    # is reset if time step is saved, prevents unnecessary copies and assignments
+    integrator.integrator.accept_step = false
 end
 
 """
@@ -197,16 +182,18 @@ end
 Set initial values of `integrator`.
 """
 function initialize!(integrator::DDEIntegrator)
+    # initialize DDE integrator
     initialize!(integrator, integrator.cache)
-
-    # interpolation data of integrator and ODE integrator have to be cached
-    # when next step is calculated
-    integrator.k_cache = recursivecopy(integrator.k)
-    integrator.k_integrator_cache = recursivecopy(integrator.k)
 
     # copy interpolation data to ODE integrator
     integrator.integrator.kshortsize = integrator.kshortsize
     integrator.integrator.k = recursivecopy(integrator.k)
+
+    # add interpolation steps to ODE integrator to ensure that interpolation data
+    # is always maximal when calculating the next step
+    # exact values do not matter since in the initial time step always a constant
+    # extrapolation is used
+    OrdinaryDiffEq.ode_addsteps!(integrator.integrator, integrator.f)
 end
 
 """

--- a/src/integrator_type.jl
+++ b/src/integrator_type.jl
@@ -1,8 +1,7 @@
-mutable struct DDEIntegrator{algType<:OrdinaryDiffEq.OrdinaryDiffEqAlgorithm,uType,tType,absType,relType,
-                             residType,tTypeNoUnits,tdirType,ksEltype,SolType,rateType,F,
-                             ProgressType,CacheType,IType,ProbType,NType,O,tstopsType} <:
-                                 AbstractDDEIntegrator
-
+mutable struct DDEIntegrator{algType<:OrdinaryDiffEq.OrdinaryDiffEqAlgorithm,uType,tType,
+                             absType,relType,residType,tTypeNoUnits,tdirType,ksEltype,
+                             SolType,rateType,F,ProgressType,CacheType,IType,ProbType,NType,
+                             O,tstopsType} <: AbstractDDEIntegrator
     sol::SolType
     prob::ProbType
     u::uType
@@ -13,15 +12,13 @@ mutable struct DDEIntegrator{algType<:OrdinaryDiffEq.OrdinaryDiffEqAlgorithm,uTy
     uprev::uType
     uprev2::uType
     tprev::tType
-    uprev_cache::uType
-    k_cache::ksEltype
-    k_integrator_cache::ksEltype
+    prev_idx::Int
+    prev2_idx::Int
     fixedpoint_abstol::absType
     fixedpoint_reltol::relType
     resid::residType # This would have to resize for resizing DDE to work
     fixedpoint_norm::NType
     max_fixedpoint_iters::Int
-    minimal_solution::Bool
     alg::algType
     rate_prototype::rateType
     notsaveat_idxs::Vector{Int}
@@ -58,24 +55,23 @@ mutable struct DDEIntegrator{algType<:OrdinaryDiffEq.OrdinaryDiffEqAlgorithm,uTy
     function DDEIntegrator{algType,uType,tType,absType,relType,residType,tTypeNoUnits,
                            tdirType,ksEltype,SolType,rateType,F,ProgressType,CacheType,
                            IType,ProbType,NType,O,tstopsType}(
-                               sol,prob,u,k,t,dt,f,uprev,uprev2,tprev,uprev_cache,k_cache,
-                               k_integrator_cache,fixedpoint_abstol,fixedpoint_reltol,resid,
-                               fixedpoint_norm,max_fixedpoint_iters,minimal_solution,alg,
-                               rate_prototype,notsaveat_idxs,dtcache,dtchangeable,dtpropose,
-                               tdir,EEst,qold,q11,erracc,dtacc,success_iter,iter,saveiter,
-                               saveiter_dense,prog,cache,kshortsize,force_stepfail,
-                               last_stepfail,just_hit_tstop,accept_step,isout,reeval_fsal,
-                               u_modified,opts,integrator,saveat) where
-        {algType,uType,tType,absType,relType,residType,
-         tTypeNoUnits,tdirType,ksEltype,SolType,rateType,F,ProgressType,CacheType,IType,
-         ProbType,NType,O,tstopsType}
+                               sol,prob,u,k,t,dt,f,uprev,uprev2,tprev,prev_idx,prev2_idx,
+                               fixedpoint_abstol,fixedpoint_reltol,resid,fixedpoint_norm,
+                               max_fixedpoint_iters,alg,rate_prototype,notsaveat_idxs,
+                               dtcache,dtchangeable,dtpropose,tdir,EEst,qold,q11,erracc,
+                               dtacc,success_iter,iter,saveiter,saveiter_dense,prog,cache,
+                               kshortsize,force_stepfail,last_stepfail,just_hit_tstop,
+                               accept_step,isout,reeval_fsal,u_modified,opts,integrator,
+                               saveat) where
+        {algType,uType,tType,absType,relType,residType,tTypeNoUnits,tdirType,ksEltype,
+         SolType,rateType,F,ProgressType,CacheType,IType,ProbType,NType,O,tstopsType}
 
-        new(sol,prob,u,k,t,dt,f,uprev,uprev2,tprev,uprev_cache,k_cache,k_integrator_cache,
-            fixedpoint_abstol,fixedpoint_reltol,resid,fixedpoint_norm,max_fixedpoint_iters,
-            minimal_solution,alg,rate_prototype,notsaveat_idxs,dtcache,dtchangeable,
-            dtpropose,tdir,EEst,qold,q11,erracc,dtacc,success_iter,iter,saveiter,
-            saveiter_dense,prog,cache,kshortsize,force_stepfail,last_stepfail,
-            just_hit_tstop,accept_step,isout,reeval_fsal,u_modified,opts,integrator,saveat)
+        new(sol,prob,u,k,t,dt,f,uprev,uprev2,tprev,prev_idx,prev2_idx,fixedpoint_abstol,
+            fixedpoint_reltol,resid,fixedpoint_norm,max_fixedpoint_iters,alg,rate_prototype,
+            notsaveat_idxs,dtcache,dtchangeable,dtpropose,tdir,EEst,qold,q11,erracc,dtacc,
+            success_iter,iter,saveiter,saveiter_dense,prog,cache,kshortsize,force_stepfail,
+            last_stepfail,just_hit_tstop,accept_step,isout,reeval_fsal,u_modified,opts,
+            integrator,saveat)
     end
 end
 

--- a/src/interpolants.jl
+++ b/src/interpolants.jl
@@ -1,0 +1,97 @@
+"""
+    hermite_interpolant(t, integrator::DEIntegrator, idxs, deriv)
+
+Calculate Hermite interpolation of derivative `deriv` at time `t` and indices `idxs`
+for `integrator`.
+"""
+function hermite_interpolant(t, integrator::DEIntegrator, idxs, deriv)
+    [hermite_interpolant(τ, integrator, idxs, deriv) for τ in t]
+end
+
+function hermite_interpolant(t::Number, integrator::DEIntegrator, idxs, deriv)
+    Θ = (t - integrator.tprev)/integrator.dt
+    OrdinaryDiffEq.hermite_interpolant(Θ, integrator.dt, integrator.uprev,
+                                       integrator.u, integrator.k, integrator.cache,
+                                       idxs, deriv)
+end
+
+"""
+    hermite_interpolant!(val, t, integrator::DEIntegrator, idxs, deriv)
+
+Calculate Hermite interpolation of derivative `deriv` at time `t` and indices `idxs`
+for `integrator`, and save result in `val` if `val` is not `nothing`.
+"""
+function hermite_interpolant!(val, t, integrator::DEIntegrator, idxs, deriv)
+    [hermite_interpolant!(val, τ, integrator, idxs, deriv) for τ in t]
+end
+
+function hermite_interpolant!(val, t::Number, integrator::DEIntegrator, idxs, deriv)
+    Θ = (t - integrator.tprev)/integrator.dt
+    OrdinaryDiffEq.hermite_interpolant!(val, Θ, integrator.dt, integrator.uprev,
+                                       integrator.u, integrator.k, integrator.cache,
+                                       idxs, deriv)
+end
+
+"""
+    constant_extrapolant(t, integrator::DEIntegrator, idxs, deriv)
+
+Calculate constant extrapolation of derivative `deriv` at time `t` and indices `idxs`
+for `integrator`.
+"""
+function constant_extrapolant(t, integrator::DEIntegrator, idxs, deriv)
+    [constant_extrapolant(τ, integrator, idxs, deriv) for τ in t]
+end
+
+function constant_extrapolant(t::Number, integrator::DEIntegrator, idxs, T::Type{Val{0}})
+    if typeof(idxs) <: Void
+        return integrator.u
+    else
+        return integrator.u[idxs]
+    end
+end
+
+function constant_extrapolant(t::Number, integrator::DEIntegrator, idxs, T::Type{Val{1}})
+    if typeof(idxs) <: Void
+        return zero(integrator.u)./oneunit(t)
+    else
+        return zero(integrator.u[idxs])./oneunit(t)
+    end
+end
+
+"""
+    constant_extrapolant!(val, t, integrator::DEIntegrator, idxs, deriv)
+
+Calculate constant extrapolation of derivative `deriv` at time `t` and indices `idxs`
+for `integrator`, and save result in `val` if `val` is not `nothing`.
+"""
+function constant_extrapolant!(val, t, integrator::DEIntegrator, idxs, deriv)
+    [constant_extrapolant!(val, τ, integrator, idxs, deriv) for τ in t]
+end
+
+function constant_extrapolant!(val, t::Number, integrator::DEIntegrator, idxs, T::Type{Val{0}})
+    if val == nothing
+        if idxs == nothing
+            return integrator.u
+        else
+            return integrator.u[idxs]
+        end
+    elseif idxs == nothing
+        @. val = integrator.u
+    else
+        @views @. out = integrator.u[idxs]
+    end
+end
+
+function constant_extrapolant!(val, t::Number, integrator::DEIntegrator, idxs, T::Type{Val{1}})
+    if val == nothing
+        if idxs == nothing
+            return zero(integrator.u)./oneunit(t)
+        else
+            return zero(integrator.u[idxs])./oneunit(t)
+        end
+    elseif idxs == nothing
+        val .= zero(integrator.u)./oneunit(t)
+    else
+        @views val .= zero(integrator.u)./oneunit(t)
+    end
+end

--- a/src/interpolants.jl
+++ b/src/interpolants.jl
@@ -1,38 +1,4 @@
 """
-    hermite_interpolant(t, integrator::DEIntegrator, idxs, deriv)
-
-Calculate Hermite interpolation of derivative `deriv` at time `t` and indices `idxs`
-for `integrator`.
-"""
-function hermite_interpolant(t, integrator::DEIntegrator, idxs, deriv)
-    [hermite_interpolant(τ, integrator, idxs, deriv) for τ in t]
-end
-
-function hermite_interpolant(t::Number, integrator::DEIntegrator, idxs, deriv)
-    Θ = (t - integrator.tprev)/integrator.dt
-    OrdinaryDiffEq.hermite_interpolant(Θ, integrator.dt, integrator.uprev,
-                                       integrator.u, integrator.k, integrator.cache,
-                                       idxs, deriv)
-end
-
-"""
-    hermite_interpolant!(val, t, integrator::DEIntegrator, idxs, deriv)
-
-Calculate Hermite interpolation of derivative `deriv` at time `t` and indices `idxs`
-for `integrator`, and save result in `val` if `val` is not `nothing`.
-"""
-function hermite_interpolant!(val, t, integrator::DEIntegrator, idxs, deriv)
-    [hermite_interpolant!(val, τ, integrator, idxs, deriv) for τ in t]
-end
-
-function hermite_interpolant!(val, t::Number, integrator::DEIntegrator, idxs, deriv)
-    Θ = (t - integrator.tprev)/integrator.dt
-    OrdinaryDiffEq.hermite_interpolant!(val, Θ, integrator.dt, integrator.uprev,
-                                       integrator.u, integrator.k, integrator.cache,
-                                       idxs, deriv)
-end
-
-"""
     constant_extrapolant(t, integrator::DEIntegrator, idxs, deriv)
 
 Calculate constant extrapolation of derivative `deriv` at time `t` and indices `idxs`

--- a/test/events.jl
+++ b/test/events.jl
@@ -22,8 +22,8 @@ sol2 = solve(prob, alg, callback=cb, dtmax=0.01)
 
 sol3 = appxtrue(sol1, sol2)
 
-@test sol3.errors[:L2] < 3.2e-3
-@test sol3.errors[:L∞] < 7.8e-3
+@test sol3.errors[:L2] < 4.1e-3
+@test sol3.errors[:L∞] < 1.3e-2
 
 # discrete callback
 

--- a/test/lazy_interpolants.jl
+++ b/test/lazy_interpolants.jl
@@ -1,31 +1,66 @@
 using DelayDiffEq, DiffEqProblemLibrary, Base.Test
 
-# in-place problem
-prob = prob_dde_1delay(1.0)
+## simple problems
+prob_inplace = prob_dde_1delay(1.0)
+prob_notinplace = prob_dde_1delay_scalar_notinplace(1.0)
+
+# Vern6
+sol = solve(prob_inplace, MethodOfSteps(Vern6()))
+
+@test sol.errors[:l∞] < 8.7e-4
+@test sol.errors[:final] < 7.4e-6
+@test sol.errors[:l2] < 5.4e-4
+
+sol2 = solve(prob_notinplace, MethodOfSteps(Vern6()))
+
+@test sol.t == sol2.t && sol[1, :] == sol2.u
 
 # Vern7
-sol = solve(prob, MethodOfSteps(Vern7()))
+sol = solve(prob_inplace, MethodOfSteps(Vern7()))
 
 @test sol.errors[:l∞] < 4.0e-4
-@test sol.errors[:final] < 3.5e-7
-@test sol.errors[:l2] < 1.8e-4
+@test sol.errors[:final] < 1.7e-5
+@test sol.errors[:l2] < 1.9e-4
+
+sol2 = solve(prob_notinplace, MethodOfSteps(Vern7()))
+
+@test sol.t == sol2.t && sol[1, :] == sol2.u
+
+# Vern8
+
+sol = solve(prob_inplace, MethodOfSteps(Vern8()))
+
+@test sol.errors[:l∞] < 2.0e-3
+@test sol.errors[:final] < 1.8e-5
+@test sol.errors[:l2] < 8.0e-4
+
+sol2 = solve(prob_notinplace, MethodOfSteps(Vern8()))
+
+@test sol.t == sol2.t && sol[1, :] == sol2.u
 
 # Vern9
-sol2 = solve(prob, MethodOfSteps(Vern9()))
+sol = solve(prob_inplace, MethodOfSteps(Vern9()))
 
-@test sol2.errors[:l∞] < 1.5e-3
-@test sol2.errors[:final] < 3.8e-6
-@test sol2.errors[:l2] < 6.2e-4
+@test sol.errors[:l∞] < 1.5e-3
+@test sol.errors[:final] < 3.8e-6
+@test sol.errors[:l2] < 6.2e-4
 
-# not in-place problem
-prob = prob_dde_1delay_scalar_notinplace(1.0)
+sol2 = solve(prob_notinplace, MethodOfSteps(Vern9()))
 
-# Vern7
-sol_scalar = solve(prob, MethodOfSteps(Vern7()))
+@test sol.t == sol2.t && sol[1, :] == sol2.u
 
-@test sol.t == sol_scalar.t && sol[1, :] == sol_scalar.u
+# TODO: uncomment if DiffEqProblemLibrary is updated
+# # model of Mackey and Glass
+# # prob = prob_dde_mackey
 
-# Vern9
-sol2_scalar = solve(prob, MethodOfSteps(Vern9()))
+# # Vern6
+# sol = solve(prob, MethodOfSteps(Vern6()))
 
-@test sol2.t == sol2_scalar.t && sol2[1, :] == sol2_scalar.u
+# # Vern7
+# sol = solve(prob, MethodOfSteps(Vern7()))
+
+# # Vern8
+# sol = solve(prob, MethodOfSteps(Vern8()))
+
+# # Vern9
+# sol = solve(prob, MethodOfSteps(Vern9()))

--- a/test/residual_control.jl
+++ b/test/residual_control.jl
@@ -29,7 +29,7 @@ sol4 = solve(prob2, alg, abstol=1e-13,reltol=1e-13)
 
 @test sol4.errors[:l∞] < 1.2e-10
 @test sol4.errors[:final] < 2.0e-15
-@test sol4.errors[:l2] < 1.3e-11
+@test sol4.errors[:l2] < 1.4e-11
 
 ######## Now show that non-residual control is worse
 

--- a/test/residual_control.jl
+++ b/test/residual_control.jl
@@ -6,30 +6,30 @@ u₀ = 1.0
 prob = prob_dde_1delay_scalar_notinplace(u₀)
 sol = solve(prob, alg)
 
-@test sol.errors[:l∞] < 1e-4
-@test sol.errors[:final] < 1e-4
-@test sol.errors[:l2] < 1e-4
+@test sol.errors[:l∞] < 5.6e-5
+@test sol.errors[:final] < 1.9e-6
+@test sol.errors[:l2] < 2.0e-5
 
 prob2 = deepcopy(prob)
 typeof(prob2) <: ConstantLagDDEProblem ? prob2.lags=Rational{Int}[] :
                  prob2.constant_lags=Rational{Int}[]
 sol2 = solve(prob2, alg)
 
-@test sol2.errors[:l∞] < 1e-1
-@test sol2.errors[:final] < 1e-1
-@test sol2.errors[:l2] < 1e-1
+@test sol2.errors[:l∞] < 1.1e-4
+@test sol2.errors[:final] < 4.1e-6
+@test sol2.errors[:l2] < 3.7e-5
 
 sol3 = solve(prob2, alg, abstol=1e-9,reltol=1e-6)
 
-@test sol3.errors[:l∞] < 1e-1
-@test sol3.errors[:final] < 1e-3
-@test sol3.errors[:l2] < 1e-1
+@test sol3.errors[:l∞] < 3.3e-8
+@test sol3.errors[:final] < 4.1e-9
+@test sol3.errors[:l2] < 9.2e-9
 
 sol4 = solve(prob2, alg, abstol=1e-13,reltol=1e-13)
 
-@test sol4.errors[:l∞] < 1e-1
-@test sol4.errors[:final] < 1e-3
-@test sol4.errors[:l2] < 1e-1
+@test sol4.errors[:l∞] < 1.2e-10
+@test sol4.errors[:final] < 2.0e-15
+@test sol4.errors[:l2] < 1.3e-11
 
 ######## Now show that non-residual control is worse
 
@@ -39,7 +39,7 @@ sol4 = solve(prob2, alg)
 
 @test sol4.errors[:l∞] > 1e-1
 @test sol4.errors[:final] > 1e-3
-@test sol4.errors[:l2] > 1e-2
+@test sol4.errors[:l2] > 4e-2
 
 alg = MethodOfSteps(OwrenZen5(); constrained=true)
 
@@ -47,10 +47,10 @@ sol5 = solve(prob2, alg)
 
 @test sol5.errors[:l∞] > 1e-1
 @test sol5.errors[:final] > 1e-3
-@test sol5.errors[:l2] > 1e-2
+@test sol5.errors[:l2] > 4e-2
 
 sol5 = solve(prob2, alg,abstol=1e-13,reltol=1e-13)
 
 @test sol5.errors[:l∞] > 1e-1
 @test sol5.errors[:final] > 1e-3
-@test sol5.errors[:l2] > 1e-2
+@test sol5.errors[:l2] > 5e-2

--- a/test/residual_control.jl
+++ b/test/residual_control.jl
@@ -28,8 +28,9 @@ sol3 = solve(prob2, alg, abstol=1e-9,reltol=1e-6)
 sol4 = solve(prob2, alg, abstol=1e-13,reltol=1e-13)
 
 @test sol4.errors[:l∞] < 1.3e-10
-@test sol4.errors[:final] < 2.0e-15
-@test sol4.errors[:l2] < 1.5e-11
+# relaxed tests to prevent floating point issues
+@test sol4.errors[:final] < 2.0e-12 # 2.0e-15
+@test sol4.errors[:l2] < 1.5e-10 # 1.5e-11
 
 ######## Now show that non-residual control is worse
 

--- a/test/residual_control.jl
+++ b/test/residual_control.jl
@@ -27,9 +27,9 @@ sol3 = solve(prob2, alg, abstol=1e-9,reltol=1e-6)
 
 sol4 = solve(prob2, alg, abstol=1e-13,reltol=1e-13)
 
-@test sol4.errors[:l∞] < 1.2e-10
+@test sol4.errors[:l∞] < 1.3e-10
 @test sol4.errors[:final] < 2.0e-15
-@test sol4.errors[:l2] < 1.4e-11
+@test sol4.errors[:l2] < 1.5e-11
 
 ######## Now show that non-residual control is worse
 

--- a/test/saveat.jl
+++ b/test/saveat.jl
@@ -15,7 +15,7 @@ sol = solve!(dde_int)
 dde_int2 = init(prob, alg; saveat=[25.0, 50.0, 75.0])
 
 ## solution of ODE integrator will be reduced
-@test dde_int2.minimal_solution
+@test dde_int2.saveat != nothing
 
 sol2 = solve!(dde_int2)
 
@@ -33,7 +33,7 @@ sol2 = solve!(dde_int2)
 dde_int2_full = init(prob, alg; saveat=[25.0, 50.0, 75.0], minimal_solution=false)
 
 ## solution of ODE integrator will not be reduced
-@test !dde_int2_full.minimal_solution
+@test dde_int2_full.saveat == nothing
 
 sol2_full = solve!(dde_int2_full)
 
@@ -47,7 +47,7 @@ sol2_full = solve!(dde_int2_full)
 dde_int2_dense = init(prob, alg; saveat=[25.0, 50.0, 75.0], dense=true)
 
 ## solution of ODE integrator will not be reduced
-@test !dde_int2_dense.minimal_solution
+@test dde_int2_dense.saveat == nothing
 
 sol2_dense = solve!(dde_int2_dense)
 
@@ -67,7 +67,7 @@ sol2_dense = solve!(dde_int2_dense)
 dde_int3 = init(prob, alg; saveat=[25.0, 50.0, 75.0], save_start=false)
 
 ## solution of ODE integrator will be reduced
-@test dde_int3.minimal_solution
+@test dde_int3.saveat != nothing
 
 sol3 = solve!(dde_int3)
 

--- a/test/unconstrained.jl
+++ b/test/unconstrained.jl
@@ -103,8 +103,8 @@ alg4 = MethodOfSteps(DP5(), constrained=false, max_fixedpoint_iters=100,
 sol4 = solve(prob, alg4)
 
 @test abs(sol1[end] - sol2[end]) < 2.5e-11
-@test abs(sol1[end] - sol3[end]) < 1.3e-13
-@test abs(sol1[end] - sol4[end]) < 4.5e-13
+@test abs(sol1[end] - sol3[end]) < 1.3e-14
+@test abs(sol1[end] - sol4[end]) < 1.2e-13
 
 println("Standard tests complete. Onto idxs tests")
 

--- a/test/unconstrained.jl
+++ b/test/unconstrained.jl
@@ -103,8 +103,9 @@ alg4 = MethodOfSteps(DP5(), constrained=false, max_fixedpoint_iters=100,
 sol4 = solve(prob, alg4)
 
 @test abs(sol1[end] - sol2[end]) < 2.5e-11
-@test abs(sol1[end] - sol3[end]) < 1.3e-14
-@test abs(sol1[end] - sol4[end]) < 1.2e-13
+# relaxed tests to prevent floating point issues
+@test abs(sol1[end] - sol3[end]) < 1.3e-13 # 1.3e-14
+@test abs(sol1[end] - sol4[end]) < 1.2e-12 # 1.2e-13
 
 println("Standard tests complete. Onto idxs tests")
 

--- a/test/unconstrained.jl
+++ b/test/unconstrained.jl
@@ -101,8 +101,8 @@ alg4 = MethodOfSteps(DP5(), constrained=false, max_fixedpoint_iters=100,
                      fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
 sol4 = solve(prob, alg4)
 
-@test abs(sol1[end] - sol2[end]) < 2.4e-11
 # relaxed tests to prevent floating point issues
+@test abs(sol1[end] - sol2[end]) < 2.6e-11 # 2.4e-11
 @test abs(sol1[end] - sol3[end]) < 8.6e-13 # 8.6e-15
 @test abs(sol1[end] - sol4[end]) < 4.9e-13 # 4.9e-15
 


### PR DESCRIPTION
This is a quite large update. Changes are:
- new discontinuities (arising from callbacks) are also added as time stops [this change alone causes the only regression in `events.jl`; just applying that change to master leads to the same regression]
- behaviour of ODE integrator is changed: currently ODE integrator and its interpolation data are only updated to the next interval `[t, t+dt]` during fixed-point iterations and directly before saving; with this PR it will always be updated to `[t, t+dt]` directly after calculating the next step and only be reset to the last interval `[tprev, t]` at the beginning of `perform_step!` if the last step failed. The advantage is that any evaluations of the history function (e.g. in callbacks when interpolating back) will already use the newest calculations; with the current approach they might again do a bad extrapolation as initially in `perform_steps!`.
- systematic updates of interpolation data: every time when the interpolation data of the ODE integrator is updated or moved to the next interval we instead update the current interpolation data or the one just calculated for the next interval of the DDE integrator and copy it then to the ODE integrator. The advantage is that then these updates will always use the old interpolation data of the ODE integrator when evaluating the history function. Currently updates of the first interpolation steps might change results for the last interpolation steps because the first updates already change the history function, so we can get undesired side effects. This can not happen when interpolation steps are added to the DDE integrator first (but we have to specify `tprev`, since `integrator.tprev != integrator.integrator.tprev` when moving the ODE integrator to the next interval!).
- constant extrapolation in the initial time step: currently extrapolation of the history function at the initial time step will fail since correctly `dt = 0` for the ODE integrator. This does not matter for constant delays since the initial time step is always chosen such that `dt < minimum(lag)` but this can not be ensured for dependent lags. Hence a special constant extrapolation of `integrator.u` is added to the history function in case `integrator.dt == 0`.
- initial interpolations of lazy interpolants: currently lazy interpolants fail if the time step is chosen such that in the calculation of additional interpolation steps the history function has to be evaluated at a point in the current time interval (this happens e.g. for the Mackey-Glass equation `prob_dde_mackey`, one of the new problems in DiffEqProblemLibrary). The evaluation will try to interpolate but has to add the additional steps first - so it can just not work. However, similar to the extrapolation that is necessary for implicit steps it will now fallback to a Hermite interpolant which then can be improved by further iterations using this first interpolation.
- better detection of implicit steps: instead of checking `dt > maximum(lag)` which will not work if not all constant lags are specified or additionally dependent lags exist it is now checked whether the history function was evaluated at a time point past the final time point of the solution, i.e. whether an extrapolation was used, during the initial calculation of the next step in `perform_step!`. This is done by setting `integrator.isout = true` which is always reset before this initial calculation. If an extrapolation occurred fixed-point iterations will be executed, otherwise not. This works for arbitrary delays and even without delays.
- update of "internals" after modifications by callbacks: a method `reeval_internals_due_to_modification!` for DDEIntegrator is added which will update the interpolation data of both the DDE integrator (again done first, using the "old" interpolation of the ODE integrator when evaluating the history function) and the ODE integrator (copy from DDE integrator), and the time interval of the ODE integrator.
- remove caches: since every step is saved reset of ODE integrators after failed steps is (at least partly) easy - we can just set it to the last time interval of the solution. The final element of the solution and its associated interpolation data will always be the values of the last time step and its interpolation data - however, this does not have to hold for the second-to-last element since callbacks can lead to additional savings. Hence the index of the `tprev` and `u(tprev)` in the solution arrays has to be saved and updated after successful steps. `dt` is still cached to avoid subtractions if possible.
- improved reduction of solution: it now also checks whether a time point of the solution is required for the interpolation at `tmax` up to which the solution should be reduced. However, it still does not work with callbacks, it will just remove the added steps again (maybe this can be fixed by just adding those additional points to `saveat` as well...).