### PR TITLE
Relax bound that fails on Win32

### DIFF
--- a/test/unconstrained.jl
+++ b/test/unconstrained.jl
@@ -101,7 +101,7 @@ alg4 = MethodOfSteps(DP5(), constrained=false, max_fixedpoint_iters=100,
                      fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
 sol4 = solve(prob, alg4)
 
-@test abs(sol1[end] - sol2[end]) < 2.5e-11
+@test abs(sol1[end] - sol2[end]) < 2.6e-11
 @test abs(sol1[end] - sol3[end]) < 1.3e-13
 @test abs(sol1[end] - sol4[end]) < 4.5e-13
 
@@ -132,14 +132,8 @@ function f(t,u,h,du)
   du[1] = -du[1]
   du[1] += u[1]
 end
-function h(t,idxs=nothing)
-  if typeof(idxs) <: Void
-    return [0.0]
-  else
-    return 0.0
-  end
-end
-function h(out,t,idxs=nothing)
+
+function h(out::AbstractArray,t,idxs=nothing)
   out[1] = 0.0
 end
 


### PR DESCRIPTION
The latest commit fails on Win32 since one bound in `unconstrained.jl` seems to be too strict (`2.51e-11 < 2.5e-11`). I was wondering why this error was introduced, and figured out that it is caused by line

https://github.com/JuliaDiffEq/DiffEqProblemLibrary.jl/blob/master/src/dde_premade_problems.jl#L347

which changed the lags of the affected problem from `[1//3, 1//5]` to `[1/3, 1/5]`. Manually creating this problem with old lags fixes this issue, however I thought it might be reasonable to just relax the affected bound. The lags were changed in `DiffEqProblemLibrary` to allow use of these problems with units (as e.g. done in `units.jl`).

The second change just removes a duplicate method.