### PR TITLE
Restructure tests and support purely in-place history

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -9,7 +9,7 @@ function init(prob::AbstractDDEProblem{uType,tType,lType,isinplace}, alg::algTyp
               dense=save_everystep && !(typeof(alg) <: FunctionMap),
               minimal_solution=true, discontinuity_interp_points::Int=10,
               discontinuity_abstol=tType(1//Int64(10)^12), discontinuity_reltol=0,
-              initial_order=prob.h(prob.tspan[1]) == prob.u0 ? 1 : 0,
+              initial_order=agrees(prob.h, prob.u0, prob.tspan[1]) ? 1 : 0,
               initialize_integrator = true, initialize_save = true,
               callback=nothing, kwargs...) where
     {uType,tType,lType,isinplace,algType<:AbstractMethodOfStepsAlgorithm}

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,26 @@
 """
+    agrees(h, u, t)
+
+Determine whether history function evaluates to u at time point t.
+"""
+function agrees(h, u, t)
+    # Obtain signatures of h
+    sigs = [m.sig for m in methods(h)]
+
+    # Compare evaluation of h at time point t with u
+    if any(sig<:Tuple{Any, Any} for sig in sigs)
+        return h(t) == u
+    elseif any(sig<:Tuple{Any, Any, Any} for sig in sigs)
+        val = recursivecopy(u)
+        h(val, t)
+        return val == u
+    end
+
+    return false
+end
+
+
+"""
     fsal_typeof(integrator::ODEIntegrator)
 
 Return type of FSAL of `integrator`.

--- a/test/constrained.jl
+++ b/test/constrained.jl
@@ -1,62 +1,58 @@
-using DelayDiffEq, DiffEqProblemLibrary, Base.Test
+@testset "Constrained time step" begin
+    # Check that numerical solutions approximate analytical solutions,
+    # independent of problem structure
 
-# Check that numerical solutions approximate analytical solutions,
-# independent of problem structure
+    alg = MethodOfSteps(BS3(); constrained=true)
 
-alg = MethodOfSteps(BS3(); constrained=true)
+    # Single constant delay
+    @testset "single constant delay" begin
+        ## Not in-place function with scalar history function
+        prob = prob_dde_1delay_scalar_notinplace
+        dde_int = init(prob, alg; dt=0.1)
+        sol = solve!(dde_int)
 
-# Single constant delay
+        @test sol.errors[:l∞] < 3e-5
+        @test sol.errors[:final] < 2.1e-5
+        @test sol.errors[:l2] < 1.3e-5
 
-## Not in-place function with scalar history function
+        ## Not in-place function with vectorized history function
+        prob = prob_dde_1delay_notinplace
+        dde_int = init(prob, alg; dt=0.1)
+        sol2 = solve!(dde_int)
 
-prob = prob_dde_1delay_scalar_notinplace
-dde_int = init(prob, alg; dt=0.1)
-sol = solve!(dde_int)
+        @test sol.t == sol2.t && sol.u == sol2[1, :]
 
-@test sol.errors[:l∞] < 3e-5
-@test sol.errors[:final] < 2.1e-5
-@test sol.errors[:l2] < 1.3e-5
+        ## In-place function
+        prob = prob_dde_1delay
+        dde_int = init(prob, alg; dt=0.1)
+        sol2 = solve!(dde_int)
 
-## Not in-place function with vectorized history function
+        @test sol.t == sol2.t && sol.u == sol2[1, :]
+    end
 
-prob = prob_dde_1delay_notinplace
-dde_int = init(prob, alg; dt=0.1)
-sol2 = solve!(dde_int)
+    # Two constant delays
+    @testset "two constant delays" begin
+        ## Not in-place function with scalar history function
+        prob = prob_dde_2delays_scalar_notinplace
+        dde_int = init(prob, alg; dt=0.1)
+        sol = solve!(dde_int)
 
-@test sol.t == sol2.t && sol.u == sol2[1, :]
+        @test sol.errors[:l∞] < 4.1e-6
+        @test sol.errors[:final] < 1.5e-6
+        @test sol.errors[:l2] < 2.3e-6
 
-## In-place function
+        ## Not in-place function with vectorized history function
+        prob = prob_dde_2delays_notinplace
+        dde_int = init(prob, alg; dt=0.1)
+        sol2 = solve!(dde_int)
 
-prob = prob_dde_1delay
-dde_int = init(prob, alg; dt=0.1)
-sol2 = solve!(dde_int)
+        @test sol.t == sol2.t && sol.u == sol2[1, :]
 
-@test sol.t == sol2.t && sol.u == sol2[1, :]
+        ## In-place function
+        prob = prob_dde_2delays
+        dde_int = init(prob, alg; dt=0.1)
+        sol2 = solve!(dde_int)
 
-# Two constant delays
-
-## Not in-place function with scalar history function
-
-prob = prob_dde_2delays_scalar_notinplace
-dde_int = init(prob, alg; dt=0.1)
-sol = solve!(dde_int)
-
-@test sol.errors[:l∞] < 4.1e-6
-@test sol.errors[:final] < 1.5e-6
-@test sol.errors[:l2] < 2.3e-6
-
-## Not in-place function with vectorized history function
-
-prob = prob_dde_2delays_notinplace
-dde_int = init(prob, alg; dt=0.1)
-sol2 = solve!(dde_int)
-
-@test sol.t == sol2.t && sol.u == sol2[1, :]
-
-## In-place function
-
-prob = prob_dde_2delays
-dde_int = init(prob, alg; dt=0.1)
-sol2 = solve!(dde_int)
-
-@test sol.t == sol2.t && sol.u == sol2[1, :]
+        @test sol.t == sol2.t && sol.u == sol2[1, :]
+    end
+end

--- a/test/discontinuities.jl
+++ b/test/discontinuities.jl
@@ -1,50 +1,61 @@
-using DelayDiffEq, DiffEqProblemLibrary, Base.Test
+@testset "Discontinuity" begin
+    # total order
+    @testset "total order" begin
+        a = Discontinuity(1, 3)
 
-dde_int = init(prob_dde_2delays, MethodOfSteps(BS3()))
+        @test a > 0
+        @test a < 2
+        @test a == 1
 
-# initial discontinuities
-@test isempty(dde_int.opts.d_discontinuities_cache)
-@test length(dde_int.opts.d_discontinuities) == 2 &&
-    issubset([Discontinuity(1/5, 1), Discontinuity(1/3, 1)],
-             dde_int.opts.d_discontinuities.valtree)
+        b = Discontinuity(2.0, 2)
 
-# tracked discontinuities
-@test dde_int.tracked_discontinuities == [Discontinuity(0., 0)]
+        @test !(a > b)
+        @test a < b
+        @test a != b
 
-solve!(dde_int)
+        c = Discontinuity(1.0, 2)
 
-discs = [Discontinuity(t, order) for (t, order) in
-         ((0., 0), (1/5, 1), (1/3, 1), (2/5, 2), (8/15, 2), (3/5, 3),
-          (2/3, 2), (11/15, 3), (13/15, 3))]
+        @test a > c
+        @test !(a < c)
+        @test a != c
+    end
 
-for (tracked, disc) in zip(dde_int.tracked_discontinuities, discs)
-    @test tracked.t ≈ disc.t && tracked.order == disc.order
+    # simple DDE example
+    @testset "DDE" begin
+        integrator = init(prob_dde_2delays, MethodOfSteps(BS3()))
+
+        # initial discontinuities
+        @testset "initial" begin
+            @test isempty(integrator.opts.d_discontinuities_cache)
+            @test length(integrator.opts.d_discontinuities) == 2 &&
+                issubset([Discontinuity(1/5, 1), Discontinuity(1/3, 1)],
+                         integrator.opts.d_discontinuities.valtree)
+        end
+
+        # tracked discontinuities
+        @testset "tracked" begin
+            @test integrator.tracked_discontinuities == [Discontinuity(0., 0)]
+
+            solve!(integrator)
+
+            discs = [Discontinuity(t, order) for (t, order) in
+                     ((0., 0), (1/5, 1), (1/3, 1), (2/5, 2), (8/15, 2), (3/5, 3),
+                      (2/3, 2), (11/15, 3), (13/15, 3))]
+
+            for (tracked, disc) in zip(integrator.tracked_discontinuities, discs)
+                @test tracked.t ≈ disc.t && tracked.order == disc.order
+            end
+        end
+    end
+
+    # additional discontinuities
+    @testset "DDE with discontinuities" begin
+        integrator = init(prob_dde_2delays, MethodOfSteps(BS3());
+                          d_discontinuities = [Discontinuity(0.3, 4), Discontinuity(0.6, 5)])
+
+        @test integrator.opts.d_discontinuities_cache == [Discontinuity(0.3, 4)]
+        @test length(integrator.opts.d_discontinuities) == 3 &&
+            issubset([Discontinuity(1/5, 1), Discontinuity(1/3, 1), Discontinuity(0.3, 4)],
+                         integrator.opts.d_discontinuities.valtree)
+        end
 end
-
-# additional discontinuities
-dde_int2 = init(prob_dde_2delays, MethodOfSteps(BS3());
-                d_discontinuities = [Discontinuity(0.3, 4), Discontinuity(0.6, 5)])
-
-@test dde_int2.opts.d_discontinuities_cache == [Discontinuity(0.3, 4)]
-@test length(dde_int2.opts.d_discontinuities) == 3 &&
-    issubset([Discontinuity(1/5, 1), Discontinuity(1/3, 1), Discontinuity(0.3, 4)],
-             dde_int2.opts.d_discontinuities.valtree)
-
-# comparison of discontinuities
-a = Discontinuity(1, 3)
-
-@test a > 0
-@test a < 2
-@test a == 1
-
-b = Discontinuity(2.0, 2)
-
-@test !(a > b)
-@test a < b
-@test a != b
-
-c = Discontinuity(1.0, 2)
-
-@test a > c
-@test !(a < c)
-@test a != c

--- a/test/lazy_interpolants.jl
+++ b/test/lazy_interpolants.jl
@@ -1,65 +1,76 @@
-using DelayDiffEq, DiffEqProblemLibrary, Base.Test
+@testset "Lazy interpolants" begin
+    ## simple problems
+    @testset "simple problems" begin
+        prob_inplace = prob_dde_1delay
+        prob_notinplace = prob_dde_1delay_scalar_notinplace
 
-## simple problems
-prob_inplace = prob_dde_1delay
-prob_notinplace = prob_dde_1delay_scalar_notinplace
+        # Vern6
+        @testset "Vern6" begin
+            sol = solve(prob_inplace, MethodOfSteps(Vern6()))
 
-# Vern6
-sol = solve(prob_inplace, MethodOfSteps(Vern6()))
+            @test sol.errors[:l∞] < 8.7e-4
+            @test sol.errors[:final] < 7.5e-6
+            @test sol.errors[:l2] < 5.3e-4
 
-@test sol.errors[:l∞] < 8.7e-4
-@test sol.errors[:final] < 7.5e-6
-@test sol.errors[:l2] < 5.3e-4
+            sol2 = solve(prob_notinplace, MethodOfSteps(Vern6()))
 
-sol2 = solve(prob_notinplace, MethodOfSteps(Vern6()))
+            @test sol.t == sol2.t && sol[1, :] == sol2.u
+        end
 
-@test sol.t == sol2.t && sol[1, :] == sol2.u
+        # Vern7
+        @testset "Vern7" begin
+            sol = solve(prob_inplace, MethodOfSteps(Vern7()))
 
-# Vern7
-sol = solve(prob_inplace, MethodOfSteps(Vern7()))
+            @test sol.errors[:l∞] < 4.0e-4
+            @test sol.errors[:final] < 3.5e-7
+            @test sol.errors[:l2] < 1.9e-4
 
-@test sol.errors[:l∞] < 4.0e-4
-@test sol.errors[:final] < 3.5e-7
-@test sol.errors[:l2] < 1.9e-4
+            sol2 = solve(prob_notinplace, MethodOfSteps(Vern7()))
 
-sol2 = solve(prob_notinplace, MethodOfSteps(Vern7()))
+            @test sol.t == sol2.t && sol[1, :] == sol2.u
+        end
 
-@test sol.t == sol2.t && sol[1, :] == sol2.u
+        # Vern8
+        @testset "Vern8" begin
+            sol = solve(prob_inplace, MethodOfSteps(Vern8()))
 
-# Vern8
+            @test sol.errors[:l∞] < 2.0e-3
+            @test sol.errors[:final] < 1.8e-5
+            @test sol.errors[:l2] < 8.0e-4
 
-sol = solve(prob_inplace, MethodOfSteps(Vern8()))
+            sol2 = solve(prob_notinplace, MethodOfSteps(Vern8()))
 
-@test sol.errors[:l∞] < 2.0e-3
-@test sol.errors[:final] < 1.8e-5
-@test sol.errors[:l2] < 8.0e-4
+            @test sol.t == sol2.t && sol[1, :] == sol2.u
+        end
 
-sol2 = solve(prob_notinplace, MethodOfSteps(Vern8()))
+        # Vern9
+        @testset "Vern9" begin
+            sol = solve(prob_inplace, MethodOfSteps(Vern9()))
 
-@test sol.t == sol2.t && sol[1, :] == sol2.u
+            @test sol.errors[:l∞] < 1.5e-3
+            @test sol.errors[:final] < 3.8e-6
+            @test sol.errors[:l2] < 6.2e-4
 
-# Vern9
-sol = solve(prob_inplace, MethodOfSteps(Vern9()))
+            sol2 = solve(prob_notinplace, MethodOfSteps(Vern9()))
 
-@test sol.errors[:l∞] < 1.5e-3
-@test sol.errors[:final] < 3.8e-6
-@test sol.errors[:l2] < 6.2e-4
+            @test sol.t == sol2.t && sol[1, :] == sol2.u
+        end
+    end
 
-sol2 = solve(prob_notinplace, MethodOfSteps(Vern9()))
+    # model of Mackey and Glass
+    @testset "Mackey and Glass" begin
+        prob = prob_dde_mackey
 
-@test sol.t == sol2.t && sol[1, :] == sol2.u
+        # Vern6
+        solve(prob, MethodOfSteps(Vern6()))
 
-# model of Mackey and Glass
-prob = prob_dde_mackey
+        # Vern7
+        solve(prob, MethodOfSteps(Vern7()))
 
-# Vern6
-sol = solve(prob, MethodOfSteps(Vern6()))
+        # Vern8
+        solve(prob, MethodOfSteps(Vern8()))
 
-# Vern7
-sol = solve(prob, MethodOfSteps(Vern7()))
-
-# Vern8
-sol = solve(prob, MethodOfSteps(Vern8()))
-
-# Vern9
-sol = solve(prob, MethodOfSteps(Vern9()))
+        # Vern9
+        solve(prob, MethodOfSteps(Vern9()))
+    end
+end

--- a/test/reinit.jl
+++ b/test/reinit.jl
@@ -1,29 +1,34 @@
-using DelayDiffEq, DiffEqProblemLibrary, Base.Test
+@testset "Reinitialization" begin
+    alg = MethodOfSteps(BS3(); constrained=false)
+    prob = prob_dde_1delay_scalar_notinplace
 
-alg = MethodOfSteps(BS3(); constrained=false)
-prob = prob_dde_1delay_scalar_notinplace
-integrator = init(prob, alg, dt= 0.01)
-solve!(integrator)
+    @testset "integrator" begin
+        integrator = init(prob, alg, dt= 0.01)
+        solve!(integrator)
 
-u = copy(integrator.sol.u)
-t = copy(integrator.sol.t)
+        u = copy(integrator.sol.u)
+        t = copy(integrator.sol.t)
 
-reinit!(integrator)
-integrator.dt = 0.01
-solve!(integrator)
+        reinit!(integrator)
+        integrator.dt = 0.01
+        solve!(integrator)
 
-@test u == integrator.sol.u
-@test t == integrator.sol.t
+        @test u == integrator.sol.u
+        @test t == integrator.sol.t
+    end
 
-integrator = init(prob, alg, dt= 0.01, tstops = [0.5], saveat = [0.33])
-sol = solve!(integrator)
+    @testset "solution" begin
+        integrator = init(prob, alg, dt= 0.01, tstops = [0.5], saveat = [0.33])
+        sol = solve!(integrator)
 
-u = copy(sol.u)
-t = copy(sol.t)
+        u = copy(sol.u)
+        t = copy(sol.t)
 
-reinit!(integrator)
-integrator.dt = 0.01
-sol = solve!(integrator)
+        reinit!(integrator)
+        integrator.dt = 0.01
+        sol = solve!(integrator)
 
-@test u == sol.u
-@test t == sol.t
+        @test u == sol.u
+        @test t == sol.t
+    end
+end

--- a/test/rosenbrock_integrators.jl
+++ b/test/rosenbrock_integrators.jl
@@ -1,23 +1,15 @@
-using DelayDiffEq, DiffEqProblemLibrary, Base.Test
+@testset "Rosenbrock integrators" begin
+    prob_inplace = prob_dde_1delay
+    prob_notinplace = prob_dde_1delay_scalar_notinplace
 
-prob = prob_dde_1delay
-prob_scalar = prob_dde_1delay_scalar_notinplace
+    # ODE algorithms
+    algs = [Rosenbrock23(), Rosenbrock32(), ROS3P(), Rodas3(),
+            RosShamp4(), Veldd4(), Velds4(), GRK4T(), GRK4A(),
+            Ros4LStab(), Rodas4(), Rodas42(), Rodas4P(), Rodas5()]
 
-# ODE algorithms
-algs = [Rosenbrock23(), Rosenbrock32(), ROS3P(), Rodas3(),
-        RosShamp4(), Veldd4(), Velds4(), GRK4T(), GRK4A(),
-        Ros4LStab(), Rodas4(), Rodas42(), Rodas4P(), Rodas5()]
-
-names = ["Rosenbrock23", "Rosenbrock32", "ROS3P", "Rodas3",
-         "RosShamp4", "Veldd4", "Velds4", "GRK4T", "GRK4A",
-         "Ros4LStab", "Rodas4", "Rodas42", "Rodas4P", "Rodas5"]
-
-for (alg, name) in zip(algs, names)
-    print("testing ", name, "... ")
-    step_alg = MethodOfSteps(alg)
-    solve(prob, step_alg)
-    @time solve(prob, step_alg)
-
-    # test not in-place method
-    solve(prob_scalar, step_alg)
+    @testset for alg in algs
+        stepsalg = MethodOfSteps(alg)
+        solve(prob_inplace, stepsalg)
+        solve(prob_notinplace, stepsalg)
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,17 +1,21 @@
-using Base.Test
+using DelayDiffEq, DiffEqProblemLibrary, Base.Test
 
-@time @testset "Discontinuity Tests" begin include("discontinuities.jl") end
-@time @testset "HistoryFunction Tests" begin include("history_function.jl") end
-@time @testset "Constrained Timestep" begin include("constrained.jl") end
-@time @testset "Unconstrained Timestep" begin include("unconstrained.jl") end
-@time @testset "Dependent Delay Tests" begin include("dependent_delays.jl") end
-@time @testset "Reinit" begin include("reinit.jl") end
-@time @testset "Saveat Test" begin include("saveat.jl") end
-@time @testset "Save_idxs Test" begin include("save_idxs.jl") end
-@time @testset "Events" begin include("events.jl") end
-@time @testset "Units" begin include("units.jl") end
-@time @testset "Unique Times" begin include("unique_times.jl") end
-@time @testset "Residual Control" begin include("residual_control.jl") end
-@time @testset "Lazy Interpolants" begin include("lazy_interpolants.jl") end
-@time @testset "SDIRK Integrators" begin include("sdirk_integrators.jl") end
-@time @testset "Rosenbrock Integrators" begin include("rosenbrock_integrators.jl") end
+tests = ["discontinuities.jl",
+         "history_function.jl",
+         "constrained.jl",
+         "unconstrained.jl",
+         "dependent_delays.jl",
+         "reinit.jl",
+         "saveat.jl",
+         "save_idxs.jl",
+         "events.jl",
+         "units.jl",
+         "unique_times.jl",
+         "residual_control.jl",
+         "lazy_interpolants.jl",
+         "sdirk_integrators.jl",
+         "rosenbrock_integrators.jl"]
+
+for test in tests
+    @time include(test)
+end

--- a/test/save_idxs.jl
+++ b/test/save_idxs.jl
@@ -1,86 +1,104 @@
-using DelayDiffEq, Base.Test
+@testset "save_idxs" begin
+    # out-of-place problem
+    function f_notinplace(u,h,p,t)
+        [-h(t-1/5)[1] + u[1]; -h(t-1/3)[2] - h(t-1/5)[2]]
+    end
+    prob_notinplace = DDEProblem(f_notinplace, ones(2), t->zeros(2), (0.0, 100.0),
+                                 constant_lags = [1/5, 1/3])
 
-function f_inplace(du,u,h,p,t)
-    du[1] = - h(t-1/5)[1] + u[1]
-    du[2] = - h(t-1/3)[2] - h(t-1/5)[2]
-end
-prob_inplace = DDEProblem(f_inplace, ones(2), t->zeros(2), (0.0, 100.0),
-                          constant_lags = [1/5, 1/3])
+    # in-place problem
+    function f_inplace(du,u,h,p,t)
+        du[1] = - h(t-1/5)[1] + u[1]
+        du[2] = - h(t-1/3)[2] - h(t-1/5)[2]
+    end
+    prob_inplace = DDEProblem(f_inplace, ones(2), t->zeros(2), (0.0, 100.0),
+                              constant_lags = [1/5, 1/3])
 
-function f_notinplace(u,h,p,t)
-    [-h(t-1/5)[1] + u[1]; -h(t-1/3)[2] - h(t-1/5)[2]]
-end
-prob_notinplace = DDEProblem(f_notinplace, ones(2), t->zeros(2), (0.0, 100.0),
-                             constant_lags = [1/5, 1/3])
+    alg = MethodOfSteps(BS3())
 
-alg = MethodOfSteps(BS3())
+    @testset for prob in (prob_notinplace, prob_inplace),
+        dense in (true, false), save_start in (true, false),
+        save_everystep in (true, false),
+        saveat in (Float64[], [25.0, 50.0, 100.0])
 
-for (prob, dense, save_start, save_everystep, saveat) in
-    Iterators.product((prob_inplace, prob_notinplace),
-                      (true, false),
-                      (true, false),
-                      (true, false),
-                      (Float64[], [25.0, 50.0, 100.0]))
+        # reference solution
+        dde_int = init(prob, alg; save_start=save_start, saveat=saveat,
+                       dense=dense)
+        sol = solve!(dde_int)
 
-    # save all components (without keyword argument)
-    dde_int = init(prob, alg; save_start=save_start, saveat=saveat, dense=dense)
-    sol = solve!(dde_int)
+        # save all components
+        @testset "all components" begin
+            # without keyword argument
+            @testset "without keyword" begin
+                ## solution and solution of ODE integrator contain all components
+                @test length(sol.u[1]) == 2
+                @test length(dde_int.sol.u[1]) == 2
 
-    ## solution and solution of ODE integrator contain all components
-    @test length(sol.u[1]) == 2
-    @test length(dde_int.sol.u[1]) == 2
+                ## interpolation
+                @test sol(25:100, idxs=2) == [u[1] for u in sol(25:100, idxs=[2])]
+            end
 
-    ## interpolation
-    @test sol(25:100, idxs=2) == [u[1] for u in sol(25:100, idxs=[2])]
+            # with keyword argument
+            @testset "with keyword" begin
+                dde_int2 = init(prob, alg; save_idxs=[1, 2], save_start=save_start,
+                                saveat=saveat, dense=dense)
+                sol2 = solve!(dde_int2)
 
-    # save all components (with keyword argument)
-    dde_int2 = init(prob, alg; save_idxs=[1, 2], save_start=save_start, saveat=saveat,
-                    dense=dense)
-    sol2 = solve!(dde_int2)
+                ## solution and solution of ODE integrator contain all components
+                @test length(sol2.u[1]) == 2
+                @test length(dde_int2.sol.u[1]) == 2
 
-    ## solution and solution of ODE integrator contain all components
-    @test length(sol2.u[1]) == 2
-    @test length(dde_int2.sol.u[1]) == 2
+                ## solution equals solution without keyword arguments
+                @test sol.t == sol2.t && sol.u == sol2.u
 
-    ## solution equals solution without keyword arguments
-    @test sol.t == sol2.t && sol.u == sol2.u
+                ## interpolation
+                @test sol(25:100, idxs=2) == sol2(25:100, idxs=2)
+                @test sol(25:100, idxs=[2]) == sol2(25:100, idxs=[2])
+            end
+        end
 
-    ## interpolation
-    @test sol(25:100, idxs=2) == sol2(25:100, idxs=2)
-    @test sol(25:100, idxs=[2]) == sol2(25:100, idxs=[2])
+        # save only second component
+        @testset "second component" begin
+            # array index
+            @testset "array index" begin
+                dde_int2 = init(prob, alg; save_idxs=[2], save_start=save_start,
+                                saveat=saveat, dense=dense)
+                sol2 = solve!(dde_int2)
 
-    # save only second component
-    dde_int3 = init(prob, alg; save_idxs=[2], save_start=save_start, saveat=saveat,
-                    dense=dense)
-    sol3 = solve!(dde_int3)
+                ## solution contains only second component
+                @test length(sol2.u[1]) == 1
 
-    ## solution contains only second component
-    @test length(sol3.u[1]) == 1
+                ## solution of ODE integrator contains both components
+                @test length(dde_int2.sol.u[1]) == 2
 
-    ## solution of ODE integrator contains both components
-    @test length(dde_int3.sol.u[1]) == 2
+                ## solution equals second component of complete solution
+                @test sol.t == sol2.t && sol[2, :] == sol2[1, :]
 
-    ## solution equals second component of complete solution
-    @test sol.t == sol3.t && sol[2, :] == sol3[1, :]
+                ## interpolation of solution equals second component of
+                ## interpolation of complete solution
+                @test sol(25:100, idxs=2) == sol2(25:100, idxs=1)
+                @test sol(25:100, idxs=[2]) == sol2(25:100, idxs=[1])
+            end
 
-    ## interpolation of solution equals second component of interpolation of complete solution
-    @test sol(25:100, idxs=2) == sol3(25:100, idxs=1)
-    @test sol(25:100, idxs=[2]) == sol3(25:100, idxs=[1])
+            # scalar index
+            @testset "scalar index" begin
+                dde_int2 = init(prob, alg; save_idxs=2, save_start=save_start,
+                                saveat=saveat, dense=dense)
+                sol2 = solve!(dde_int2)
 
-    # save only second component, scalar index
-    dde_int4 = init(prob, alg; save_idxs=2, save_start=save_start, saveat=saveat,
-                    dense=dense)
-    sol4 = solve!(dde_int4)
+                ## solution is only vector of floats
+                @test typeof(sol2.u) == Vector{Float64}
 
-    ## solution is only vector of floats
-    @test typeof(sol4.u) == Vector{Float64}
+                ## solution of ODE integrator contains both components
+                @test length(dde_int2.sol.u[1]) == 2
 
-    ## solution of ODE integrator contains both components
-    @test length(dde_int4.sol.u[1]) == 2
+                ## solution equals second component of complete solution
+                @test sol.t == sol2.t && sol[2, :] == sol2.u
 
-    ## solution equals second component of complete solution
-    @test sol.t == sol4.t && sol[2, :] == sol4.u
-
-    ## interpolation of solution equals second component of interpolation of complete solution
-    @test sol(25:100, idxs=2) == sol4(25:100, idxs=1)
+                ## interpolation of solution equals second component of
+                ## interpolation of complete solution
+                @test sol(25:100, idxs=2) == sol2(25:100, idxs=1)
+            end
+        end
+    end
 end

--- a/test/saveat.jl
+++ b/test/saveat.jl
@@ -1,157 +1,127 @@
-using DelayDiffEq, DiffEqProblemLibrary, Base.Test
+@testset "saveat" begin
+    prob = prob_dde_1delay_long
+    alg = MethodOfSteps(Tsit5())
 
-prob = prob_dde_1delay_long
-alg = MethodOfSteps(Tsit5())
+    # reference integrator and solution
+    dde_int = init(prob, alg)
+    sol = solve!(dde_int)
 
-# save at every time step
-dde_int = init(prob, alg)
-sol = solve!(dde_int)
+    @testset "reference" begin
+        # solution equals solution of ODE integrator
+        @test sol.t == dde_int.sol.t
+        @test sol.u == dde_int.sol.u
+    end
 
-## solution equals solution of ODE integrator
-@test sol.t == dde_int.sol.t
-@test sol.u == dde_int.sol.u
+    # do not save every step
+    @testset "not every step (save_start=$save_start)" for save_start in (false, true)
+        ## minimal ODE solution
+        dde_int_min = init(prob, alg; saveat=[25.0, 50.0, 75.0],
+                           save_start=save_start, minimal_solution=true)
 
-# save only at a particular time point
-dde_int2 = init(prob, alg; saveat=[25.0, 50.0, 75.0])
+        # solution of ODE integrator will be reduced
+        @test dde_int_min.saveat != nothing
 
-## solution of ODE integrator will be reduced
-@test dde_int2.saveat != nothing
+        sol_min = solve!(dde_int_min)
 
-sol2 = solve!(dde_int2)
+        # time point of solution
+        @test sol_min.t == (save_start ? [0.0, 25.0, 50.0, 75.0, 100.0] :
+                            [25.0, 50.0, 75.0, 100.0])
 
-## time steps of solution
-@test sol2.t == [0.0, 25.0, 50.0, 75.0, 100.0]
+        # solution of ODE integrator is reduced:
+        # [0.0, ≈24.67, ≈25.89, ≈49.23, ≈50.47, ≈73.91, ≈75.14, 100.0]
+        @test dde_int_min.sol.t ≈ [0.0, 24.67, 25.89, 49.23, 50.47, 73.91,
+                                   75.14, 100.0] atol=1.1e-2
 
-## solution of ODE integrator is reduced:
-## [0.0, ≈24.67, ≈25.89, ≈49.23, ≈50.47, ≈73.91, ≈75.14, 100.0]
-@test dde_int2.sol.t ≈ [0.0, 24.67, 25.89, 49.23, 50.47, 73.91, 75.14, 100.0] atol=1.1e-2
+        # solution lies on interpolation of full solution above
+        @test sol(sol_min.t).u == sol_min.u
 
-## solution lies on interpolation of full solution above
-@test sol(sol2.t).u == sol2.u
+        ## full ODE solution
+        dde_int_full = init(prob, alg; saveat=[25.0, 50.0, 75.0],
+                            save_start=save_start, minimal_solution=false)
 
-# save only at a particular time point, force full ODE solution
-dde_int2_full = init(prob, alg; saveat=[25.0, 50.0, 75.0], minimal_solution=false)
+        # solution of ODE integrator will not be reduced
+        @test dde_int_full.saveat == nothing
 
-## solution of ODE integrator will not be reduced
-@test dde_int2_full.saveat == nothing
+        sol_full = solve!(dde_int_full)
 
-sol2_full = solve!(dde_int2_full)
+        # solution of ODE integrator equals full solution above
+        @test sol.t == dde_int_full.sol.t && sol.u == dde_int_full.sol.u
 
-## solution of ODE integrator equals full solution above
-@test sol.t == dde_int2_full.sol.t && sol.u == dde_int2_full.sol.u
+        # solution equals reduced solution above
+        @test sol_min.t == sol_full.t && sol_min.u == sol_full.u
 
-## solution equals reduced solution above
-@test sol2.t == sol2_full.t && sol2.u == sol2_full.u
+        ## dense interpolation
+        dde_int_dense = init(prob, alg; saveat=[25.0, 50.0, 75.0],
+                             save_start=save_start, dense=true)
 
-# save only at a particular time point (dense interpolation)
-dde_int2_dense = init(prob, alg; saveat=[25.0, 50.0, 75.0], dense=true)
+        # solution of ODE integrator will not be reduced
+        @test dde_int_dense.saveat == nothing
 
-## solution of ODE integrator will not be reduced
-@test dde_int2_dense.saveat == nothing
+        sol_dense = solve!(dde_int_dense)
 
-sol2_dense = solve!(dde_int2_dense)
+        # time steps of solution
+        @test sol_dense.t == (save_start ? [0.0, 25.0, 50.0, 75.0, 100.0] :
+                              [25.0, 50.0, 75.0, 100.0])
 
-## time steps of solution
-@test sol2_dense.t == [0.0, 25.0, 50.0, 75.0, 100.0]
+        # solution of ODE integrator equals full solution above
+        @test sol.t == dde_int_dense.sol.t && sol.u == dde_int_dense.sol.u
 
-## solution of ODE integrator equals full solution above
-@test sol.t == dde_int2_dense.sol.t && sol.u == dde_int2_dense.sol.u
+        # solution lies on interpolation of full solution above
+        @test sol(sol_dense.t).u == sol_dense.u
 
-## solution lies on interpolation of full solution above
-@test sol(sol2_dense.t).u == sol2_dense.u
+        # full solution above lies on interpolation of solution
+        @test sol_dense(sol.t).u == sol.u
+    end
 
-## full solution above lies on interpolation of solution
-@test sol2_dense(sol.t).u == sol.u
+    # save every step
+    @testset "every step (save_start=$save_start)" for save_start in (false, true)
+        ## minimal ODE solution (is not possible to minimize ODE solution actually!)
+        dde_int_min = init(prob, alg; saveat=[25.0, 50.0, 75.0], save_everystep=true,
+                           save_start=save_start, minimal_solution=true)
 
-# save only at a particular time point and exclude initial time point
-dde_int3 = init(prob, alg; saveat=[25.0, 50.0, 75.0], save_start=false)
+        # solution of ODE integrator will not be reduced
+        @test dde_int_min.saveat == nothing
 
-## solution of ODE integrator will be reduced
-@test dde_int3.saveat != nothing
+        ## full ODE solution
+        dde_int_full = init(prob, alg; saveat=[25.0, 50.0, 75.0], save_everystep=true,
+                            save_start=save_start, minimal_solution=false)
 
-sol3 = solve!(dde_int3)
+        # solution of ODE integrator will not be reduced
+        @test dde_int_full.saveat == nothing
 
-## time steps of solution
-@test sol3.t == [25.0, 50.0, 75.0, 100.0]
+        sol_full = solve!(dde_int_full)
 
-## solution of ODE integrator equals reduced solution of ODE integrator above
-@test dde_int3.sol.t == dde_int2.sol.t
+        # time steps of solution
+        @test symdiff(sol.t, sol_full.t) == (save_start ? [25.0, 50.0, 75.0] :
+                                             [0.0, 25.0, 50.0, 75.0])
 
-## solution lies on interpolation of full solution above
-@test sol(sol3.t).u == sol3.u
+        # solution of ODE integrator equals full solution above
+        @test sol.t == dde_int_full.sol.t && sol.u == dde_int_full.sol.u
 
-# save only at a particular time point and exclude initial time point (dense interpolation)
-dde_int3_dense = init(prob, alg; saveat=[25.0, 50.0, 75.0], save_start=false, dense=true)
-sol3_dense = solve!(dde_int3_dense)
+        # solution lies on interpolation of full solution above
+        @test sol(sol_full.t).u == sol_full.u
 
-## time steps of solution
-@test sol3_dense.t == [25.0, 50.0, 75.0, 100.0]
+        ## dense interpolation
+        dde_int_dense = init(prob, alg; saveat=[25.0, 50.0, 75.0],
+                             save_everystep=true, save_start=save_start,
+                             dense=true)
 
-## solution of ODE integrator equals full solution above
-@test sol.t == dde_int3_dense.sol.t && sol.u == dde_int3_dense.sol.u
+        # solution of ODE integrator will not be reduced
+        @test dde_int_dense.saveat == nothing
 
-## solution lies on interpolation of full solution above
-@test sol(sol3_dense.t).u == sol3_dense.u
+        sol_dense = solve!(dde_int_dense)
 
-## full solution above lies on interpolation of solution
-@test sol3_dense(sol.t).u == sol.u
+        # time steps of solution
+        @test symdiff(sol.t, sol_dense.t) == (save_start ? [25.0, 50.0, 75.0] :
+                                              [0.0, 25.0, 50.0, 75.0])
 
-# save every step and additionally at a particular time point
-dde_int4 = init(prob, alg; saveat=[25.0, 50.0, 75.0], save_everystep=true)
-sol4 = solve!(dde_int4)
+        # solution of ODE integrator equals full solution above
+        @test sol.t == dde_int_dense.sol.t && sol.u == dde_int_dense.sol.u
 
-## time steps of solution
-@test symdiff(sol.t, sol4.t) == [25.0, 50.0, 75.0]
+        # solution lies on interpolation of full solution above
+        @test sol(sol_dense.t).u == sol_dense.u
 
-## solution of ODE integrator equals full solution above
-@test sol.t == dde_int4.sol.t && sol.u == dde_int4.sol.u
-
-## solution lies on interpolation of full solution above
-@test sol(sol4.t).u == sol4.u
-
-# save every step and additionally at a particular time point (dense interpolation)
-dde_int4_dense = init(prob, alg; saveat=[25.0, 50.0, 75.0], save_everystep=true, dense=true)
-sol4_dense = solve!(dde_int4_dense)
-
-## time steps of solution
-@test symdiff(sol.t, sol4_dense.t) == [25.0, 50.0, 75.0]
-
-## solution of ODE integrator equals full solution above
-@test sol.t == dde_int4_dense.sol.t && sol.u == dde_int4_dense.sol.u
-
-## solution lies on interpolation of full solution above
-@test sol(sol4_dense.t).u == sol4_dense.u
-
-## full solution above lies on interpolation of solution
-@test sol4_dense(sol.t).u == sol.u
-
-# save every step, additionally at a particular time point, and exclude initial time point
-dde_int5 = init(prob, alg; saveat=[25.0, 50.0, 75.0], save_everystep=true, save_start=false)
-sol5 = solve!(dde_int5)
-
-## time steps of solution
-@test symdiff(sol.t, sol5.t) == [0.0, 25.0, 50.0, 75.0]
-
-## solution of ODE integrator equals full solution above
-@test sol.t == dde_int5.sol.t && sol.u == dde_int5.sol.u
-
-## solution lies on interpolation of full solution above
-@test sol(sol5.t).u == sol5.u
-
-# save every step, additionally at a particular time point, and exclude initial time point
-# (dense interpolation)
-dde_int5_dense = init(prob, alg; saveat=[25.0, 50.0, 75.0], save_everystep=true,
-                      save_start=false, dense=true)
-sol5_dense = solve!(dde_int5_dense)
-
-## time steps of solution
-@test symdiff(sol.t, sol5_dense.t) == [0.0, 25.0, 50.0, 75.0]
-
-## solution of ODE integrator equals full solution above
-@test sol.t == dde_int5_dense.sol.t && sol.u == dde_int5_dense.sol.u
-
-## solution lies on interpolation of full solution above
-@test sol(sol5_dense.t).u == sol5_dense.u
-
-## full solution above lies on interpolation of solution
-@test sol5_dense(sol.t).u == sol.u
+        # full solution above lies on interpolation of solution
+        @test sol_dense(sol.t).u == sol.u
+    end
+end

--- a/test/sdirk_integrators.jl
+++ b/test/sdirk_integrators.jl
@@ -1,29 +1,18 @@
-using DelayDiffEq, DiffEqProblemLibrary, Base.Test
+@testset "SDIRK integrators" begin
+    prob_inplace = prob_dde_1delay
+    prob_notinplace = prob_dde_1delay_scalar_notinplace
 
-prob = prob_dde_1delay
-prob_scalar = prob_dde_1delay_scalar_notinplace
+    # ODE algorithms
+    algs = [GenericImplicitEuler(), GenericTrapezoid(),
+            ImplicitEuler(), ImplicitMidpoint(), Trapezoid(),
+            TRBDF2(), SDIRK2(), SSPSDIRK2(),
+            Kvaerno3(), KenCarp3(),
+            Cash4(), Hairer4(), Hairer42(), Kvaerno4(), KenCarp4(),
+            Kvaerno5(), KenCarp5()]
 
-# ODE algorithms
-algs = [GenericImplicitEuler(), GenericTrapezoid(),
-        ImplicitEuler(), ImplicitMidpoint(), Trapezoid(),
-        TRBDF2(), SDIRK2(), SSPSDIRK2(),
-        Kvaerno3(), KenCarp3(),
-        Cash4(), Hairer4(), Hairer42(), Kvaerno4(), KenCarp4(),
-        Kvaerno5(), KenCarp5()]
-
-names = ["GenericImplicitEuler", "GenericTrapezoid",
-         "ImplicitEuler", "ImplicitMidpoint", "Trapezoid",
-         "TRBDF2", "SDIRK2", "SSPSDIRK2",
-         "Kvaerno3", "KenCarp3",
-         "Cash4", "Hairer4", "Hairer42", "Kvaerno4", "KenCarp4",
-         "Kvaerno5", "KenCarp5"]
-
-for (alg, name) in zip(algs, names)
-    print("testing ", name, "... ")
-    step_alg = MethodOfSteps(alg)
-    solve(prob, step_alg)
-    @time solve(prob, step_alg)
-
-    # test not in-place method
-    solve(prob_scalar, step_alg)
+    @testset for alg in algs
+        stepsalg = MethodOfSteps(alg)
+        solve(prob_inplace, stepsalg)
+        solve(prob_notinplace, stepsalg)
+    end
 end

--- a/test/unconstrained.jl
+++ b/test/unconstrained.jl
@@ -1,147 +1,121 @@
-using DelayDiffEq, DiffEqProblemLibrary, Base.Test
+@testset "Unconstrained time step" begin
+    # Check that numerical solutions approximate analytical solutions,
+    # independent of problem structure
+    @testset "standard history" begin
+        # standard algorithm
+        alg = MethodOfSteps(BS3(); constrained=false)
 
-# Check that numerical solutions approximate analytical solutions,
-# independent of problem structure
+        # different tolerances
+        alg1 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                             fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
+        alg2 = MethodOfSteps(DP8(), constrained=false, max_fixedpoint_iters=10,
+                             fixedpoint_abstol=1e-8, fixedpoint_reltol=1e-10)
+        alg3 = MethodOfSteps(Tsit5(), constrained=true, max_fixedpoint_iters=10,
+                             fixedpoint_abstol=1e-8, fixedpoint_reltol=1e-10)
+        alg4 = MethodOfSteps(DP5(), constrained=false, max_fixedpoint_iters=100,
+                             fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
 
-alg = MethodOfSteps(BS3(); constrained=false)
+        ## Single constant delay
+        @testset "single constant delay" begin
+            @testset "short time span" begin
+                ### Not in-place function with scalar history function
+                prob = prob_dde_1delay_scalar_notinplace
+                sol = solve(prob, alg)
 
-## Single constant delay
+                @test sol.errors[:l∞] < 3.0e-5
+                @test sol.errors[:final] < 2.1e-5
+                @test sol.errors[:l2] < 1.2e-5
 
-### Not in-place function with scalar history function
+                ### Not in-place function with vectorized history function
+                prob = prob_dde_1delay_notinplace
+                sol2 = solve(prob, alg)
 
-prob = prob_dde_1delay_scalar_notinplace
-sol = solve(prob, alg)
+                @test sol.t == sol2.t && sol.u == sol2[1, :]
 
-@test sol.errors[:l∞] < 3.0e-5
-@test sol.errors[:final] < 2.1e-5
-@test sol.errors[:l2] < 1.2e-5
+                ### In-place function
+                prob = prob_dde_1delay
+                sol2 = solve(prob, alg)
 
-### Not in-place function with vectorized history function
+                @test sol.t == sol2.t && sol.u == sol2[1, :]
+            end
 
-prob = prob_dde_1delay_notinplace
-sol2 = solve(prob, alg)
+            @testset "long time span" begin
+                prob = prob_dde_1delay_long_scalar_notinplace
 
-@test sol.t == sol2.t && sol.u == sol2[1, :]
+                sol1 = solve(prob, alg1)
+                sol2 = solve(prob, alg2)
+                sol3 = solve(prob, alg3)
+                sol4 = solve(prob, alg4)
 
-### In-place function
+                @test abs(sol1[end] - sol2[end]) < 5.3e-4
+                @test abs(sol1[end] - sol3[end]) < 1.1e-8
+                @test abs(sol1[end] - sol4[end]) < 2.9e-4
+            end
+        end
 
-prob = prob_dde_1delay
-sol2 = solve(prob, alg)
+        ## Two constant delays
+        @testset "two constant delays" begin
+            @testset "short time span" begin
+                ### Not in-place function with scalar history function
+                prob = prob_dde_2delays_scalar_notinplace
+                sol = solve(prob, alg)
 
-@test sol.t == sol2.t && sol.u == sol2[1, :]
+                @test sol.errors[:l∞] < 1.9e-6
+                @test sol.errors[:final] < 1.2e-6
+                @test sol.errors[:l2] < 1.0e-6
 
-## Two constant delays
+                ### Not in-place function with vectorized history function
+                prob = prob_dde_2delays_notinplace
+                sol2 = solve(prob, alg)
 
-### Not in-place function with scalar history function
+                @test sol.t == sol2.t && sol.u == sol2[1, :]
 
-prob = prob_dde_2delays_scalar_notinplace
-sol = solve(prob, alg)
+                ### In-place function
+                prob = prob_dde_2delays
+                sol2 = solve(prob, alg)
 
-@test sol.errors[:l∞] < 1.9e-6
-@test sol.errors[:final] < 1.2e-6
-@test sol.errors[:l2] < 1.0e-6
+                @test sol.t == sol2.t && sol.u == sol2[1, :]
+            end
 
-### Not in-place function with vectorized history function
+            @testset "long time span" begin
+                prob = prob_dde_2delays_long_scalar_notinplace
 
-prob = prob_dde_2delays_notinplace
-sol2 = solve(prob, alg)
+                sol1 = solve(prob, alg1)
+                # sol2 = solve(prob, alg) # aborted because of dt <= dtmin
+                sol3 = solve(prob, alg3)
+                sol4 = solve(prob, alg4)
 
-@test sol.t == sol2.t && sol.u == sol2[1, :]
+                # relaxed tests to prevent floating point issues
+                @test abs(sol1[end] - sol3[end]) < 7.9e-13 # 7.9e-15
+                @test abs(sol1[end] - sol4[end]) < 1.6e-12 # 1.6e-14
+            end
+        end
+    end
 
-### In-place function
+    ## Non-standard history functions
+    @testset "non-standard history" begin
+        alg = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                            fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
 
-prob = prob_dde_2delays
-sol2 = solve(prob, alg)
+        @testset "idxs" begin
+            function f(du,u,h,p,t)
+                du[1] = -h(t-0.2;idxs=1) + u[1]
+            end
+            h(t; idxs=nothing) = typeof(idxs) <: Number ? 0.0 : [0.0]
 
-@test sol.t == sol2.t && sol.u == sol2[1, :]
+            prob = DDEProblem(f, [1.0], h, (0.0, 100.), constant_lags = [0.2])
+            solve(prob, alg)
+        end
 
-# Problems with long time span
+        @testset "in-place" begin
+            function f(du,u,h,p,t)
+                h(du, t-0.2)
+                du[1] = -du[1] + u[1]
+            end
+            h(out,t) = (out .= 0.0)
 
-## Single constant delay
-
-prob = prob_dde_1delay_long_scalar_notinplace
-
-alg1 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
-                     fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
-sol1 = solve(prob, alg1)
-
-alg2 = MethodOfSteps(DP8(), constrained=false, max_fixedpoint_iters=10,
-                     fixedpoint_abstol=1e-8, fixedpoint_reltol=1e-10)
-sol2 = solve(prob, alg2)
-
-alg3 = MethodOfSteps(Tsit5(), constrained=true, max_fixedpoint_iters=10,
-                     fixedpoint_abstol=1e-8, fixedpoint_reltol=1e-10)
-sol3 = solve(prob, alg3)
-
-alg4 = MethodOfSteps(DP5(), constrained=false, max_fixedpoint_iters=100,
-                     fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
-sol4 = solve(prob, alg4)
-
-@test abs(sol1[end] - sol2[end]) < 5.3e-4
-@test abs(sol1[end] - sol3[end]) < 1.1e-8
-@test abs(sol1[end] - sol4[end]) < 2.9e-4
-
-## Two constant delays
-
-prob = prob_dde_2delays_long_scalar_notinplace
-
-alg1 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
-                     fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
-sol1 = solve(prob, alg1)
-
-# Aborted because of dt <= dtmin
-# alg2 = MethodOfSteps(DP8(), constrained=false, max_fixedpoint_iters=10,
-#                      fixedpoint_abstol=1e-8, fixedpoint_reltol=1e-10)
-# sol2 = solve(prob, alg2)
-
-alg3 = MethodOfSteps(Tsit5(), constrained=true, max_fixedpoint_iters=10,
-                     fixedpoint_abstol=1e-8, fixedpoint_reltol=1e-10)
-sol3 = solve(prob, alg3)
-
-alg4 = MethodOfSteps(DP5(), constrained=false, max_fixedpoint_iters=100,
-                     fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
-sol4 = solve(prob, alg4)
-
-# relaxed tests to prevent floating point issues
-@test abs(sol1[end] - sol3[end]) < 7.9e-13 # 7.9e-15
-@test abs(sol1[end] - sol4[end]) < 1.6e-12 # 1.6e-14
-
-println("Standard tests complete. Onto idxs tests")
-
-# Idxs
-
-function f(du,u,h,p,t)
-  du[1] = -h(t-0.2;idxs=1) + u[1]
+            prob = DDEProblem(f, [1.0], h, (0.0, 100.0), constant_lags = [0.2])
+            solve(prob, alg)
+        end
+    end
 end
-
-function h(t;idxs=nothing)
-  if typeof(idxs) <: Void
-    return [0.0]
-  else
-    return 0.0
-  end
-end
-
-prob = DDEProblem(f, [1.0], h, (0.0, 100.),
-                  constant_lags = [0.2])
-
-alg1 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
-                     fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
-@time sol1 = solve(prob, alg1)
-
-function f(du,u,h,p,t)
-  h(du, t-0.2)
-  du[1] = -du[1]
-  du[1] += u[1]
-end
-
-function h(out::AbstractArray,t)
-  out[1] = 0.0
-end
-
-prob = DDEProblem(f, [1.0], h, (0.0, 100.0),
-                  constant_lags = [0.2])
-
-alg1 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
-                     fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
-@time sol1 = solve(prob, alg1)

--- a/test/unique_times.jl
+++ b/test/unique_times.jl
@@ -1,10 +1,10 @@
-using DelayDiffEq, DiffEqProblemLibrary, Base.Test
+@testset "Unique times" begin
+    prob = prob_dde_1delay_long
 
-prob = prob_dde_1delay_long
+    @testset for constrained in (false, true)
+        alg = MethodOfSteps(Tsit5(), constrained=constrained)
+        sol = solve(prob, alg)
 
-for constrained in (false, true)
-    alg = MethodOfSteps(Tsit5(), constrained=constrained)
-    sol = solve(prob, alg)
-
-    @test allunique(sol.t)
+        @test allunique(sol.t)
+    end
 end


### PR DESCRIPTION
This is a huge PR but it mainly just restructures the existing tests. Similar to the tests of [NLsolve.jl](https://github.com/JuliaNLSolvers/NLsolve.jl), `@testset`s are now defined in the included files instead of `runtests.jl` and tests are better structured by nested `@testset`s and for loops of `@testset`s. The new structure helps with defining methods only locally; before in some cases the definition of a new function only added a new method to an already existing function. In particular, because of this problem the tests succeeded in the case of in-place history functions since additionally some out-of-place methods existed - although the `init` method required an out-of-place history function or an explicit `initial_order` keyword. Hence in addition to the mentioned refactoring of the tests this PR changes the default value of `initial_order` using a newly defined method `agrees` (I'm not quite satisfied with this name...) such that also purely in-place history functions are supported and the restructured and improved tests do not fail.

Since this PR is quite big already, I did not add any further implementation changes. However, I guess one should also require the history function to include parameters, i.e. users should define functions `h(p, t[, ::Type{Val{deriv}}; idxs])` or `h(val, p, t[, ::Type{Val{deriv}}; idxs])`. This would enable a simple way of dealing with parametrized history functions (and thus completely parametrized DDEs, it seems),  and I think, it should be easy to implement and improve consistency throughout the DiffEq ecosystem.