### PR TITLE
Change initialization of tolerances of fixed point iterations

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -92,12 +92,11 @@ function DiffEqBase.__init(
                             mass_matrix = prob.f.mass_matrix)
     end
 
-    # absolut tolerance for fixed-point iterations has to be of same type as elements of u
-    # in particular important for calculations with units
-    if typeof(alg.fixedpoint_abstol) <: Nothing
-        fixedpoint_abstol_internal = map(eltype(uType), integrator.opts.abstol)
+    # define absolut tolerance for fixed-point iterations
+    if alg.fixedpoint_abstol === nothing
+        fixedpoint_abstol_internal = integrator.opts.abstol
     else
-        fixedpoint_abstol_internal = map(eltype(uType), alg.fixedpoint_abstol)
+        fixedpoint_abstol_internal = real.(alg.fixedpoint_abstol)
     end
 
     # use norm of ODE integrator if no norm for fixed-point iterations is specified
@@ -105,18 +104,16 @@ function DiffEqBase.__init(
         fixedpoint_norm = integrator.opts.internalnorm
     end
 
-    # derive unitless types
-    uEltypeNoUnits = typeof(recursive_one(integrator.u))
-    tTypeNoUnits = typeof(recursive_one(prob.tspan[1]))
-
-    # relative tolerance for fixed-point iterations has to be of same type as elements of u
-    # without units
-    # in particular important for calculations with units
-    if typeof(alg.fixedpoint_reltol) <: Nothing
-        fixedpoint_reltol_internal = convert.(eltype(uType), integrator.opts.reltol)
+    # define relative tolerance for fixed-point iterations
+    if alg.fixedpoint_reltol === nothing
+        fixedpoint_reltol_internal = integrator.opts.reltol
     else
-        fixedpoint_reltol_internal = convert.(eltype(uType), oneunit.(integrator.u).*alg.fixedpoint_reltol)
+        fixedpoint_reltol_internal = real.(alg.fixedpoint_reltol)
     end
+
+    # derive unitless types
+    uEltypeNoUnits = recursive_unitless_eltype(prob.u0)
+    tTypeNoUnits = typeof(one(tType))
 
     # create separate copies u and uprev, not pointing to integrator.u or integrator.uprev,
     # containers for residuals and to cache uprev with correct dimensions and types

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -92,7 +92,7 @@ function DiffEqBase.__init(
                             mass_matrix = prob.f.mass_matrix)
     end
 
-    # define absolut tolerance for fixed-point iterations
+    # define absolute tolerance for fixed-point iterations
     if alg.fixedpoint_abstol === nothing
         fixedpoint_abstol_internal = integrator.opts.abstol
     else

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -94,7 +94,12 @@ function DiffEqBase.__init(
 
     # define absolute tolerance for fixed-point iterations
     if alg.fixedpoint_abstol === nothing
-        fixedpoint_abstol_internal = integrator.opts.abstol
+        abstol = integrator.opts.abstol
+        if typeof(abstol) <: Number
+            fixedpoint_abstol_internal = abstol
+        else
+            fixedpoint_abstol_internal = recursivecopy(abstol)
+        end
     else
         fixedpoint_abstol_internal = real.(alg.fixedpoint_abstol)
     end
@@ -106,7 +111,12 @@ function DiffEqBase.__init(
 
     # define relative tolerance for fixed-point iterations
     if alg.fixedpoint_reltol === nothing
-        fixedpoint_reltol_internal = integrator.opts.reltol
+        reltol = integrator.opts.reltol
+        if typeof(reltol) <: Number
+            fixedpoint_reltol_internal = reltol
+        else
+            fixedpoint_reltol_internal = recursivecopy(reltol)
+        end
     else
         fixedpoint_reltol_internal = real.(alg.fixedpoint_reltol)
     end

--- a/test/units.jl
+++ b/test/units.jl
@@ -6,40 +6,38 @@ using Unitful
         DiffEqProblemLibrary.DDEProblemLibrary.build_prob_dde_1delay_long_scalar_notinplace(1.0u"N", 1.0u"s")
     prob_inplace = DiffEqProblemLibrary.DDEProblemLibrary.build_prob_dde_1delay_long(1.0u"N", 1.0u"s")
 
-    @testset for prob in (prob_notinplace, prob_inplace), constrained in (false, true)
+    @testset for prob in (prob_notinplace, prob_inplace)
         @testset "correct" begin
-            # without units
-            alg1 = MethodOfSteps(Tsit5(), constrained=constrained, max_fixedpoint_iters=100,
-                                 fixedpoint_abstol=1e-10, fixedpoint_reltol=1e-4)
-            sol1 = solve(prob, alg1)
-
             # with correct units
-            alg2 = MethodOfSteps(Tsit5(), constrained=constrained, max_fixedpoint_iters=100,
-                                 fixedpoint_abstol=1e-7u"mN", fixedpoint_reltol=1e-4)
-            sol2 = solve(prob, alg2)
-
-            @test sol1.t == sol2.t && sol1.u == sol2.u
+            alg1 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                                 fixedpoint_abstol=1e-7u"mN", fixedpoint_reltol=1e-4u"μN")
+            sol1 = solve(prob, alg1)
 
             # with correct units as vectors
             if typeof(prob.u0) <: AbstractArray
-                alg3 = MethodOfSteps(Tsit5(), constrained=constrained, max_fixedpoint_iters=100,
-                                     fixedpoint_abstol=[1e-7u"mN"], fixedpoint_reltol=[1e-4])
-                sol3 = solve(prob, alg3)
+                alg2 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                                     fixedpoint_abstol=[1e-7u"mN"], fixedpoint_reltol=[1e-4u"μN"])
+                sol2 = solve(prob, alg2)
 
-                @test sol1.t == sol3.t && sol1.u == sol3.u
+                @test sol1.t == sol2.t && sol1.u == sol2.u
             end
         end
 
         @testset "incorrect" begin
-            # with incorrect units for absolute tolerance
-            alg1 = MethodOfSteps(Tsit5(), constrained=constrained, max_fixedpoint_iters=100,
-                                fixedpoint_abstol=1e-10u"s", fixedpoint_reltol=1e-4)
+            # without units
+            alg1 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                                 fixedpoint_abstol=1e-10, fixedpoint_reltol=1e-4)
             @test_throws Unitful.DimensionError solve(prob, alg1)
 
-            # with incorrect units for relative tolerance
-            alg2 = MethodOfSteps(Tsit5(), constrained=constrained, max_fixedpoint_iters=100,
-                                fixedpoint_abstol=1e-10, fixedpoint_reltol=1e-4u"N")
+            # with incorrect units for absolute tolerance
+            alg2 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                                fixedpoint_abstol=1e-10u"s", fixedpoint_reltol=1e-4u"μN")
             @test_throws Unitful.DimensionError solve(prob, alg2)
+
+            # with incorrect units for relative tolerance
+            alg3 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                                fixedpoint_abstol=1e-7u"mN", fixedpoint_reltol=1e-4u"s")
+            @test_throws Unitful.DimensionError solve(prob, alg3)
         end
     end
 end

--- a/test/units.jl
+++ b/test/units.jl
@@ -8,35 +8,41 @@ using Unitful
 
     @testset for prob in (prob_notinplace, prob_inplace)
         @testset "correct" begin
-            # with correct units
-            alg1 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
-                                 fixedpoint_abstol=1e-7u"mN", fixedpoint_reltol=1e-4u"μN")
+            # default tolerances
+            alg1 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100)
             sol1 = solve(prob, alg1)
+
+            # with correct units
+            alg2 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                                 fixedpoint_abstol=1e-6u"N", fixedpoint_reltol=1e-3u"N")
+            sol2 = solve(prob, alg2)
+
+            @test sol1.t == sol2.t && sol1.u == sol2.u
 
             # with correct units as vectors
             if typeof(prob.u0) <: AbstractArray
-                alg2 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
-                                     fixedpoint_abstol=[1e-7u"mN"], fixedpoint_reltol=[1e-4u"μN"])
-                sol2 = solve(prob, alg2)
+                alg3 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                                     fixedpoint_abstol=[1e-6u"N"], fixedpoint_reltol=[1e-3u"N"])
+                sol3 = solve(prob, alg3)
 
-                @test sol1.t == sol2.t && sol1.u == sol2.u
+                @test sol1.t == sol3.t && sol1.u == sol3.u
             end
         end
 
         @testset "incorrect" begin
             # without units
             alg1 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
-                                 fixedpoint_abstol=1e-10, fixedpoint_reltol=1e-4)
+                                 fixedpoint_abstol=1e-6, fixedpoint_reltol=1e-3)
             @test_throws Unitful.DimensionError solve(prob, alg1)
 
             # with incorrect units for absolute tolerance
             alg2 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
-                                fixedpoint_abstol=1e-10u"s", fixedpoint_reltol=1e-4u"μN")
+                                fixedpoint_abstol=1e-6u"s", fixedpoint_reltol=1e-3u"N")
             @test_throws Unitful.DimensionError solve(prob, alg2)
 
             # with incorrect units for relative tolerance
             alg3 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
-                                fixedpoint_abstol=1e-7u"mN", fixedpoint_reltol=1e-4u"s")
+                                fixedpoint_abstol=1e-6u"N", fixedpoint_reltol=1e-3u"s")
             @test_throws Unitful.DimensionError solve(prob, alg3)
         end
     end


### PR DESCRIPTION
This PR changes how the tolerances of fixed point iterations are initialized. If unspecified, the error tolerances of the integrator are used without any conversions - the correct types are supposed to be set by the logic in OrdinaryDiffEq (https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/blob/master/src/solve.jl#L112-L134). If they are specified, then it is only ensured that they are real numbers (similar to https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/blob/master/src/solve.jl#L121 and https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/blob/master/src/solve.jl#L133). Hence if units are used and tolerances are specified they always have to be given with correct units. Currently unitless numbers were converted to the correct units but in my opinion we shouldn't do that since it is not transparent to the user.

This PR, however, has bigger implications: when used with Flux currently `fixedpoint_reltol_internal` is initialized as `TrackedReal{TrackedReal{Float64}}` which is incorrect and causes a stack overflow. With this PR the following code (modification of https://github.com/JuliaLang/www.julialang.org/pull/274) runs without any issues:
```julia
using DelayDiffEq
using DiffEqFlux
using Flux
using Plots

gr()

function delay_lotka_volterra(du,u,h,p,t)
  x, y = u
  α, β, δ, γ = p
  du[1] = dx = (α - β*y)*h(p,t-0.1)[1]
  du[2] = dy = (δ*x - γ)*y
end

h(p,t) = ones(eltype(p),2)

prob = DDEProblem(delay_lotka_volterra,[1.0,1.0],h,(0.0,10.0),constant_lags=[0.1])

p = param([2.2, 1.0, 2.0, 0.4])
params = Flux.Params([p])

reduction(sol) = sol[1,:]

function predict_rd_dde()
  diffeq_rd(p,reduction,prob,MethodOfSteps(Tsit5()),saveat=0.1)
end

loss_rd_dde() = sum(abs2,x-1 for x in predict_rd_dde())

data = Iterators.repeated((), 100)
opt = ADAM(0.1)
cb = function ()
  display(loss_rd_dde())
  display(plot(solve(remake(prob,p=Flux.data(p)),MethodOfSteps(Tsit5()),saveat=0.1),
          ylim=(0,6)))
end

cb()

Flux.train!(loss_rd_dde, params, data, opt, cb = cb)
``` 