### PR TITLE
Update DDEIntegrator

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,10 +1,9 @@
 julia 0.6
 DiffEqBase 1.21.0
-OrdinaryDiffEq 2.18.0
+OrdinaryDiffEq 2.19.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
 Combinatorics
-Compat 0.17.0
 Reexport
 MuladdMacro
 ForwardDiff

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -15,5 +15,5 @@
 
     push!(integrator.opts.d_discontinuities,
           compute_discontinuity_tree(constant_lags, integrator.alg,
-                                     integrator.t,integrator.prob.tspan[2],neutral)...)
+                                     integrator.t,integrator.sol.prob.tspan[2],neutral)...)
 end

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -61,13 +61,13 @@ Calculate next step of `integrator`.
     # perform always at least one calculation
     perform_step!(integrator, integrator.cache)
 
-    if typeof(integrator.prob) <: ConstantLagDDEProblem
+    if typeof(integrator.sol.prob) <: ConstantLagDDEProblem
         #warn("ConstantLagDDEProblem is deprecated. Use DDEProblem instead.")
         neutral = false
-        constant_lags = integrator.prob.lags
+        constant_lags = integrator.sol.prob.lags
     else
-        neutral = integrator.prob.neutral
-        constant_lags = integrator.prob.constant_lags
+        neutral = integrator.sol.prob.neutral
+        constant_lags = integrator.sol.prob.constant_lags
     end
 
     # if dt is greater than the minimal lag, then use a fixed-point iteration

--- a/src/integrator_type.jl
+++ b/src/integrator_type.jl
@@ -1,10 +1,7 @@
 mutable struct DDEIntegrator{algType<:OrdinaryDiffEq.OrdinaryDiffEqAlgorithm,uType,tType,absType,relType,
-                             residType,tTypeNoUnits,tdirType,ksEltype,SolType,rateType,F,
-                             ProgressType,CacheType,IType,ProbType,NType,O,tstopsType} <:
-                                 AbstractDDEIntegrator
-
+                             residType,tTypeNoUnits,tdirType,ksEltype,SolType,F,ProgressType,CacheType,
+                             IType,NType,O,tstopsType,FSALType} <: AbstractDDEIntegrator
     sol::SolType
-    prob::ProbType
     u::uType
     k::ksEltype
     t::tType
@@ -22,8 +19,8 @@ mutable struct DDEIntegrator{algType<:OrdinaryDiffEq.OrdinaryDiffEqAlgorithm,uTy
     fixedpoint_norm::NType
     max_fixedpoint_iters::Int
     minimal_solution::Bool
+    saveat::tstopsType
     alg::algType
-    rate_prototype::rateType
     notsaveat_idxs::Vector{Int}
     dtcache::tType
     dtchangeable::Bool
@@ -50,32 +47,30 @@ mutable struct DDEIntegrator{algType<:OrdinaryDiffEq.OrdinaryDiffEqAlgorithm,uTy
     u_modified::Bool
     opts::O
     integrator::IType
-    saveat::tstopsType
-    fsalfirst::rateType
-    fsallast::rateType
+    fsalfirst::FSALType
+    fsallast::FSALType
 
     # incomplete initialization without fsalfirst and fsallast
     function DDEIntegrator{algType,uType,tType,absType,relType,residType,tTypeNoUnits,
-                           tdirType,ksEltype,SolType,rateType,F,ProgressType,CacheType,
-                           IType,ProbType,NType,O,tstopsType}(
-                               sol,prob,u,k,t,dt,f,uprev,uprev2,tprev,uprev_cache,k_cache,
+                           tdirType,ksEltype,SolType,F,ProgressType,CacheType,IType,
+                           NType,O,tstopsType,FSALType}(
+                               sol,u,k,t,dt,f,uprev,uprev2,tprev,uprev_cache,k_cache,
                                k_integrator_cache,fixedpoint_abstol,fixedpoint_reltol,resid,
-                               fixedpoint_norm,max_fixedpoint_iters,minimal_solution,alg,
-                               rate_prototype,notsaveat_idxs,dtcache,dtchangeable,dtpropose,
-                               tdir,EEst,qold,q11,erracc,dtacc,success_iter,iter,saveiter,
+                               fixedpoint_norm,max_fixedpoint_iters,minimal_solution,saveat,
+                               alg,notsaveat_idxs,dtcache,dtchangeable,dtpropose,tdir,EEst,
+                               qold,q11,erracc,dtacc,success_iter,iter,saveiter,
                                saveiter_dense,prog,cache,kshortsize,force_stepfail,
                                last_stepfail,just_hit_tstop,accept_step,isout,reeval_fsal,
-                               u_modified,opts,integrator,saveat) where
-        {algType,uType,tType,absType,relType,residType,
-         tTypeNoUnits,tdirType,ksEltype,SolType,rateType,F,ProgressType,CacheType,IType,
-         ProbType,NType,O,tstopsType}
+                               u_modified,opts,integrator) where
+        {algType,uType,tType,absType,relType,residType,tTypeNoUnits,tdirType,ksEltype,
+         SolType,F,ProgressType,CacheType,IType,NType,O,tstopsType,FSALType}
 
-        new(sol,prob,u,k,t,dt,f,uprev,uprev2,tprev,uprev_cache,k_cache,k_integrator_cache,
+        new(sol,u,k,t,dt,f,uprev,uprev2,tprev,uprev_cache,k_cache,k_integrator_cache,
             fixedpoint_abstol,fixedpoint_reltol,resid,fixedpoint_norm,max_fixedpoint_iters,
-            minimal_solution,alg,rate_prototype,notsaveat_idxs,dtcache,dtchangeable,
-            dtpropose,tdir,EEst,qold,q11,erracc,dtacc,success_iter,iter,saveiter,
-            saveiter_dense,prog,cache,kshortsize,force_stepfail,last_stepfail,
-            just_hit_tstop,accept_step,isout,reeval_fsal,u_modified,opts,integrator,saveat)
+            minimal_solution,saveat,alg,notsaveat_idxs,dtcache,dtchangeable,dtpropose,tdir,
+            EEst,qold,q11,erracc,dtacc,success_iter,iter,saveiter,saveiter_dense,prog,cache,
+            kshortsize,force_stepfail,last_stepfail,just_hit_tstop,accept_step,isout,
+            reeval_fsal,u_modified,opts,integrator)
     end
 end
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -236,16 +236,15 @@ function init(prob::AbstractDDEProblem{uType,tType,lType,isinplace}, alg::algTyp
                             typeof(fixedpoint_abstol_internal),
                             typeof(fixedpoint_reltol_internal),typeof(resid),tTypeNoUnits,
                             typeof(integrator.tdir),typeof(integrator.k),typeof(sol),
-                            typeof(integrator.rate_prototype),typeof(dde_f),
-                            typeof(integrator.prog),typeof(dde_cache),
-                            typeof(integrator),typeof(prob),typeof(fixedpoint_norm),
-                            typeof(opts),typeof(saveat_copy)}(
-                                sol, prob, u, integrator.k, integrator.t, dt, dde_f,
-                                uprev, uprev2, integrator.tprev, uprev_cache,
-                                k_cache, k_integrator_cache, fixedpoint_abstol_internal,
+                            typeof(dde_f),typeof(integrator.prog),typeof(dde_cache),
+                            typeof(integrator),typeof(fixedpoint_norm),typeof(opts),
+                            typeof(saveat_copy),fsal_typeof(integrator)}(
+                                sol, u, integrator.k, integrator.t, dt, dde_f, uprev,
+                                uprev2, integrator.tprev, uprev_cache, k_cache,
+                                k_integrator_cache, fixedpoint_abstol_internal,
                                 fixedpoint_reltol_internal, resid, fixedpoint_norm,
-                                alg.max_fixedpoint_iters, minimal_solution, integrator.alg,
-                                integrator.rate_prototype, integrator.notsaveat_idxs,
+                                alg.max_fixedpoint_iters, minimal_solution, saveat_copy,
+                                integrator.alg, integrator.notsaveat_idxs,
                                 integrator.dtcache, integrator.dtchangeable,
                                 integrator.dtpropose, integrator.tdir, integrator.EEst,
                                 integrator.qold, integrator.q11, integrator.erracc,
@@ -255,7 +254,7 @@ function init(prob::AbstractDDEProblem{uType,tType,lType,isinplace}, alg::algTyp
                                 integrator.force_stepfail, integrator.just_hit_tstop,
                                 integrator.last_stepfail, integrator.accept_step,
                                 integrator.isout, integrator.reeval_fsal,
-                                integrator.u_modified, opts, integrator, saveat_copy)
+                                integrator.u_modified, opts, integrator)
 
     # set up additional initial values of newly created DDE integrator
     # (such as fsalfirst) and its callbacks
@@ -296,13 +295,15 @@ function solve!(integrator::DDEIntegrator)
     # create interpolation data of solution
     interp = build_solution_interpolation(integrator, sol_array)
 
+    # obtain DDE problem
+    prob = integrator.sol.prob
+
     # calculate analytical solutions to problem if existent
-    if has_analytic(integrator.prob.f)
+    if has_analytic(prob.f)
         if typeof(integrator.opts.save_idxs) <: Void
-            u_analytic = [integrator.prob.f(Val{:analytic}, t, integrator.sol[1])
-                          for t in sol_array.t]
+            u_analytic = [prob.f(Val{:analytic}, t, integrator.sol[1]) for t in sol_array.t]
         else
-            u_analytic = [@view(integrator.prob.f(
+            u_analytic = [@view(prob.f(
                 Val{:analytic}, t, integrator.sol[1])[integrator.opts.save_idxs])
                           for t in sol_array.t]
         end
@@ -315,18 +316,18 @@ function solve!(integrator::DDEIntegrator)
     # combine arrays of time points and values, interpolation data, and analytical solution
     # to solution
 
-    if typeof(integrator.prob.u0) <: Tuple
+    if typeof(prob.u0) <: Tuple
       N = length((size(ArrayPartition(prob.u0))..., length(sol_array.u)))
     else
-      N = length((size(integrator.prob.u0)..., length(sol_array.u)))
+      N = length((size(prob.u0)..., length(sol_array.u)))
     end
 
     sol = ODESolution{eltype(sol_array),N,typeof(sol_array.u),
                       typeof(u_analytic),typeof(errors),typeof(sol_array.t),
-                      typeof(interp.ks),typeof(integrator.sol.prob),
+                      typeof(interp.ks),typeof(prob),
                       typeof(integrator.sol.alg),typeof(interp)}(
                           sol_array.u, u_analytic, errors, sol_array.t, interp.ks,
-                          integrator.sol.prob, integrator.sol.alg, interp, interp.dense,
+                          prob, integrator.sol.alg, interp, interp.dense,
                           integrator.sol.tslocation, integrator.sol.retcode)
 
     # calculate errors of solution

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -41,6 +41,21 @@ function compute_discontinuity_tree(lags, alg, start_val,end_val,neutral)
 end
 
 """
+    fsal_typeof(integrator::ODEIntegrator)
+
+Return type of FSAL of `integrator`.
+"""
+function fsal_typeof(integrator::ODEIntegrator{<:OrdinaryDiffEq.OrdinaryDiffEqAlgorithm,
+                                               uType,tType,tTypeNoUnits,tdirType,ksEltype,
+                                               SolType,F,ProgressType,CacheType,O,
+                                               FSALType}) where {uType,tType,tTypeNoUnits,
+                                                                 tdirType,ksEltype,SolType,
+                                                                 F,ProgressType,CacheType,O,
+                                                                 FSALType}
+    return FSALType
+end
+
+"""
     build_linked_cache(cache, alg, u, uprev, uprev2, f, t, dt)
 
 Create cache for algorithm `alg` from existing cache `cache` with updated `u`, `uprev`,


### PR DESCRIPTION
This updates `DDEIntegrator` to the newest commits of `OrdinaryDiffEq` in which `rate_prototype` was removed. Additionally I removed the field `prob` (also not existent in `ODEIntegrator`) since it always equals `sol.prob`.