### PR TITLE
Add test for constant_delays = nothing

### DIFF
--- a/src/integrator_utils.jl
+++ b/src/integrator_utils.jl
@@ -355,8 +355,8 @@ function add_next_discontinuities!(integrator, order, t=integrator.t)
     order > alg_order(integrator.alg) && !neutral && return nothing
 
     # discontinuities caused by constant lags
-    maxlag = integrator.sol.prob.tspan[2] - t
     if constant_lags != nothing
+        maxlag = integrator.sol.prob.tspan[2] - t
         for lag in constant_lags
             if lag < maxlag
                 # calculate discontinuity and add it to heap of discontinuities and time stops

--- a/test/dependent_delays.jl
+++ b/test/dependent_delays.jl
@@ -19,6 +19,16 @@ sol2 = solve!(dde_int2)
 
 @test dde_int.tracked_discontinuities == dde_int2.tracked_discontinuities
 
+# with nothing
+prob2_nothing = DDEProblem(DiffEqProblemLibrary.f_1delay, t -> [0.0], [1.0], (0., 10.), nothing,
+                   [(t, u) -> 1])
+
+dde_int2_nothing = init(prob2_nothing, alg)
+sol2_nothing = solve!(dde_int2_nothing)
+
+@test dde_int.tracked_discontinuities == dde_int2_nothing.tracked_discontinuities
+@test sol2.u == sol2_nothing.u && sol2.t == sol2_nothing.t
+
 # worse than results above with constant delays specified as scalars
 @test sol2.errors[:l∞] < 4.2e-5
 @test sol2.errors[:final] < 2.2e-5


### PR DESCRIPTION
Adds a simple test and removes an unnecessary computation for `constant_delays = nothing`.