### PR TITLE
Update for DiffEqBase.check_error!

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.6
-DiffEqBase 3.0.3
-OrdinaryDiffEq 3.10.0
+DiffEqBase 3.10.0
+OrdinaryDiffEq 3.11.0
 DataStructures 0.4.6
 RecursiveArrayTools 0.2.0
 Reexport

--- a/src/DelayDiffEq.jl
+++ b/src/DelayDiffEq.jl
@@ -18,8 +18,10 @@ import DiffEqBase: solve, solve!, init, resize!, u_cache, user_cache, du_cache, 
                    deleteat!, terminate!, u_modified!, get_proposed_dt, set_proposed_dt!,
                    has_reinit, reinit!, auto_dt_reset!
 
-import OrdinaryDiffEq: Rosenbrock23Cache, Rosenbrock32Cache, ImplicitEulerCache,
-                       TrapezoidCache
+using OrdinaryDiffEq: Rosenbrock23Cache, Rosenbrock32Cache, ImplicitEulerCache,
+    TrapezoidCache
+
+using DiffEqBase: check_error!
 
 include("discontinuity_type.jl")
 include("integrator_type.jl")


### PR DESCRIPTION
Current master/next release of OrdinaryDiffEq breaks DelayDiffEq since `@ode_exit_conditions` requires `DiffEqBase.check_error!`. I guess the latest release OrdinaryDiffEq 3.10.0 should be added as an upper bound to previous versions of DelayDiffEq on METADATA.jl as well?