### PR TITLE
Fix calls of eps

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -5,9 +5,12 @@ Update solution of `integrator`, if necessary or forced by `force_save`.
 """
 function savevalues!(integrator::DDEIntegrator, force_save=false)
     # update time of ODE integrator (can be slightly modified (< 10ϵ) because of time stops)
-    if typeof(integrator.t) <: AbstractFloat # does not work for units!
+    # integrator.EEst has unitless type of integrator.t
+    if typeof(integrator.EEst) <: AbstractFloat
         if integrator.integrator.t != integrator.t
-            if abs(integrator.t - integrator.integrator.t) >= 10eps(integrator.t)
+            if abs(integrator.t - integrator.integrator.t) >= 10eps(integrator.EEst) *
+                oneunit(integrator.t)
+
                 error("unexpected time discrepancy detected")
             end
 

--- a/src/integrator_utils.jl
+++ b/src/integrator_utils.jl
@@ -312,9 +312,12 @@ function handle_discontinuities!(integrator::DDEIntegrator)
 
     # remove all discontinuities close to the current time point as well and
     # calculate minimal order of these discontinuities
-    if typeof(integrator.t) <: AbstractFloat # does not work for units!
+    # integrator.EEst has unitless type of integrator.t
+    if typeof(integrator.EEst) <: AbstractFloat
+        maxΔt = 10eps(integrator.EEst) * oneunit(integrator.t)
+
         while !isempty(integrator.opts.d_discontinuities) &&
-            abs(top(integrator.opts.d_discontinuities).t - integrator.t) < 10eps(integrator.t)
+            abs(top(integrator.opts.d_discontinuities).t - integrator.t) < maxΔt
 
             d2 = pop!(integrator.opts.d_discontinuities)
             order = min(order, d2.order)
@@ -322,7 +325,7 @@ function handle_discontinuities!(integrator::DDEIntegrator)
 
         # also remove all corresponding time stops
         while !isempty(integrator.opts.tstops) &&
-            abs(top(integrator.opts.tstops) - integrator.t) < 10eps(integrator.t)
+            abs(top(integrator.opts.tstops) - integrator.t) < maxΔt
 
             pop!(integrator.opts.tstops)
         end


### PR DESCRIPTION
Similar to https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/189, this ensures that `eps` is computed for unitless types.