### PR TITLE
Add parameters to history function

### DIFF
--- a/src/history_function.jl
+++ b/src/history_function.jl
@@ -15,16 +15,16 @@ struct HistoryFunction{F1,F2,F3<:ODEIntegrator} <: Function
     integrator::F3
 end
 
-function (f::HistoryFunction)(t, ::Type{Val{deriv}}=Val{0}; idxs=nothing) where deriv
+function (f::HistoryFunction)(p, t, ::Type{Val{deriv}}=Val{0}; idxs=nothing) where deriv
     @inbounds if t < f.sol.t[1]
         if deriv == 0 && typeof(idxs) <: Void
-            return f.h(t)
+            return f.h(p, t)
         elseif typeof(idxs) <: Void
-            return f.h(t, Val{deriv})
+            return f.h(p, t, Val{deriv})
         elseif deriv == 0
-            return f.h(t; idxs = idxs)
+            return f.h(p, t; idxs = idxs)
         else
-            return f.h(t, Val{deriv}; idxs = idxs)
+            return f.h(p, t, Val{deriv}; idxs = idxs)
         end
     elseif t <= f.sol.t[end] # Put equals back
         return f.sol.interp(t, idxs, Val{deriv}, f.integrator.p)
@@ -47,16 +47,16 @@ function (f::HistoryFunction)(t, ::Type{Val{deriv}}=Val{0}; idxs=nothing) where 
     end
 end
 
-function (f::HistoryFunction)(val, t, ::Type{Val{deriv}}=Val{0}; idxs=nothing) where deriv
+function (f::HistoryFunction)(val, p, t, ::Type{Val{deriv}}=Val{0}; idxs=nothing) where deriv
     @inbounds if t < f.sol.t[1]
         if deriv == 0 && typeof(idxs) <: Void
-            return f.h(val, t)
+            return f.h(val, p, t)
         elseif typeof(idxs) <: Void
-            return f.h(val, t, Val{deriv})
+            return f.h(val, p, t, Val{deriv})
         elseif deriv == 0
-            return f.h(val, t; idxs = idxs)
+            return f.h(val, p, t; idxs = idxs)
         else
-            return f.h(val, t, Val{deriv}; idxs = idxs)
+            return f.h(val, p, t, Val{deriv}; idxs = idxs)
         end
     elseif t <= f.sol.t[end] # Put equals back
         return f.sol.interp(val, t, idxs, Val{deriv}, f.integrator.p)

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -303,7 +303,7 @@ function reinit!(integrator::DDEIntegrator, u0 = integrator.sol.prob.u0;
                  tstops = integrator.opts.tstops_cache,
                  saveat = integrator.opts.saveat_cache,
                  d_discontinuities = integrator.opts.d_discontinuities_cache,
-                 initial_order = integrator.sol.prob.h(t0) == u0 ? 1 : 0,
+                 initial_order = agrees(integrator.sol.prob.h, u0, integrator.sol.prob.p, t0) ? 1 : 0,
                  reset_dt = iszero(integrator.dtcache) && integrator.opts.adaptive,
                  reinit_callbacks = true, initialize_save = true,
                  reinit_cache = true)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,18 +1,19 @@
 """
-    agrees(h, u, t)
+    agrees(h, u, p, t)
 
-Determine whether history function evaluates to u at time point t.
+Determine whether history function evaluates to `u` at time point `t`
+for parameters `p`.
 """
-function agrees(h, u, t)
+function agrees(h, u, p, t)
     # Obtain signatures of h
     sigs = [m.sig for m in methods(h)]
 
     # Compare evaluation of h at time point t with u
-    if any(sig<:Tuple{Any, Any} for sig in sigs)
-        return h(t) == u
-    elseif any(sig<:Tuple{Any, Any, Any} for sig in sigs)
+    if any(sig<:Tuple{Any, Any, Any} for sig in sigs)
+        return h(p, t) == u
+    elseif any(sig<:Tuple{Any, Any, Any, Any} for sig in sigs)
         val = recursivecopy(u)
-        h(val, t)
+        h(val, p, t)
         return val == u
     end
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,4 +1,5 @@
 DiffEqDevTools
 DiffEqCallbacks
-DiffEqProblemLibrary 0.11.0
+DiffEqProblemLibrary 1.1.0
 Unitful 0.7.1
+RecursiveArrayTools

--- a/test/dependent_delays.jl
+++ b/test/dependent_delays.jl
@@ -11,7 +11,8 @@
 
     @testset "constant lag function" begin
         # constant delay specified as lag function
-        prob2 = DDEProblem(DiffEqProblemLibrary.f_1delay, [1.0], t -> [0.0], (0., 10.),
+        prob2 = DDEProblem(DiffEqProblemLibrary.f_1delay, [1.0],
+                           (p, t) -> [0.0], (0., 10.),
                            dependent_lags = [(u,p,t) -> 1])
         dde_int2 = init(prob2, alg)
         sol2 = solve!(dde_int2)
@@ -41,7 +42,8 @@
 
     # without any delays specified is worse
     @testset "without delays" begin
-        prob2 = DDEProblem(DiffEqProblemLibrary.f_1delay, [1.0], t -> [0.0], (0., 10.))
+        prob2 = DDEProblem(DiffEqProblemLibrary.f_1delay, [1.0],
+                           (p, t) -> [0.0], (0., 10.))
         sol2 = solve(prob2, alg)
 
         @test sol2.errors[:l∞] > 1e-3

--- a/test/reinit.jl
+++ b/test/reinit.jl
@@ -1,34 +1,39 @@
+using RecursiveArrayTools
+
 @testset "Reinitialization" begin
     alg = MethodOfSteps(BS3(); constrained=false)
-    prob = prob_dde_1delay_scalar_notinplace
 
-    @testset "integrator" begin
-        integrator = init(prob, alg, dt= 0.01)
-        solve!(integrator)
+    @testset for inplace in (true, false)
+        prob = inplace ? prob_dde_1delay : prob_dde_1delay_scalar_notinplace
 
-        u = copy(integrator.sol.u)
-        t = copy(integrator.sol.t)
+        @testset "integrator" begin
+            integrator = init(prob, alg, dt= 0.01)
+            solve!(integrator)
 
-        reinit!(integrator)
-        integrator.dt = 0.01
-        solve!(integrator)
+            u = recursivecopy(integrator.sol.u)
+            t = copy(integrator.sol.t)
 
-        @test u == integrator.sol.u
-        @test t == integrator.sol.t
-    end
+            reinit!(integrator)
+            integrator.dt = 0.01
+            solve!(integrator)
 
-    @testset "solution" begin
-        integrator = init(prob, alg, dt= 0.01, tstops = [0.5], saveat = [0.33])
-        sol = solve!(integrator)
+            @test u == integrator.sol.u
+            @test t == integrator.sol.t
+        end
 
-        u = copy(sol.u)
-        t = copy(sol.t)
+        @testset "solution" begin
+            integrator = init(prob, alg, dt= 0.01, tstops = [0.5], saveat = [0.33])
+            sol = solve!(integrator)
 
-        reinit!(integrator)
-        integrator.dt = 0.01
-        sol = solve!(integrator)
+            u = recursivecopy(sol.u)
+            t = copy(sol.t)
 
-        @test u == sol.u
-        @test t == sol.t
+            reinit!(integrator)
+            integrator.dt = 0.01
+            sol = solve!(integrator)
+
+            @test u == sol.u
+            @test t == sol.t
+        end
     end
 end

--- a/test/save_idxs.jl
+++ b/test/save_idxs.jl
@@ -1,17 +1,17 @@
 @testset "save_idxs" begin
     # out-of-place problem
     function f_notinplace(u,h,p,t)
-        [-h(t-1/5)[1] + u[1]; -h(t-1/3)[2] - h(t-1/5)[2]]
+        [-h(p, t-1/5)[1] + u[1]; -h(p, t-1/3)[2] - h(p, t-1/5)[2]]
     end
-    prob_notinplace = DDEProblem(f_notinplace, ones(2), t->zeros(2), (0.0, 100.0),
+    prob_notinplace = DDEProblem(f_notinplace, ones(2), (p, t)->zeros(2), (0.0, 100.0),
                                  constant_lags = [1/5, 1/3])
 
     # in-place problem
     function f_inplace(du,u,h,p,t)
-        du[1] = - h(t-1/5)[1] + u[1]
-        du[2] = - h(t-1/3)[2] - h(t-1/5)[2]
+        du[1] = - h(p, t-1/5)[1] + u[1]
+        du[2] = - h(p, t-1/3)[2] - h(p, t-1/5)[2]
     end
-    prob_inplace = DDEProblem(f_inplace, ones(2), t->zeros(2), (0.0, 100.0),
+    prob_inplace = DDEProblem(f_inplace, ones(2), (p, t)->zeros(2), (0.0, 100.0),
                               constant_lags = [1/5, 1/3])
 
     alg = MethodOfSteps(BS3())

--- a/test/unconstrained.jl
+++ b/test/unconstrained.jl
@@ -99,9 +99,9 @@
 
         @testset "idxs" begin
             function f(du,u,h,p,t)
-                du[1] = -h(t-0.2;idxs=1) + u[1]
+                du[1] = -h(p, t-0.2;idxs=1) + u[1]
             end
-            h(t; idxs=nothing) = typeof(idxs) <: Number ? 0.0 : [0.0]
+            h(p, t; idxs=nothing) = typeof(idxs) <: Number ? 0.0 : [0.0]
 
             prob = DDEProblem(f, [1.0], h, (0.0, 100.), constant_lags = [0.2])
             solve(prob, alg)
@@ -109,10 +109,10 @@
 
         @testset "in-place" begin
             function f(du,u,h,p,t)
-                h(du, t-0.2)
+                h(du, p, t-0.2)
                 du[1] = -du[1] + u[1]
             end
-            h(out,t) = (out .= 0.0)
+            h(val, p, t) = (val .= 0.0)
 
             prob = DDEProblem(f, [1.0], h, (0.0, 100.0), constant_lags = [0.2])
             solve(prob, alg)


### PR DESCRIPTION
This PR adds parameters to the history function by default, i.e. with this change history functions have to be provided by the user in the forms `h(p, t[; idxs=nothing])` or `h(val, p, t[; idxs=nothing])`, and `h(p, t, Val{deriv}[; idxs=nothing])` or `h(val, p, t, Val{deriv}[; idxs=nothing])` for higher-order derivatives. Moreover, `reinit!` is fixed and now also works with in-place history functions (I missed this bug in https://github.com/JuliaDiffEq/DelayDiffEq.jl/pull/60 and added tests for it).

Currently tests fail since this PR requires a new release of DiffEqProblemLibrary with DDE problems updated to the new interface.