### PR TITLE
Update to NLsolve changes in OrdinaryDiffEq

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.6
 DiffEqBase 2.0.0
-OrdinaryDiffEq 2.21.0
+OrdinaryDiffEq 2.22.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
 Reexport

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -68,19 +68,11 @@ assign_expr(::Val{name}, ::Type{ForwardDiff.JacobianConfig{T,V,N,D}},
 
 # update implicit RHS
 assign_expr(::Val{name}, ::Type{<:OrdinaryDiffEq.ImplicitRHS}, ::Type) where name =
-    :($name = OrdinaryDiffEq.ImplicitRHS(
-        f,
-        getfield(cache, :tmp),
-        t, t, t,
-        getfield(cache, :dual_cache)))
+    :($name = OrdinaryDiffEq.ImplicitRHS(f, cache.tmp, t, t, t, cache.dual_cache))
 assign_expr(::Val{name}, ::Type{<:OrdinaryDiffEq.ImplicitRHS_Scalar}, ::Type) where name =
     :($name = OrdinaryDiffEq.ImplicitRHS_Scalar(f, zero(u), t, t, t))
 assign_expr(::Val{name}, ::Type{<:OrdinaryDiffEq.RHS_IIF}, ::Type) where name =
-    :($name = OrdinaryDiffEq.RHS_IIF(
-        f,
-        getfield(cache, :tmp),
-        t, t, getfield(cache, $(Meta.quot(name))).a,
-        getfield(cache, :dual_cache)))
+    :($name = OrdinaryDiffEq.RHS_IIF(f, cache.tmp, t, t, cache.tmp, cache.dual_cache))
 assign_expr(::Val{name}, ::Type{<:OrdinaryDiffEq.RHS_IIF_Scalar}, ::Type) where name =
     :($name = OrdinaryDiffEq.RHS_IIF_Scalar(f, zero(u), t, t,
                                             getfield(cache, $(Meta.quot(name))).a))


### PR DESCRIPTION
This PR fixes issues in `build_linked_cache` described in https://github.com/JuliaDiffEq/DelayDiffEq.jl/issues/50 that were introduced by https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/pull/217.