### PR TITLE
Fix constant extrapolation

### DIFF
--- a/src/history_function.jl
+++ b/src/history_function.jl
@@ -36,9 +36,11 @@ function (f::HistoryFunction)(t, deriv::Type=Val{0}, idxs=nothing)
     integrator.isout = true
 
     # handle extrapolations at initial time point
-    f.sol.t[end] == integrator.sol.prob.tspan[1] && return constant_extrapolant(t, integrator, idxs, deriv)
-
-    return OrdinaryDiffEq.current_interpolant(t, integrator, idxs, deriv)
+    if integrator.t == integrator.sol.prob.tspan[1]
+        return constant_extrapolant(t, integrator, idxs, deriv)
+    else
+        return OrdinaryDiffEq.current_interpolant(t, integrator, idxs, deriv)
+    end
 end
 
 function (f::HistoryFunction)(val, t, deriv::Type=Val{0}, idxs=nothing)
@@ -62,7 +64,9 @@ function (f::HistoryFunction)(val, t, deriv::Type=Val{0}, idxs=nothing)
     integrator.isout = true
 
     # handle extrapolations at initial time point
-    f.sol.t[end] == integrator.sol.prob.tspan[1] && return constant_extrapolant!(val, t, integrator, idxs, deriv)
-
-    return OrdinaryDiffEq.current_interpolant!(val, t, f.integrator, idxs, deriv)
+    if integrator.t == integrator.sol.prob.tspan[1]
+        return constant_extrapolant!(val, t, integrator, idxs, deriv)
+    else
+        return OrdinaryDiffEq.current_interpolant!(val, t, f.integrator, idxs, deriv)
+    end
 end

--- a/src/history_function.jl
+++ b/src/history_function.jl
@@ -35,8 +35,8 @@ function (f::HistoryFunction)(t, deriv::Type=Val{0}, idxs=nothing)
     # affect whether time steps are accepted
     integrator.isout = true
 
-    # handle extrapolations in initial time step (otherwise dt = 0 should not occur)
-    integrator.dt == 0 && return constant_extrapolation(t, integrator, idxs, deriv)
+    # handle extrapolations at initial time point
+    f.sol.t[end] == integrator.sol.prob.tspan[1] && return constant_extrapolant(t, integrator, idxs, deriv)
 
     return OrdinaryDiffEq.current_interpolant(t, integrator, idxs, deriv)
 end
@@ -61,8 +61,8 @@ function (f::HistoryFunction)(val, t, deriv::Type=Val{0}, idxs=nothing)
     # affect whether time steps are accepted
     integrator.isout = true
 
-    # handle extrapolations in initial time step (otherwise dt = 0 should not occur)
-    integrator.dt == 0 && return constant_extrapolation!(val, t, integrator, idxs, deriv)
+    # handle extrapolations at initial time point
+    f.sol.t[end] == integrator.sol.prob.tspan[1] && return constant_extrapolant!(val, t, integrator, idxs, deriv)
 
     return OrdinaryDiffEq.current_interpolant!(val, t, f.integrator, idxs, deriv)
 end

--- a/src/interpolants.jl
+++ b/src/interpolants.jl
@@ -44,7 +44,7 @@ function constant_extrapolant!(val, t::Number, integrator::DEIntegrator, idxs, T
     elseif idxs == nothing
         @. val = integrator.u
     else
-        @views @. out = integrator.u[idxs]
+        @views @. val = integrator.u[idxs]
     end
 end
 
@@ -58,6 +58,6 @@ function constant_extrapolant!(val, t::Number, integrator::DEIntegrator, idxs, T
     elseif idxs == nothing
         val .= zero(integrator.u)./oneunit(t)
     else
-        @views val .= zero(integrator.u)./oneunit(t)
+        @views val .= zero(integrator.u[idxs])./oneunit(t)
     end
 end

--- a/test/history_function.jl
+++ b/test/history_function.jl
@@ -1,0 +1,126 @@
+using DelayDiffEq, DiffEqProblemLibrary, Base.Test
+
+## Special test
+
+# check constant extrapolation with problem with vanishing delays at t = 0
+prob = DDEProblem((t,u,h,du) -> -h(t/2)[1], t -> [1.0], [1.0], (0.0, 10.0), [])
+solve(prob, MethodOfSteps(RK4()))
+
+## General tests
+
+# history function
+function h(t, idxs=nothing)
+    if typeof(idxs) <: Void
+        return [t; -t]
+    else
+        return [t; -t][idxs]
+    end
+end
+function h(val::AbstractArray, t, idxs=nothing)
+    if typeof(idxs) <: Void
+        val[1] = t
+        val[2] = -t
+    else
+        val .= [t; -t][idxs]
+    end
+end
+
+# ODE integrator
+prob = ODEProblem(DiffEqProblemLibrary.f_2dlinear, ones(2), (0.0, 1.0))
+integrator = init(prob, Tsit5())
+
+# combined history function
+history = DelayDiffEq.HistoryFunction(h, integrator.sol, integrator)
+
+# test evaluation of history function
+for idxs in (nothing, [2])
+    @test history(-0.5, Val{0}, idxs) == h(-0.5, idxs)
+
+    val = idxs == nothing ? zeros(2) : [0.0]
+    val2 = deepcopy(val)
+
+    history(val, -0.5, Val{0}, idxs)
+    h(val2, -0.5, idxs)
+
+    @test val == val2
+end
+
+# test constant extrapolation
+for (deriv, idxs) in Iterators.product((Val{0}, Val{1}), (nothing, [2]))
+    integrator.isout = false
+
+    extrapolation = deriv == Val{0} ?
+        (idxs == nothing ? integrator.u : integrator.u[[2]]) :
+        (idxs == nothing ? zeros(2) : [0.0])
+
+    @test history(0.5, deriv, idxs) == extrapolation && integrator.isout
+
+    integrator.isout = false
+    @test history(nothing, 0.5, deriv, idxs) == extrapolation && integrator.isout
+
+    integrator.isout = false
+    val = 1 .- extrapolation # ensures that val ≠ extrapolation
+    history(val, 0.5, deriv, idxs)
+
+    @test val == extrapolation && integrator.isout
+end
+
+# add step to integrator
+OrdinaryDiffEq.loopheader!(integrator)
+OrdinaryDiffEq.perform_step!(integrator, integrator.cache)
+integrator.t = integrator.dt
+@test 0.01 < integrator.t < 1
+@test integrator.sol.t[end] == 0
+
+# test integrator interpolation
+for (deriv, idxs) in Iterators.product((Val{0}, Val{1}), (nothing, [2]))
+    integrator.isout = false
+
+    @test history(0.01, deriv, idxs) ==
+        OrdinaryDiffEq.current_interpolant(0.01, integrator, idxs, deriv) &&
+        integrator.isout
+
+    integrator.isout = false
+    val = idxs == nothing ? zeros(2) : [0.0]
+    val2 = deepcopy(val)
+    history(val, 0.01, deriv, idxs)
+    OrdinaryDiffEq.current_interpolant!(val2, 0.01, integrator, idxs, deriv)
+
+    @test val == val2 && integrator.isout
+end
+
+# add step to solution
+integrator.t = 0
+OrdinaryDiffEq.loopfooter!(integrator)
+@test integrator.t == integrator.sol.t[end]
+
+# test solution interpolation
+for (deriv, idxs) in Iterators.product((Val{0}, Val{1}), (nothing, [2]))
+    @test history(0.01, deriv, idxs) ==
+        integrator.sol.interp(0.01, idxs, deriv) &&
+        !integrator.isout
+
+    val = idxs == nothing ? zeros(2) : [0.0]
+    val2 = deepcopy(val)
+    history(val, 0.01, deriv, idxs)
+    integrator.sol.interp(val2, 0.01, idxs, deriv)
+
+    @test val == val2 && !integrator.isout
+end
+
+# test integrator extrapolation
+for (deriv, idxs) in Iterators.product((Val{0}, Val{1}), (nothing, [2]))
+    integrator.isout = false
+
+    @test history(1, deriv, idxs) ==
+        OrdinaryDiffEq.current_interpolant(1, integrator, idxs, deriv) &&
+        integrator.isout
+
+    integrator.isout = false
+    val = idxs == nothing ? zeros(2) : [0.0]
+    val2 = deepcopy(val)
+    history(val, 1, deriv, idxs)
+    OrdinaryDiffEq.current_interpolant!(val2, 1, integrator, idxs, deriv)
+
+    @test val == val2 && integrator.isout
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Base.Test
 
 @time @testset "Discontinuity Tests" begin include("discontinuities.jl") end
+@time @testset "HistoryFunction Tests" begin include("history_function.jl") end
 @time @testset "Constrained Timestep" begin include("constrained.jl") end
 @time @testset "Unconstrained Timestep" begin include("unconstrained.jl") end
 @time @testset "Dependent Delay Tests" begin include("dependent_delays.jl") end


### PR DESCRIPTION
Constant extrapolation at the initial time point currently does not work, as shown in https://github.com/JuliaDiffEq/DelayDiffEq.jl/issues/40.

We should also add tests for `HistoryFunction` which should have catched these errors.