### PR TITLE
Fix not in-place Rosenbrock methods

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -55,7 +55,7 @@ assign_expr(::Val{:phi1}, ::Type, ::Type{<:OrdinaryDiffEq.NorsettEulerCache}) =
 assign_expr(::Val{name}, ::Type{<:OrdinaryDiffEq.TimeDerivativeWrapper}, ::Type) where name =
     :($name = OrdinaryDiffEq.TimeDerivativeWrapper(f, u))
 assign_expr(::Val{name}, ::Type{<:OrdinaryDiffEq.UDerivativeWrapper}, ::Type) where name =
-    :($name = OrdinaryDiffEq.UDerivativeWrapper(f, getfield(cache, t)))
+    :($name = OrdinaryDiffEq.UDerivativeWrapper(f, t))
 assign_expr(::Val{name}, ::Type{<:OrdinaryDiffEq.TimeGradientWrapper}, ::Type) where name =
     :($name = OrdinaryDiffEq.TimeGradientWrapper(
         OrdinaryDiffEq.VectorF(f, size(u)),

--- a/test/rosenbrock_integrators.jl
+++ b/test/rosenbrock_integrators.jl
@@ -1,6 +1,7 @@
 using DelayDiffEq, DiffEqProblemLibrary, Base.Test
 
 prob = prob_dde_1delay
+prob_scalar = prob_dde_1delay_scalar_notinplace
 
 # ODE algorithms
 algs = [Rosenbrock23(), Rosenbrock32(), ROS3P(), Rodas3(),
@@ -16,4 +17,7 @@ for (alg, name) in zip(algs, names)
     step_alg = MethodOfSteps(alg)
     solve(prob, step_alg)
     @time solve(prob, step_alg)
+
+    # test not in-place method
+    solve(prob_scalar, step_alg)
 end

--- a/test/sdirk_integrators.jl
+++ b/test/sdirk_integrators.jl
@@ -1,6 +1,7 @@
 using DelayDiffEq, DiffEqProblemLibrary, Base.Test
 
 prob = prob_dde_1delay
+prob_scalar = prob_dde_1delay_scalar_notinplace
 
 # ODE algorithms
 algs = [GenericImplicitEuler(), GenericTrapezoid(),
@@ -22,4 +23,7 @@ for (alg, name) in zip(algs, names)
     step_alg = MethodOfSteps(alg)
     solve(prob, step_alg)
     @time solve(prob, step_alg)
+
+    # test not in-place method
+    solve(prob_scalar, step_alg)
 end


### PR DESCRIPTION
There's a bug in `build_linked_cache` that went unnoticed. It affects not in-place methods whose cache contains an `UDerivativeWrapper`, such as not in-place Rosenbrock methods. Therefore I also added tests that check whether not in-place Rosenbrock methods fail.