### PR TITLE
Fix deprecations of DDEProblemlibrary and use SafeTestsets

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DelayDiffEq"
 uuid = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "v5.4.1"
+version = "5.4.1"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
@@ -19,7 +19,7 @@ Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 DataStructures = "≥ 0.4.6"
 DiffEqBase = "≥ 5.3.2"
 DiffEqDiffTools = "≥ 0.3.0"
-DiffEqProblemLibrary = "≥ 1.1.0"
+DiffEqProblemLibrary = "≥ 4.2.0"
 NLSolversBase = "≥ 4.2.0"
 OrdinaryDiffEq = "≥ 5.2.0"
 RecursiveArrayTools = "≥ 0.18.6"
@@ -31,8 +31,9 @@ DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
 DiffEqDevTools = "f3b72e0c-5b89-59e1-b016-84e28bfd966d"
 DiffEqProblemLibrary = "a077e3f3-b75c-5d7f-a0c6-6bc4c8ec64a9"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["DiffEqCallbacks", "Unitful", "Test", "DiffEqProblemLibrary", "RecursiveArrayTools", "DiffEqDevTools"]
+test = ["DiffEqCallbacks", "DiffEqDevTools", "DiffEqProblemLibrary", "RecursiveArrayTools", "SafeTestsets", "Test", "Unitful"]

--- a/test/common.jl
+++ b/test/common.jl
@@ -1,9 +1,14 @@
 using DelayDiffEq, DiffEqProblemLibrary, Test
-using DiffEqProblemLibrary.DDEProblemLibrary: importddeproblems; importddeproblems()
-import DiffEqProblemLibrary.DDEProblemLibrary: prob_dde_1delay, prob_dde_1delay_notinplace,
-       prob_dde_1delay_scalar_notinplace,
-       prob_dde_2delays, prob_dde_2delays_notinplace, prob_dde_2delays_scalar_notinplace,
-       prob_dde_1delay_long, prob_dde_1delay_long_notinplace,
-       prob_dde_1delay_long_scalar_notinplace, prob_dde_2delays_long,
-       prob_dde_2delays_long_notinplace, prob_dde_2delays_long_scalar_notinplace,
-       prob_dde_mackey
+using DiffEqProblemLibrary.DDEProblemLibrary
+
+DDEProblemLibrary.importddeproblems()
+
+using DiffEqProblemLibrary.DDEProblemLibrary:
+  # DDE problems with 1 constant delay
+  prob_dde_constant_1delay_ip, prob_dde_constant_1delay_oop, prob_dde_constant_1delay_scalar,
+  prob_dde_constant_1delay_long_ip, prob_dde_constant_1delay_long_oop, prob_dde_constant_1delay_long_scalar,
+  # DDE problems with 2 constant delays
+  prob_dde_constant_2delays_ip, prob_dde_constant_2delays_oop, prob_dde_constant_2delays_scalar,
+  prob_dde_constant_2delays_long_ip, prob_dde_constant_2delays_long_oop, prob_dde_constant_2delays_long_scalar,
+  # Mackey-Glass equation (model of blood production) with 1 constant delay
+  prob_dde_DDETST_A1

--- a/test/constrained.jl
+++ b/test/constrained.jl
@@ -1,59 +1,46 @@
 include("common.jl")
-@testset "Constrained time step" begin
-    # Check that numerical solutions approximate analytical solutions,
-    # independent of problem structure
 
-    alg = MethodOfSteps(BS3(); constrained=true)
+# Check that numerical solutions approximate analytical solutions,
+# independent of problem structure
 
-    # Single constant delay
-    @testset "single constant delay" begin
-        ## Not in-place function with scalar history function
-        prob = prob_dde_1delay_scalar_notinplace
-        dde_int = init(prob, alg; dt=0.1)
-        sol = solve!(dde_int)
+const alg = MethodOfSteps(BS3(); constrained=true)
 
-        @test sol.errors[:l∞] < 3e-5
-        @test sol.errors[:final] < 2.1e-5
-        @test sol.errors[:l2] < 1.3e-5
+# Single constant delay
+@testset "single constant delay" begin
+  ## Scalar function
+  sol_scalar = solve(prob_dde_constant_1delay_scalar, alg; dt=0.1)
 
-        ## Not in-place function with vectorized history function
-        prob = prob_dde_1delay_notinplace
-        dde_int = init(prob, alg; dt=0.1)
-        sol2 = solve!(dde_int)
+  @test sol_scalar.errors[:l∞] < 3e-5
+  @test sol_scalar.errors[:final] < 2.1e-5
+  @test sol_scalar.errors[:l2] < 1.3e-5
 
-        @test sol.t ≈ sol2.t && sol.u ≈ sol2[1, :]
+  ## Out-of-place function
+  sol_oop = solve(prob_dde_constant_1delay_oop, alg; dt=0.1)
 
-        ## In-place function
-        prob = prob_dde_1delay
-        dde_int = init(prob, alg; dt=0.1)
-        sol2 = solve!(dde_int)
+  @test sol_scalar.t ≈ sol_oop.t && sol_scalar.u ≈ sol_oop[1, :]
 
-        @test sol.t == sol2.t && sol.u == sol2[1, :]
-    end
+  ## In-place function
+  sol_ip = solve(prob_dde_constant_1delay_ip, alg; dt=0.1)
 
-    # Two constant delays
-    @testset "two constant delays" begin
-        ## Not in-place function with scalar history function
-        prob = prob_dde_2delays_scalar_notinplace
-        dde_int = init(prob, alg; dt=0.1)
-        sol = solve!(dde_int)
+  @test sol_scalar.t == sol_ip.t && sol_scalar.u == sol_ip[1, :]
+end
 
-        @test sol.errors[:l∞] < 4.1e-6
-        @test sol.errors[:final] < 1.5e-6
-        @test sol.errors[:l2] < 2.3e-6
+# Two constant delays
+@testset "two constant delays" begin
+  ## Scalar function
+  sol_scalar = solve(prob_dde_constant_2delays_scalar, alg; dt=0.1)
 
-        ## Not in-place function with vectorized history function
-        prob = prob_dde_2delays_notinplace
-        dde_int = init(prob, alg; dt=0.1)
-        sol2 = solve!(dde_int)
+  @test sol_scalar.errors[:l∞] < 4.1e-6
+  @test sol_scalar.errors[:final] < 1.5e-6
+  @test sol_scalar.errors[:l2] < 2.3e-6
 
-        @test sol.t ≈ sol2.t && sol.u ≈ sol2[1, :]
+  ## Out-of-place function
+  sol_oop = solve(prob_dde_constant_2delays_oop, alg; dt=0.1)
 
-        ## In-place function
-        prob = prob_dde_2delays
-        dde_int = init(prob, alg; dt=0.1)
-        sol2 = solve!(dde_int)
+  @test sol_scalar.t ≈ sol_oop.t && sol_scalar.u ≈ sol_oop[1, :]
 
-        @test sol.t == sol2.t && sol.u == sol2[1, :]
-    end
+  ## In-place function
+  sol_ip = solve(prob_dde_constant_2delays_ip, alg; dt=0.1)
+
+  @test sol_scalar.t == sol_ip.t && sol_scalar.u == sol_ip[1, :]
 end

--- a/test/dependent_delays.jl
+++ b/test/dependent_delays.jl
@@ -1,56 +1,51 @@
 include("common.jl")
-@testset "Dependent delays" begin
-    alg = MethodOfSteps(BS3())
-    dde_int = init(prob_dde_1delay, alg)
-    sol = solve!(dde_int)
 
-    @testset "reference" begin
-        @test sol.errors[:l∞] < 3.0e-5
-        @test sol.errors[:final] < 2.1e-5
-        @test sol.errors[:l2] < 1.2e-5
-    end
+const alg = MethodOfSteps(BS3())
+const dde_int = init(prob_dde_constant_1delay_ip, alg)
+const sol = solve!(dde_int)
 
-    @testset "constant lag function" begin
-        # constant delay specified as lag function
-        prob2 = DDEProblem(DiffEqProblemLibrary.DDEProblemLibrary.ff_1delay,
-                           [1.0],
-                           (p, t) -> [0.0], (0., 10.),
-                           dependent_lags = [(u,p,t) -> 1])
-        dde_int2 = init(prob2, alg)
-        sol2 = solve!(dde_int2)
+@testset "reference" begin
+  @test sol.errors[:l∞] < 3.0e-5
+  @test sol.errors[:final] < 2.1e-5
+  @test sol.errors[:l2] < 1.2e-5
+end
 
-        @test dde_int.tracked_discontinuities == dde_int2.tracked_discontinuities
+@testset "constant lag function" begin
+  # constant delay specified as lag function
+  prob2 = remake(prob_dde_constant_1delay_ip; constant_lags = nothing,
+                 dependent_lags = [(u, p, t) -> 1])
+  dde_int2 = init(prob2, alg)
+  sol2 = solve!(dde_int2)
 
-        # worse than results above with constant delays specified as scalars
-        @test sol2.errors[:l∞] < 4.2e-5
-        @test sol2.errors[:final] < 2.2e-5
-        @test sol2.errors[:l2] < 1.7e-5
+  @test dde_int.tracked_discontinuities == dde_int2.tracked_discontinuities
 
-        # simple convergence tests
-        @testset "convergence" begin
-            sol3 = solve(prob2, alg, abstol=1e-9, reltol=1e-6)
+  # worse than results above with constant delays specified as scalars
+  @test sol2.errors[:l∞] < 4.2e-5
+  @test sol2.errors[:final] < 2.2e-5
+  @test sol2.errors[:l2] < 1.7e-5
 
-            @test sol3.errors[:l∞] < 7.5e-8
-            @test sol3.errors[:final] < 4.6e-8
-            @test sol3.errors[:l2] < 3.9e-8
+  # simple convergence tests
+  @testset "convergence" begin
+    sol3 = solve(prob2, alg, abstol=1e-9, reltol=1e-6)
 
-            sol4 = solve(prob2, alg, abstol=1e-13, reltol=1e-13)
+    @test sol3.errors[:l∞] < 7.5e-8
+    @test sol3.errors[:final] < 4.6e-8
+    @test sol3.errors[:l2] < 3.9e-8
 
-            @test sol4.errors[:l∞] < 6.9e-11
-            @test sol4.errors[:final] < 1.1e-11
-            @test sol4.errors[:l2] < 6.8e-12 # 6.7e-12, relaxed for Win32
-        end
-    end
+    sol4 = solve(prob2, alg, abstol=1e-13, reltol=1e-13)
 
-    # without any delays specified is worse
-    @testset "without delays" begin
-        prob2 = DDEProblem(DiffEqProblemLibrary.DDEProblemLibrary.ff_1delay,
-                           [1.0],
-                           (p, t) -> [0.0], (0., 10.))
-        sol2 = solve(prob2, alg)
+    @test sol4.errors[:l∞] < 6.9e-11
+    @test sol4.errors[:final] < 1.1e-11
+    @test sol4.errors[:l2] < 6.8e-12 # 6.7e-12, relaxed for Win32
+  end
+end
 
-        @test sol2.errors[:l∞] > 1e-3
-        @test sol2.errors[:final] > 4e-5
-        @test sol2.errors[:l2] > 7e-4
-    end
+# without any delays specified is worse
+@testset "without delays" begin
+  prob2 = remake(prob_dde_constant_1delay_ip; constant_lags = nothing)
+  sol2 = solve(prob2, alg)
+
+  @test sol2.errors[:l∞] > 1e-3
+  @test sol2.errors[:final] > 4e-5
+  @test sol2.errors[:l2] > 7e-4
 end

--- a/test/discontinuities.jl
+++ b/test/discontinuities.jl
@@ -1,62 +1,61 @@
 include("common.jl")
-@testset "Discontinuity" begin
-    # total order
-    @testset "total order" begin
-        a = Discontinuity(1, 3)
 
-        @test a > 0
-        @test a < 2
-        @test a == 1
+# total order
+@testset "total order" begin
+  a = Discontinuity(1, 3)
 
-        b = Discontinuity(2.0, 2)
+  @test a > 0
+  @test a < 2
+  @test a == 1
 
-        @test !(a > b)
-        @test a < b
-        @test a != b
+  b = Discontinuity(2.0, 2)
 
-        c = Discontinuity(1.0, 2)
+  @test !(a > b)
+  @test a < b
+  @test a != b
 
-        @test a > c
-        @test !(a < c)
-        @test a != c
+  c = Discontinuity(1.0, 2)
+
+  @test a > c
+  @test !(a < c)
+  @test a != c
+end
+
+# simple DDE example
+@testset "DDE" begin
+  integrator = init(prob_dde_constant_2delays_ip, MethodOfSteps(BS3()))
+
+  # initial discontinuities
+  @testset "initial" begin
+    @test isempty(integrator.opts.d_discontinuities_cache)
+    @test length(integrator.opts.d_discontinuities) == 2 &&
+      issubset([Discontinuity(1/5, 1), Discontinuity(1/3, 1)],
+               integrator.opts.d_discontinuities.valtree)
+  end
+
+  # tracked discontinuities
+  @testset "tracked" begin
+    @test integrator.tracked_discontinuities == [Discontinuity(0., 0)]
+
+    solve!(integrator)
+
+    discs = [Discontinuity(t, order) for (t, order) in
+             ((0., 0), (1/5, 1), (1/3, 1), (2/5, 2), (8/15, 2), (3/5, 3),
+              (2/3, 2), (11/15, 3), (13/15, 3))]
+
+    for (tracked, disc) in zip(integrator.tracked_discontinuities, discs)
+      @test tracked.t ≈ disc.t && tracked.order == disc.order
     end
+  end
+end
 
-    # simple DDE example
-    @testset "DDE" begin
-        integrator = init(prob_dde_2delays, MethodOfSteps(BS3()))
+# additional discontinuities
+@testset "DDE with discontinuities" begin
+  integrator = init(prob_dde_constant_2delays_ip, MethodOfSteps(BS3());
+                    d_discontinuities = [Discontinuity(0.3, 4), Discontinuity(0.6, 5)])
 
-        # initial discontinuities
-        @testset "initial" begin
-            @test isempty(integrator.opts.d_discontinuities_cache)
-            @test length(integrator.opts.d_discontinuities) == 2 &&
-                issubset([Discontinuity(1/5, 1), Discontinuity(1/3, 1)],
-                         integrator.opts.d_discontinuities.valtree)
-        end
-
-        # tracked discontinuities
-        @testset "tracked" begin
-            @test integrator.tracked_discontinuities == [Discontinuity(0., 0)]
-
-            solve!(integrator)
-
-            discs = [Discontinuity(t, order) for (t, order) in
-                     ((0., 0), (1/5, 1), (1/3, 1), (2/5, 2), (8/15, 2), (3/5, 3),
-                      (2/3, 2), (11/15, 3), (13/15, 3))]
-
-            for (tracked, disc) in zip(integrator.tracked_discontinuities, discs)
-                @test tracked.t ≈ disc.t && tracked.order == disc.order
-            end
-        end
-    end
-
-    # additional discontinuities
-    @testset "DDE with discontinuities" begin
-        integrator = init(prob_dde_2delays, MethodOfSteps(BS3());
-                          d_discontinuities = [Discontinuity(0.3, 4), Discontinuity(0.6, 5)])
-
-        @test integrator.opts.d_discontinuities_cache == [Discontinuity(0.3, 4)]
-        @test length(integrator.opts.d_discontinuities) == 3 &&
-            issubset([Discontinuity(1/5, 1), Discontinuity(1/3, 1), Discontinuity(0.3, 4)],
-                         integrator.opts.d_discontinuities.valtree)
-        end
+  @test integrator.opts.d_discontinuities_cache == [Discontinuity(0.3, 4)]
+  @test length(integrator.opts.d_discontinuities) == 3 &&
+    issubset([Discontinuity(1/5, 1), Discontinuity(1/3, 1), Discontinuity(0.3, 4)],
+             integrator.opts.d_discontinuities.valtree)
 end

--- a/test/events.jl
+++ b/test/events.jl
@@ -1,47 +1,45 @@
 include("common.jl")
-using DiffEqDevTools, DiffEqCallbacks, Test
+using DiffEqDevTools, DiffEqCallbacks
 
-@testset "Events" begin
-    prob = prob_dde_1delay_scalar_notinplace
-    alg = MethodOfSteps(Tsit5(); constrained=false)
+const prob = prob_dde_constant_1delay_scalar
+const alg = MethodOfSteps(Tsit5(); constrained=false)
 
-    # continuous callback
-    @testset "continuous" begin
-        cb = ContinuousCallback(
-            (u, t, integrator) -> t - 2.60, # Event when event_f(t,u,k) == 0
-            integrator -> (integrator.u = - integrator.u))
+# continuous callback
+@testset "continuous" begin
+  cb = ContinuousCallback(
+    (u, t, integrator) -> t - 2.60, # Event when event_f(t,u,k) == 0
+    integrator -> (integrator.u = - integrator.u))
 
-        sol1 = solve(prob, alg, callback=cb)
-        sol2 = solve(prob, alg, callback=cb, dtmax=0.01)
-        sol3 = appxtrue(sol1, sol2)
+  sol1 = solve(prob, alg, callback=cb)
+  sol2 = solve(prob, alg, callback=cb, dtmax=0.01)
+  sol3 = appxtrue(sol1, sol2)
 
-        @test sol3.errors[:L2] < 4.1e-3
-        @test sol3.errors[:L∞] < 1.3e-2
-    end
+  @test sol3.errors[:L2] < 4.1e-3
+  @test sol3.errors[:L∞] < 1.3e-2
+end
 
-    # discrete callback
-    @testset "discrete" begin
-        cb = AutoAbstol()
+# discrete callback
+@testset "discrete" begin
+  cb = AutoAbstol()
 
-        sol1 = solve(prob, alg, callback=cb)
-        sol2 = solve(prob, alg, callback=cb, dtmax=0.01)
-        sol3 = appxtrue(sol1, sol2)
+  sol1 = solve(prob, alg, callback=cb)
+  sol2 = solve(prob, alg, callback=cb, dtmax=0.01)
+  sol3 = appxtrue(sol1, sol2)
 
-        @test sol3.errors[:L2] < 1.4e-3
-        @test sol3.errors[:L∞] < 4.1e-3
-    end
+  @test sol3.errors[:L2] < 1.4e-3
+  @test sol3.errors[:L∞] < 4.1e-3
+end
 
-    @testset "save discontinuity" begin
-        f(du, u, h, p, t) = (du .= 0)
-        prob = DDEProblem(f, [0.0], nothing, (0.0, 1.0))
+@testset "save discontinuity" begin
+  f(du, u, h, p, t) = (du .= 0)
+  prob = DDEProblem(f, [0.0], nothing, (0.0, 1.0))
 
-        condition(u, t, integrator) = t == 0.5
-        global iter
-        function affect!(integrator) integrator.u[1] += 100; global iter = integrator.iter end
-        cb = DiscreteCallback(condition, affect!)
-        sol = solve(prob, MethodOfSteps(Tsit5()), callback=cb, tstops=[0.5])
-        @test sol.t[iter+1] == sol.t[iter+2]
-        @test sol.u[iter+1] == [0.0]
-        @test sol.u[iter+2] != [0.0]
-    end
+  condition(u, t, integrator) = t == 0.5
+  global iter
+  function affect!(integrator) integrator.u[1] += 100; global iter = integrator.iter end
+  cb = DiscreteCallback(condition, affect!)
+  sol = solve(prob, MethodOfSteps(Tsit5()), callback=cb, tstops=[0.5])
+  @test sol.t[iter+1] == sol.t[iter+2]
+  @test sol.u[iter+1] == [0.0]
+  @test sol.u[iter+2] != [0.0]
 end

--- a/test/history_function.jl
+++ b/test/history_function.jl
@@ -1,151 +1,149 @@
 include("common.jl")
-@testset "HistoryFunction" begin
-    # check constant extrapolation with problem with vanishing delays at t = 0
-    @testset "vanishing delays" begin
-        prob = DDEProblem((du,u,h,p,t) -> -h(p, t/2)[1], [1.0], (p, t) -> [1.0], (0.0, 10.0))
-        solve(prob, MethodOfSteps(RK4()))
+
+# check constant extrapolation with problem with vanishing delays at t = 0
+@testset "vanishing delays" begin
+  prob = DDEProblem((u, h, p, t) -> -h(p, t/2), 1.0, (p, t) -> 1.0, (0.0, 10.0))
+  solve(prob, MethodOfSteps(RK4()))
+end
+
+@testset "general" begin
+  # naive history functions
+  h_notinplace(p, t; idxs = nothing) = idxs === nothing ? [t, -t] : [t, -t][idxs]
+
+  function h_inplace(val, p, t; idxs=nothing)
+    if idxs === nothing
+      val[1] = t
+      val[2] = -t
+    else
+      val .= [t; -t][idxs]
     end
+  end
 
+  @testset "agrees (h=$h)" for h in (h_notinplace, h_inplace)
+    @test DelayDiffEq.agrees(h, zeros(2), nothing, 0)
+    @test !DelayDiffEq.agrees(h, ones(2), nothing, 1)
+  end
 
-    @testset "general" begin
-        # naive history functions
-        h_notinplace(p, t; idxs=nothing) = idxs === nothing ? [t, -t] : [t, -t][idxs]
+  # ODE integrator
+  prob = ODEProblem((du,u,p,t)->@.(du=p*u), ones(2), (0.0, 1.0),1.01)
+  integrator = init(prob, Tsit5())
 
-        function h_inplace(val, p, t; idxs=nothing)
-            if idxs === nothing
-                val[1] = t
-                val[2] = -t
-            else
-                val .= [t; -t][idxs]
-            end
-        end
+  # combined history function
+  history_notinplace = DelayDiffEq.HistoryFunction(h_notinplace,
+                                                   integrator.sol,
+                                                   integrator)
+  history_inplace = DelayDiffEq.HistoryFunction(h_inplace,
+                                                integrator.sol,
+                                                integrator)
 
-        @testset "agrees (h=$h)" for h in (h_notinplace, h_inplace)
-            @test DelayDiffEq.agrees(h, zeros(2), nothing, 0)
-            @test !DelayDiffEq.agrees(h, ones(2), nothing, 1)
-        end
+  # test evaluation of history function
+  @testset "evaluation" for idxs in (nothing, [2]) # (idxs=$idxs)
+    # expected value
+    trueval = h_notinplace(nothing, -1; idxs = idxs)
 
-        # ODE integrator
-        prob = ODEProblem((du,u,p,t)->@.(du=p*u), ones(2), (0.0, 1.0),1.01)
-        integrator = init(prob, Tsit5())
+    # out-of-place
+    @test history_notinplace(nothing, -1, Val{0}; idxs = idxs) == trueval
 
-        # combined history function
-        history_notinplace = DelayDiffEq.HistoryFunction(h_notinplace,
-                                                         integrator.sol,
-                                                         integrator)
-        history_inplace = DelayDiffEq.HistoryFunction(h_inplace,
-                                                      integrator.sol,
-                                                      integrator)
+    # in-place
+    val = zero(trueval)
+    history_inplace(val, nothing, -1; idxs = idxs)
+    @test val == trueval
 
-        # test evaluation of history function
-        @testset "evaluation" for idxs in (nothing, [2]) # (idxs=$idxs)
-            # expected value
-            trueval = h_notinplace(nothing, -1; idxs = idxs)
+    val = zero(trueval)
+    history_inplace(val, nothing, -1, Val{0}; idxs = idxs)
+    @test val == trueval
+  end
 
-            # out-of-place
-            @test history_notinplace(nothing, -1, Val{0}; idxs = idxs) == trueval
+  # test constant extrapolation
+  @testset "constant extrapolation" for #  (deriv=$deriv, idxs=$idxs)
+    deriv in (Val{0}, Val{1}), idxs in (nothing, [2])
+    # expected value
+    trueval = deriv == Val{0} ?
+      (idxs === nothing ? integrator.u : integrator.u[[2]]) :
+      (idxs === nothing ? zeros(2) : [0.0])
 
-            # in-place
-            val = zero(trueval)
-            history_inplace(val, nothing, -1; idxs = idxs)
-            @test val == trueval
+    # out-of-place
+    integrator.isout = false
+    @test history_notinplace(nothing, 1, deriv; idxs = idxs) == trueval &&
+      integrator.isout
 
-            val = zero(trueval)
-            history_inplace(val, nothing, -1, Val{0}; idxs = idxs)
-            @test val == trueval
-        end
+    # in-place
+    integrator.isout = false
+    @test history_inplace(nothing, nothing, 1, deriv; idxs = idxs) == trueval &&
+      integrator.isout
 
-        # test constant extrapolation
-        @testset "constant extrapolation" for #  (deriv=$deriv, idxs=$idxs)
-            deriv in (Val{0}, Val{1}), idxs in (nothing, [2])
-            # expected value
-            trueval = deriv == Val{0} ?
-                (idxs === nothing ? integrator.u : integrator.u[[2]]) :
-                (idxs === nothing ? zeros(2) : [0.0])
+    integrator.isout = false
+    val = 1 .- trueval # ensures that val ≠ trueval
+    history_inplace(val, nothing, 1, deriv; idxs = idxs)
+    @test val == trueval && integrator.isout
+  end
 
-            # out-of-place
-            integrator.isout = false
-            @test history_notinplace(nothing, 1, deriv; idxs = idxs) == trueval &&
-                integrator.isout
+  # add step to integrator
+  @testset "update integrator" begin
+    OrdinaryDiffEq.loopheader!(integrator)
+    OrdinaryDiffEq.perform_step!(integrator, integrator.cache)
+    integrator.t = integrator.dt
+    @test 0.01 < integrator.t < 1
+    @test integrator.sol.t[end] == 0
+  end
 
-            # in-place
-            integrator.isout = false
-            @test history_inplace(nothing, nothing, 1, deriv; idxs = idxs) == trueval &&
-                integrator.isout
+  # test integrator interpolation
+  @testset "integrator interpolation" for # (deriv=$deriv, idxs=$idxs)
+    deriv in (Val{0}, Val{1}), idxs in (nothing, [2])
+    # expected value
+    trueval = OrdinaryDiffEq.current_interpolant(0.01, integrator, idxs, deriv)
 
-            integrator.isout = false
-            val = 1 .- trueval # ensures that val ≠ trueval
-            history_inplace(val, nothing, 1, deriv; idxs = idxs)
-            @test val == trueval && integrator.isout
-        end
+    # out-of-place
+    integrator.isout = false
+    @test history_notinplace(nothing, 0.01, deriv; idxs = idxs) == trueval &&
+      integrator.isout
 
-        # add step to integrator
-        @testset "update integrator" begin
-            OrdinaryDiffEq.loopheader!(integrator)
-            OrdinaryDiffEq.perform_step!(integrator, integrator.cache)
-            integrator.t = integrator.dt
-            @test 0.01 < integrator.t < 1
-            @test integrator.sol.t[end] == 0
-        end
+    # in-place
+    integrator.isout = false
+    val = zero(trueval)
+    history_inplace(val, nothing, 0.01, deriv; idxs = idxs)
+    @test val == trueval && integrator.isout
+  end
 
-        # test integrator interpolation
-        @testset "integrator interpolation" for # (deriv=$deriv, idxs=$idxs)
-            deriv in (Val{0}, Val{1}), idxs in (nothing, [2])
-            # expected value
-            trueval = OrdinaryDiffEq.current_interpolant(0.01, integrator, idxs, deriv)
+  # add step to solution
+  @testset "update solution" begin
+    integrator.t = 0
+    OrdinaryDiffEq.loopfooter!(integrator)
+    @test integrator.t == integrator.sol.t[end]
+  end
 
-            # out-of-place
-            integrator.isout = false
-            @test history_notinplace(nothing, 0.01, deriv; idxs = idxs) == trueval &&
-                integrator.isout
+  # test solution interpolation
+  @testset "solution interpolation" for # (deriv=$deriv, idxs=$idxs)
+    deriv in (Val{0}, Val{1}), idxs in (nothing, [2])
+    # expected value
+    trueval = integrator.sol.interp(0.01, idxs, deriv, integrator.p)
 
-            # in-place
-            integrator.isout = false
-            val = zero(trueval)
-            history_inplace(val, nothing, 0.01, deriv; idxs = idxs)
-            @test val == trueval && integrator.isout
-        end
+    # out-of-place
+    @test history_notinplace(nothing, 0.01, deriv; idxs = idxs) == trueval &&
+      !integrator.isout
 
-        # add step to solution
-        @testset "update solution" begin
-            integrator.t = 0
-            OrdinaryDiffEq.loopfooter!(integrator)
-            @test integrator.t == integrator.sol.t[end]
-        end
+    # in-place
+    val = zero(trueval)
+    history_inplace(val, nothing, 0.01, deriv; idxs = idxs)
+    @test val == trueval && !integrator.isout
+  end
 
-        # test solution interpolation
-        @testset "solution interpolation" for # (deriv=$deriv, idxs=$idxs)
-            deriv in (Val{0}, Val{1}), idxs in (nothing, [2])
-            # expected value
-            trueval = integrator.sol.interp(0.01, idxs, deriv, integrator.p)
+  # test integrator extrapolation
+  @testset "integrator extrapolation" for # (deriv=$deriv, idxs=$idxs)
+    deriv in (Val{0}, Val{1}), idxs in (0, [2])
+    idxs == 0 && (idxs = nothing)
+    # expected value
+    trueval = OrdinaryDiffEq.current_interpolant(1, integrator, idxs, deriv)
 
-            # out-of-place
-            @test history_notinplace(nothing, 0.01, deriv; idxs = idxs) == trueval &&
-                !integrator.isout
+    # out-of-place
+    integrator.isout = false
+    @test history_notinplace(nothing, 1, deriv; idxs = idxs) == trueval &&
+      integrator.isout
 
-            # in-place
-            val = zero(trueval)
-            history_inplace(val, nothing, 0.01, deriv; idxs = idxs)
-            @test val == trueval && !integrator.isout
-        end
-
-        # test integrator extrapolation
-        @testset "integrator extrapolation" for # (deriv=$deriv, idxs=$idxs)
-            deriv in (Val{0}, Val{1}), idxs in (0, [2])
-            idxs == 0 && (idxs = nothing)
-            # expected value
-            trueval = OrdinaryDiffEq.current_interpolant(1, integrator, idxs, deriv)
-
-            # out-of-place
-            integrator.isout = false
-            @test history_notinplace(nothing, 1, deriv; idxs = idxs) == trueval &&
-                integrator.isout
-
-            # in-place
-            integrator.isout = false
-            val = zero(trueval)
-            history_inplace(val, nothing, 1, deriv; idxs = idxs)
-            @test val == trueval && integrator.isout
-        end
-    end
+    # in-place
+    integrator.isout = false
+    val = zero(trueval)
+    history_inplace(val, nothing, 1, deriv; idxs = idxs)
+    @test val == trueval && integrator.isout
+  end
 end

--- a/test/lazy_interpolants.jl
+++ b/test/lazy_interpolants.jl
@@ -1,87 +1,90 @@
 include("common.jl")
-@testset "Lazy interpolants" begin
-    ## simple problems
-    @testset "simple problems" begin
-        prob_inplace = prob_dde_1delay
-        prob_notinplace = prob_dde_1delay_scalar_notinplace
-        ts = 0:0.1:10
 
-        # Vern6
-        println("Vern6")
-        @testset "Vern6" begin
-            sol = solve(prob_inplace, MethodOfSteps(Vern6()))
+## simple problems
+@testset "simple problems" begin
+  prob_ip = prob_dde_constant_1delay_ip
+  prob_scalar = prob_dde_constant_1delay_scalar
+  ts = 0:0.1:10
 
-            @test sol.errors[:l∞] < 8.7e-4
-            @test sol.errors[:final] < 7.5e-6
-            @test sol.errors[:l2] < 5.5e-4
+  # Vern6
+  println("Vern6")
+  @testset "Vern6" begin
+    alg = MethodOfSteps(Vern6())
+    sol_ip = solve(prob_ip, alg)
 
-            sol2 = solve(prob_notinplace, MethodOfSteps(Vern6()))
+    @test sol_ip.errors[:l∞] < 8.7e-4
+    @test sol_ip.errors[:final] < 7.5e-6
+    @test sol_ip.errors[:l2] < 5.5e-4
 
-            # fails due to floating point issues on Haswell CPUs: https://github.com/JuliaDiffEq/DelayDiffEq.jl/issues/97
-            # @test sol.t ≈ sol2.t && sol[1, :] ≈ sol2.u
-            @test sol(ts, idxs=1) ≈ sol2(ts) atol = 1e-8
-        end
+    sol_scalar = solve(prob_scalar, alg)
 
-        # Vern7
-        println("Vern7")
-        @testset "Vern7" begin
-            sol = solve(prob_inplace, MethodOfSteps(Vern7()))
+    # fails due to floating point issues on Haswell CPUs: https://github.com/JuliaDiffEq/DelayDiffEq.jl/issues/97
+    # @test sol_ip.t ≈ sol_scalar.t && sol_ip[1, :] ≈ sol_scalar.u
+    @test sol_ip(ts, idxs=1) ≈ sol_scalar(ts) atol = 1e-8
+  end
 
-            @test sol.errors[:l∞] < 4.0e-4
-            @test sol.errors[:final] < 3.5e-7
-            @test sol.errors[:l2] < 1.9e-4
+  # Vern7
+  println("Vern7")
+  @testset "Vern7" begin
+    alg = MethodOfSteps(Vern7())
+    sol_ip = solve(prob_ip, alg)
 
-            sol2 = solve(prob_notinplace, MethodOfSteps(Vern7()))
+    @test sol_ip.errors[:l∞] < 4.0e-4
+    @test sol_ip.errors[:final] < 3.5e-7
+    @test sol_ip.errors[:l2] < 1.9e-4
 
-            @test sol.t ≈ sol2.t && sol[1, :] ≈ sol2.u
-        end
+    sol_scalar = solve(prob_scalar, alg)
 
-        # Vern8
-        println("Vern8")
-        @testset "Vern8" begin
-            sol = solve(prob_inplace, MethodOfSteps(Vern8()))
+    @test sol_ip.t ≈ sol_scalar.t && sol_ip[1, :] ≈ sol_scalar.u
+  end
 
-            @test sol.errors[:l∞] < 2.0e-3
-            @test sol.errors[:final] < 1.8e-5
-            @test sol.errors[:l2] < 9.0e-4
+  # Vern8
+  println("Vern8")
+  @testset "Vern8" begin
+    alg = MethodOfSteps(Vern8())
+    sol_ip = solve(prob_ip, alg)
 
-            sol2 = solve(prob_notinplace, MethodOfSteps(Vern8()))
+    @test sol_ip.errors[:l∞] < 2.0e-3
+    @test sol_ip.errors[:final] < 1.8e-5
+    @test sol_ip.errors[:l2] < 9.0e-4
 
-            @test_broken sol.t ≈ sol2.t && sol[1, :] ≈ sol2.u
-        end
+    sol_scalar = solve(prob_scalar, alg)
 
-        # Vern9
-        println("Vern9")
-        @testset "Vern9" begin
-            sol = solve(prob_inplace, MethodOfSteps(Vern9()))
+    @test sol_ip.t ≈ sol_scalar.t && sol_ip[1, :] ≈ sol_scalar.u
+  end
 
-            @test sol.errors[:l∞] < 1.5e-3
-            @test sol.errors[:final] < 3.8e-6
-            @test sol.errors[:l2] < 6.5e-4
+  # Vern9
+  println("Vern9")
+  @testset "Vern9" begin
+    alg = MethodOfSteps(Vern9())
+    sol_ip = solve(prob_ip, alg)
 
-            sol2 = solve(prob_notinplace, MethodOfSteps(Vern9()))
+    @test sol_ip.errors[:l∞] < 1.5e-3
+    @test sol_ip.errors[:final] < 3.8e-6
+    @test sol_ip.errors[:l2] < 6.5e-4
 
-            # fails due to floating point issues on Haswell CPUs: https://github.com/JuliaDiffEq/DelayDiffEq.jl/issues/97
-            # @test sol.t ≈ sol2.t && sol[1, :] ≈ sol2.u
-            @test sol(ts, idxs=1) ≈ sol2(ts) atol = 1e-12
-        end
-    end
+    sol_scalar = solve(prob_scalar, alg)
 
-    # model of Mackey and Glass
-    println("Mackey and Glass")
-    @testset "Mackey and Glass" begin
-        prob = prob_dde_mackey
+    # fails due to floating point issues on Haswell CPUs: https://github.com/JuliaDiffEq/DelayDiffEq.jl/issues/97
+    # @test sol_ip.t ≈ sol_scalar.t && sol_ip[1, :] ≈ sol_scalar.u
+    @test sol_ip(ts, idxs=1) ≈ sol_scalar(ts) atol = 1e-12
+  end
+end
 
-        # Vern6
-        solve(prob, MethodOfSteps(Vern6()))
+# model of Mackey and Glass
+println("Mackey and Glass")
+@testset "Mackey and Glass" begin
+  prob = prob_dde_DDETST_A1
 
-        # Vern7
-        solve(prob, MethodOfSteps(Vern7()))
+  # Vern6
+  solve(prob, MethodOfSteps(Vern6()))
 
-        # Vern8
-        solve(prob, MethodOfSteps(Vern8()))
+  # Vern7
+  solve(prob, MethodOfSteps(Vern7()))
 
-        # Vern9
-        solve(prob, MethodOfSteps(Vern9()))
-    end
+  # Vern8
+  solve(prob, MethodOfSteps(Vern8()))
+
+  # Vern9
+  solve(prob, MethodOfSteps(Vern9()))
 end

--- a/test/parameters.jl
+++ b/test/parameters.jl
@@ -1,34 +1,33 @@
 include("common.jl")
-@testset "Parameterized functions" begin
-    # Test parameterized delayed logistic equation
 
-    # delayed logistic equation
-    f_inplace(du, u, h, p, t) = (du[1] = p[1] * u[1] * (1 - h(p, t-1; idxs = 1)))
-    f_scalar(u, h, p, t) = p[1] * u * (1 - h(p, t-1))
+# Test parameterized delayed logistic equation
 
-    # simple history function (simplicity here comes at a price, see below)
-    h(p, t; idxs=nothing) = 0.1
+# delayed logistic equation
+f_inplace(du, u, h, p, t) = (du[1] = p[1] * u[1] * (1 - h(p, t-1; idxs = 1)))
+f_scalar(u, h, p, t) = p[1] * u * (1 - h(p, t-1))
 
-    @testset for inplace in (true, false)
-        # define problem
-        prob = DDEProblem(inplace ? f_inplace : f_scalar,
-                          inplace ? [0.1] : 0.1,
-                          h, (0.0, 50.0), [0.3]; constant_lags = [1])
+# simple history function (simplicity here comes at a price, see below)
+h(p, t; idxs=nothing) = 0.1
 
-        # solve problem with initial parameter:
-        # since h(p, 0) = u0 holds only in the scalar case we have to specify
-        # initial_order=1 to indicate that the discontinuity at t = 0 is of first
-        # order and to obtain the same results in both cases
-        sol1 = solve(prob, MethodOfSteps(Tsit5()); initial_order = 1)
-        @test length(sol1) == 26
-        @test first(sol1(12)) ≈ 0.884 atol=1e-4
-        @test first(sol1[end]) ≈ 1 atol=1e-5
+@testset for inplace in (true, false)
+  # define problem
+  prob = DDEProblem(inplace ? f_inplace : f_scalar,
+                    inplace ? [0.1] : 0.1,
+                    h, (0.0, 50.0), [0.3]; constant_lags = [1])
 
-        # solve problem with updated parameter
-        prob.p[1] = 1.4
-        sol2 = solve(prob, MethodOfSteps(Tsit5()); initial_order = 1)
-        @test length(sol2) == 52
-        @test first(sol2(12)) ≈ 1.127 atol=4e-4
-        @test first(sol2[end]) ≈ 0.995 atol=3e-4
-    end
+  # solve problem with initial parameter:
+  # since h(p, 0) = u0 holds only in the scalar case we have to specify
+  # initial_order=1 to indicate that the discontinuity at t = 0 is of first
+  # order and to obtain the same results in both cases
+  sol1 = solve(prob, MethodOfSteps(Tsit5()); initial_order = 1)
+  @test length(sol1) == 26
+  @test first(sol1(12)) ≈ 0.884 atol=1e-4
+  @test first(sol1[end]) ≈ 1 atol=1e-5
+
+  # solve problem with updated parameter
+  prob.p[1] = 1.4
+  sol2 = solve(prob, MethodOfSteps(Tsit5()); initial_order = 1)
+  @test length(sol2) == 52
+  @test first(sol2(12)) ≈ 1.127 atol=4e-4
+  @test first(sol2[end]) ≈ 0.995 atol=3e-4
 end

--- a/test/reinit.jl
+++ b/test/reinit.jl
@@ -1,40 +1,38 @@
 include("common.jl")
 using RecursiveArrayTools
 
-@testset "Reinitialization" begin
-    alg = MethodOfSteps(BS3(); constrained=false)
+const alg = MethodOfSteps(BS3(); constrained=false)
 
-    @testset for inplace in (true, false)
-        prob = inplace ? prob_dde_1delay : prob_dde_1delay_scalar_notinplace
+@testset for inplace in (true, false)
+  prob = inplace ? prob_dde_constant_1delay_ip : prob_dde_constant_1delay_scalar
 
-        @testset "integrator" begin
-            integrator = init(prob, alg, dt= 0.01)
-            solve!(integrator)
+  @testset "integrator" begin
+    integrator = init(prob, alg, dt= 0.01)
+    solve!(integrator)
 
-            u = recursivecopy(integrator.sol.u)
-            t = copy(integrator.sol.t)
+    u = recursivecopy(integrator.sol.u)
+    t = copy(integrator.sol.t)
 
-            reinit!(integrator)
-            integrator.dt = 0.01
-            solve!(integrator)
+    reinit!(integrator)
+    integrator.dt = 0.01
+    solve!(integrator)
 
-            @test u == integrator.sol.u
-            @test t == integrator.sol.t
-        end
+    @test u == integrator.sol.u
+    @test t == integrator.sol.t
+  end
 
-        @testset "solution" begin
-            integrator = init(prob, alg, dt= 0.01, tstops = [0.5], saveat = [0.33])
-            sol = solve!(integrator)
+  @testset "solution" begin
+    integrator = init(prob, alg, dt= 0.01, tstops = [0.5], saveat = [0.33])
+    sol = solve!(integrator)
 
-            u = recursivecopy(sol.u)
-            t = copy(sol.t)
+    u = recursivecopy(sol.u)
+    t = copy(sol.t)
 
-            reinit!(integrator)
-            integrator.dt = 0.01
-            sol = solve!(integrator)
+    reinit!(integrator)
+    integrator.dt = 0.01
+    sol = solve!(integrator)
 
-            @test u == sol.u
-            @test t == sol.t
-        end
-    end
+    @test u == sol.u
+    @test t == sol.t
+  end
 end

--- a/test/residual_control.jl
+++ b/test/residual_control.jl
@@ -1,62 +1,58 @@
 include("common.jl")
-@testset "Residual control" begin
-    alg = MethodOfSteps(RK4(); constrained=false)
 
-    # reference solution with delays specified
-    @testset "reference" begin
-        prob = prob_dde_1delay_scalar_notinplace
-        sol = solve(prob, alg)
+const alg = MethodOfSteps(RK4(); constrained=false)
 
-        @test sol.errors[:l∞] < 5.6e-5
-        @test sol.errors[:final] < 1.8e-6
-        @test sol.errors[:l2] < 2.0e-5
-    end
+# reference solution with delays specified
+@testset "reference" begin
+  sol = solve(prob_dde_constant_1delay_scalar, alg)
 
-    # problem without delays specified
-    prob = DDEProblem(prob.f,prob.u0,prob.h,prob.tspan)
+  @test sol.errors[:l∞] < 5.6e-5
+  @test sol.errors[:final] < 1.8e-6
+  @test sol.errors[:l2] < 2.0e-5
+end
 
-    # solutions with residual control
-    @testset "residual control" begin
-        sol = solve(prob, alg)
+# problem without delays specified
+const prob = remake(prob_dde_constant_1delay_scalar; constant_lags = nothing)
 
-        @test sol.errors[:l∞] < 1.8e-4
-        @test sol.errors[:final] < 4.1e-6
-        @test sol.errors[:l2] < 9.0e-5
+# solutions with residual control
+@testset "residual control" begin
+  sol = solve(prob, alg)
 
-        sol = solve(prob, alg, abstol=1e-9,reltol=1e-6)
+  @test sol.errors[:l∞] < 1.8e-4
+  @test sol.errors[:final] < 4.1e-6
+  @test sol.errors[:l2] < 9.0e-5
 
-        @test sol.errors[:l∞] < 1.5e-7
-        @test sol.errors[:final] < 4.1e-9
-        @test sol.errors[:l2] < 7.5e-8
+  sol = solve(prob, alg, abstol=1e-9,reltol=1e-6)
 
-        sol = solve(prob, alg, abstol=1e-13,reltol=1e-13)
+  @test sol.errors[:l∞] < 1.5e-7
+  @test sol.errors[:final] < 4.1e-9
+  @test sol.errors[:l2] < 7.5e-8
 
-        @test sol.errors[:l∞] < 7.0e-11
-        @test sol.errors[:final] < 1.1e-11
-        @test sol.errors[:l2] < 9.3e-12
-    end
+  sol = solve(prob, alg, abstol=1e-13,reltol=1e-13)
 
-    ######## Now show that non-residual control is worse
-    # solutions without residual control
-    @testset "non-residual control" begin
-        alg = MethodOfSteps(OwrenZen5(); constrained=false)
-        sol = solve(prob, alg)
+  @test sol.errors[:l∞] < 7.0e-11
+  @test sol.errors[:final] < 1.1e-11
+  @test sol.errors[:l2] < 9.3e-12
+end
 
-        @test sol.errors[:l∞] > 1e-1
-        @test sol.errors[:final] > 1e-3
-        @test sol.errors[:l2] > 4e-2
+######## Now show that non-residual control is worse
+# solutions without residual control
+@testset "non-residual control" begin
+  sol = solve(prob, MethodOfSteps(OwrenZen5(); constrained=false))
 
-        alg = MethodOfSteps(OwrenZen5(); constrained=true)
-        sol = solve(prob, alg)
+  @test sol.errors[:l∞] > 1e-1
+  @test sol.errors[:final] > 1e-3
+  @test sol.errors[:l2] > 4e-2
 
-        @test sol.errors[:l∞] > 1e-1
-        @test sol.errors[:final] > 1e-3
-        @test sol.errors[:l2] > 4e-2
+  sol = solve(prob, MethodOfSteps(OwrenZen5(); constrained=true))
 
-        sol = solve(prob, alg,abstol=1e-13,reltol=1e-13)
+  @test sol.errors[:l∞] > 1e-1
+  @test sol.errors[:final] > 1e-3
+  @test sol.errors[:l2] > 4e-2
 
-        @test sol.errors[:l∞] > 1e-1
-        @test sol.errors[:final] > 1e-3
-        @test sol.errors[:l2] > 5e-2
-    end
+  sol = solve(prob, MethodOfSteps(OwrenZen5(); constrained=true); abstol=1e-13, reltol=1e-13)
+
+  @test sol.errors[:l∞] > 1e-1
+  @test sol.errors[:final] > 1e-3
+  @test sol.errors[:l2] > 5e-2
 end

--- a/test/retcode.jl
+++ b/test/retcode.jl
@@ -1,16 +1,15 @@
 include("common.jl")
-@testset "Return code" begin
-    @testset for composite in (true, false)
-        alg = MethodOfSteps(composite ? AutoTsit5(Rosenbrock23()) : Tsit5();
-                            constrained=false)
 
-        sol1 = solve(prob_dde_1delay, alg)
-        @test sol1.retcode == :Success
+@testset for composite in (true, false)
+  alg = MethodOfSteps(composite ? AutoTsit5(Rosenbrock23()) : Tsit5();
+                      constrained=false)
 
-        sol2 = solve(prob_dde_1delay, alg; maxiters = 1, verbose = false)
-        @test sol2.retcode == :MaxIters
+  sol1 = solve(prob_dde_constant_1delay_ip, alg)
+  @test sol1.retcode == :Success
 
-        sol3 = solve(prob_dde_1delay, alg; dtmin = 5, verbose = false)
-        @test sol3.retcode == :DtLessThanMin
-    end
+  sol2 = solve(prob_dde_constant_1delay_ip, alg; maxiters = 1, verbose = false)
+  @test sol2.retcode == :MaxIters
+
+  sol3 = solve(prob_dde_constant_1delay_ip, alg; dtmin = 5, verbose = false)
+  @test sol3.retcode == :DtLessThanMin
 end

--- a/test/rosenbrock_integrators.jl
+++ b/test/rosenbrock_integrators.jl
@@ -1,17 +1,19 @@
 include("common.jl")
-@testset "Rosenbrock integrators" begin
-    prob_inplace = prob_dde_1delay
-    prob_notinplace = prob_dde_1delay_scalar_notinplace
 
-    # ODE algorithms
-    algs = [Rosenbrock23(), Rosenbrock32(), ROS3P(), Rodas3(),
-            RosShamp4(), Veldd4(), Velds4(), GRK4T(), GRK4A(),
-            Ros4LStab(), Rodas4(), Rodas42(), Rodas4P(), Rodas5()]
+const prob_ip = prob_dde_constant_1delay_ip
+const prob_scalar = prob_dde_constant_1delay_scalar
 
-    @testset for alg in algs
-        @show alg
-        stepsalg = MethodOfSteps(alg)
-        solve(prob_inplace, stepsalg)
-        solve(prob_notinplace, stepsalg)
-    end
+# ODE algorithms
+const algs = [Rosenbrock23(), Rosenbrock32(), ROS3P(), Rodas3(),
+              RosShamp4(), Veldd4(), Velds4(), GRK4T(), GRK4A(),
+              Ros4LStab(), Rodas4(), Rodas42(), Rodas4P(), Rodas5()]
+
+@testset "Algorithm $(nameof(typeof(alg)))" for alg in algs
+  println(nameof(typeof(alg)))
+
+  stepsalg = MethodOfSteps(alg)
+  sol_ip = solve(prob_ip, stepsalg)
+  sol_scalar = solve(prob_scalar, stepsalg)
+
+  @test sol_ip.t ≈ sol_scalar.t && sol_ip[1, :] ≈ sol_scalar.u
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,38 +1,26 @@
-if haskey(ENV,"GROUP")
-   group = ENV["GROUP"]
-else
-   group = "All"
+using SafeTestsets
+
+const GROUP = get(ENV, "GROUP", "All")
+
+if GROUP == "All" || GROUP == "Interface"
+  @time @safetestset "Discontinuity Tests" begin include("discontinuities.jl") end
+  @time @safetestset "History Function Tests" begin include("history_function.jl") end
+  @time @safetestset "Parameterized Function Tests" begin include("parameters.jl") end
+  @time @safetestset "Return Code Tests" begin include("retcode.jl") end
+  @time @safetestset "Dependent Delay Tests" begin include("dependent_delays.jl") end
+  @time @safetestset "Reinitialization Tests" begin include("reinit.jl") end
+  @time @safetestset "saveat Tests" begin include("saveat.jl") end
+  @time @safetestset "save_idxs Tests" begin include("save_idxs.jl") end
+  @time @safetestset "Event Tests" begin include("events.jl") end
+  @time @safetestset "Units Tests" begin include("units.jl") end
+  @time @safetestset "Unique Timepoints Tests" begin include("unique_times.jl") end
 end
 
-is_APPVEYOR = ( Sys.iswindows() && haskey(ENV,"APPVEYOR") )
-
-if group == "All" || group == "Interface"
-  tests = ["discontinuities.jl",
-           "history_function.jl",
-           "parameters.jl",
-           "retcode.jl",
-           "composite_solution.jl",
-           "dependent_delays.jl",
-           "reinit.jl",
-           "saveat.jl",
-           "save_idxs.jl",
-           "events.jl",
-           "units.jl",
-           "unique_times.jl"
-           ]
-   for test in tests
-       @time include(test)
-   end
-end
-if group == "All" || group == "Integrators"
-  tests =   ["constrained.jl",
-             "unconstrained.jl",
-             "residual_control.jl",
-             "lazy_interpolants.jl",
-             "sdirk_integrators.jl",
-             "rosenbrock_integrators.jl"
-             ]
-   for test in tests
-       @time include(test)
-   end
+if GROUP == "All" || GROUP == "Integrators"
+  @time @safetestset "Constrained Time Steps Tests" begin include("constrained.jl") end
+  @time @safetestset "Unconstrained Time Steps Tests" begin include("unconstrained.jl") end
+  @time @safetestset "Residual Control Tests" begin include("residual_control.jl") end
+  @time @safetestset "Lazy Interpolants Tests" begin include("lazy_interpolants.jl") end
+  @time @safetestset "SDIRK Tests" begin include("sdirk_integrators.jl") end
+  @time @safetestset "Rosenbrock Tests" begin include("rosenbrock_integrators.jl") end
 end

--- a/test/save_idxs.jl
+++ b/test/save_idxs.jl
@@ -1,105 +1,104 @@
 include("common.jl")
-@testset "save_idxs" begin
-    # out-of-place problem
-    function f_notinplace(u,h,p,t)
-        [-h(p, t-1/5)[1] + u[1]; -h(p, t-1/3)[2] - h(p, t-1/5)[2]]
+
+# out-of-place problem
+function f_notinplace(u,h,p,t)
+  [-h(p, t-1/5)[1] + u[1]; -h(p, t-1/3)[2] - h(p, t-1/5)[2]]
+end
+const prob_notinplace = DDEProblem(f_notinplace, ones(2), (p, t)->zeros(2), (0.0, 100.0),
+                                   constant_lags = [1/5, 1/3])
+
+# in-place problem
+function f_inplace(du,u,h,p,t)
+  du[1] = - h(p, t-1/5)[1] + u[1]
+  du[2] = - h(p, t-1/3)[2] - h(p, t-1/5)[2]
+end
+const prob_inplace = DDEProblem(f_inplace, ones(2), (p, t)->zeros(2), (0.0, 100.0),
+                                constant_lags = [1/5, 1/3])
+
+const alg = MethodOfSteps(BS3())
+
+@testset for prob in (prob_notinplace, prob_inplace),
+  dense in (true, false), save_start in (true, false),
+  save_everystep in (true, false),
+  saveat in (Float64[], [25.0, 50.0, 100.0])
+
+  # reference solution
+  dde_int = init(prob, alg; save_start=save_start, saveat=saveat,
+                 dense=dense)
+  sol = solve!(dde_int)
+
+  # save all components
+  @testset "all components" begin
+    # without keyword argument
+    @testset "without keyword" begin
+      ## solution and solution of ODE integrator contain all components
+      @test length(sol.u[1]) == 2
+      @test length(dde_int.sol.u[1]) == 2
+
+      ## interpolation
+      @test sol(25:100, idxs=2) ≈ [u[1] for u in sol(25:100, idxs=[2])]
     end
-    prob_notinplace = DDEProblem(f_notinplace, ones(2), (p, t)->zeros(2), (0.0, 100.0),
-                                 constant_lags = [1/5, 1/3])
 
-    # in-place problem
-    function f_inplace(du,u,h,p,t)
-        du[1] = - h(p, t-1/5)[1] + u[1]
-        du[2] = - h(p, t-1/3)[2] - h(p, t-1/5)[2]
+    # with keyword argument
+    @testset "with keyword" begin
+      dde_int2 = init(prob, alg; save_idxs=[1, 2], save_start=save_start,
+                      saveat=saveat, dense=dense)
+      sol2 = solve!(dde_int2)
+
+      ## solution and solution of ODE integrator contain all components
+      @test length(sol2.u[1]) == 2
+      @test length(dde_int2.sol.u[1]) == 2
+
+      ## solution equals solution without keyword arguments
+      @test sol.t == sol2.t && sol.u == sol2.u
+
+      ## interpolation
+      @test sol(25:100, idxs=2) ≈ sol2(25:100, idxs=2)
+      @test sol(25:100, idxs=[2]) ≈ sol2(25:100, idxs=[2])
     end
-    prob_inplace = DDEProblem(f_inplace, ones(2), (p, t)->zeros(2), (0.0, 100.0),
-                              constant_lags = [1/5, 1/3])
+  end
 
-    alg = MethodOfSteps(BS3())
+  # save only second component
+  @testset "second component" begin
+    # array index
+    @testset "array index" begin
+      dde_int2 = init(prob, alg; save_idxs=[2], save_start=save_start,
+                      saveat=saveat, dense=dense)
+      sol2 = solve!(dde_int2)
 
-    @testset for prob in (prob_notinplace, prob_inplace),
-        dense in (true, false), save_start in (true, false),
-        save_everystep in (true, false),
-        saveat in (Float64[], [25.0, 50.0, 100.0])
+      ## solution contains only second component
+      @test length(sol2.u[1]) == 1
 
-        # reference solution
-        dde_int = init(prob, alg; save_start=save_start, saveat=saveat,
-                       dense=dense)
-        sol = solve!(dde_int)
+      ## solution of ODE integrator contains both components
+      @test length(dde_int2.sol.u[1]) == 2
 
-        # save all components
-        @testset "all components" begin
-            # without keyword argument
-            @testset "without keyword" begin
-                ## solution and solution of ODE integrator contain all components
-                @test length(sol.u[1]) == 2
-                @test length(dde_int.sol.u[1]) == 2
+      ## solution equals second component of complete solution
+      @test sol.t == sol2.t && sol[2, :] == sol2[1, :]
 
-                ## interpolation
-                @test sol(25:100, idxs=2) ≈ [u[1] for u in sol(25:100, idxs=[2])]
-            end
-
-            # with keyword argument
-            @testset "with keyword" begin
-                dde_int2 = init(prob, alg; save_idxs=[1, 2], save_start=save_start,
-                                saveat=saveat, dense=dense)
-                sol2 = solve!(dde_int2)
-
-                ## solution and solution of ODE integrator contain all components
-                @test length(sol2.u[1]) == 2
-                @test length(dde_int2.sol.u[1]) == 2
-
-                ## solution equals solution without keyword arguments
-                @test sol.t == sol2.t && sol.u == sol2.u
-
-                ## interpolation
-                @test sol(25:100, idxs=2) ≈ sol2(25:100, idxs=2)
-                @test sol(25:100, idxs=[2]) ≈ sol2(25:100, idxs=[2])
-            end
-        end
-
-        # save only second component
-        @testset "second component" begin
-            # array index
-            @testset "array index" begin
-                dde_int2 = init(prob, alg; save_idxs=[2], save_start=save_start,
-                                saveat=saveat, dense=dense)
-                sol2 = solve!(dde_int2)
-
-                ## solution contains only second component
-                @test length(sol2.u[1]) == 1
-
-                ## solution of ODE integrator contains both components
-                @test length(dde_int2.sol.u[1]) == 2
-
-                ## solution equals second component of complete solution
-                @test sol.t == sol2.t && sol[2, :] == sol2[1, :]
-
-                ## interpolation of solution equals second component of
-                ## interpolation of complete solution
-                @test sol(25:100, idxs=2) ≈ sol2(25:100, idxs=1)
-                @test sol(25:100, idxs=[2]) ≈ sol2(25:100, idxs=[1])
-            end
-
-            # scalar index
-            @testset "scalar index" begin
-                dde_int2 = init(prob, alg; save_idxs=2, save_start=save_start,
-                                saveat=saveat, dense=dense)
-                sol2 = solve!(dde_int2)
-
-                ## solution is only vector of floats
-                @test typeof(sol2.u) == Vector{Float64}
-
-                ## solution of ODE integrator contains both components
-                @test length(dde_int2.sol.u[1]) == 2
-
-                ## solution equals second component of complete solution
-                @test sol.t ≈ sol2.t && sol[2, :] ≈ sol2.u
-
-                ## interpolation of solution equals second component of
-                ## interpolation of complete solution
-                @test sol(25:100, idxs=2) ≈ sol2(25:100, idxs=1)
-            end
-        end
+      ## interpolation of solution equals second component of
+      ## interpolation of complete solution
+      @test sol(25:100, idxs=2) ≈ sol2(25:100, idxs=1)
+      @test sol(25:100, idxs=[2]) ≈ sol2(25:100, idxs=[1])
     end
+
+    # scalar index
+    @testset "scalar index" begin
+      dde_int2 = init(prob, alg; save_idxs=2, save_start=save_start,
+                      saveat=saveat, dense=dense)
+      sol2 = solve!(dde_int2)
+
+      ## solution is only vector of floats
+      @test typeof(sol2.u) == Vector{Float64}
+
+      ## solution of ODE integrator contains both components
+      @test length(dde_int2.sol.u[1]) == 2
+
+      ## solution equals second component of complete solution
+      @test sol.t ≈ sol2.t && sol[2, :] ≈ sol2.u
+
+      ## interpolation of solution equals second component of
+      ## interpolation of complete solution
+      @test sol(25:100, idxs=2) ≈ sol2(25:100, idxs=1)
+    end
+  end
 end

--- a/test/saveat.jl
+++ b/test/saveat.jl
@@ -1,133 +1,132 @@
 include("common.jl")
-@testset "saveat" begin
-    prob = prob_dde_1delay_long
-    alg = MethodOfSteps(Tsit5())
 
-    # reference integrator and solution
-    dde_int = init(prob, alg)
-    sol = solve!(dde_int)
+const prob = prob_dde_constant_1delay_long_ip
+const alg = MethodOfSteps(Tsit5())
 
-    @testset "reference" begin
-        # solution equals solution of ODE integrator
-        @test sol.t == dde_int.sol.t
-        @test sol.u == dde_int.sol.u
-    end
+# reference integrator and solution
+const dde_int = init(prob, alg)
+const sol = solve!(dde_int)
 
-    # do not save every step
-    @testset "not every step (save_start=$save_start)" for save_start in (false, true)
-        # for time(s) as scalar (implicitly adds end point as well!) and vectors
-        for saveat in (25.0, [25.0, 50.0, 75.0])
-            ## minimal ODE solution
-            dde_int_min = init(prob, alg; saveat=saveat, save_start=save_start,
-                               minimal_solution=true)
+@testset "reference" begin
+  # solution equals solution of ODE integrator
+  @test sol.t == dde_int.sol.t
+  @test sol.u == dde_int.sol.u
+end
 
-            # solution of ODE integrator will be reduced
-            @test dde_int_min.saveat !== nothing
+# do not save every step
+@testset "not every step (save_start=$save_start)" for save_start in (false, true)
+  # for time(s) as scalar (implicitly adds end point as well!) and vectors
+  for saveat in (25.0, [25.0, 50.0, 75.0])
+    ## minimal ODE solution
+    dde_int_min = init(prob, alg; saveat=saveat, save_start=save_start,
+                       minimal_solution=true)
 
-            sol_min = solve!(dde_int_min)
+    # solution of ODE integrator will be reduced
+    @test dde_int_min.saveat !== nothing
 
-            # time point of solution
-            @test sol_min.t == (save_start ? [0.0, 25.0, 50.0, 75.0, 100.0] :
-                                [25.0, 50.0, 75.0, 100.0])
+    sol_min = solve!(dde_int_min)
 
-            # solution of ODE integrator is reduced:
-            # [0.0, ≈24.67, ≈25.89, ≈49.23, ≈50.47, ≈73.91, ≈75.14, 100.0]
-            @test dde_int_min.sol.t ≈ [0.0, 24.67, 25.89, 49.23, 50.47, 73.91,
-                                       75.14, 100.0] atol=1.1e-2
+    # time point of solution
+    @test sol_min.t == (save_start ? [0.0, 25.0, 50.0, 75.0, 100.0] :
+                        [25.0, 50.0, 75.0, 100.0])
 
-            # solution lies on interpolation of full solution above
-            @test sol(sol_min.t).u == sol_min.u
+    # solution of ODE integrator is reduced:
+    # [0.0, ≈24.67, ≈25.89, ≈49.23, ≈50.47, ≈73.91, ≈75.14, 100.0]
+    @test dde_int_min.sol.t ≈ [0.0, 24.67, 25.89, 49.23, 50.47, 73.91,
+                               75.14, 100.0] atol=1.1e-2
 
-            ## full ODE solution
-            dde_int_full = init(prob, alg; saveat=saveat, save_start=save_start,
-                                minimal_solution=false)
+    # solution lies on interpolation of full solution above
+    @test sol(sol_min.t).u == sol_min.u
 
-            # solution of ODE integrator will not be reduced
-            @test dde_int_full.saveat === nothing
+    ## full ODE solution
+    dde_int_full = init(prob, alg; saveat=saveat, save_start=save_start,
+                        minimal_solution=false)
 
-            sol_full = solve!(dde_int_full)
+    # solution of ODE integrator will not be reduced
+    @test dde_int_full.saveat === nothing
 
-            # solution of ODE integrator equals full solution above
-            @test sol.t == dde_int_full.sol.t && sol.u == dde_int_full.sol.u
+    sol_full = solve!(dde_int_full)
 
-            # solution equals reduced solution above
-            @test sol_min.t == sol_full.t && sol_min.u == sol_full.u
+    # solution of ODE integrator equals full solution above
+    @test sol.t == dde_int_full.sol.t && sol.u == dde_int_full.sol.u
 
-            ## dense interpolation
-            dde_int_dense = init(prob, alg; saveat=saveat, save_start=save_start,
-                                 dense=true)
+    # solution equals reduced solution above
+    @test sol_min.t == sol_full.t && sol_min.u == sol_full.u
 
-            # solution of ODE integrator will not be reduced
-            @test dde_int_dense.saveat === nothing
+    ## dense interpolation
+    dde_int_dense = init(prob, alg; saveat=saveat, save_start=save_start,
+                         dense=true)
 
-            sol_dense = solve!(dde_int_dense)
+    # solution of ODE integrator will not be reduced
+    @test dde_int_dense.saveat === nothing
 
-            # time steps of solution
-            @test sol_dense.t == (save_start ? [0.0, 25.0, 50.0, 75.0, 100.0] :
-                                  [25.0, 50.0, 75.0, 100.0])
+    sol_dense = solve!(dde_int_dense)
 
-            # solution of ODE integrator equals full solution above
-            @test sol.t == dde_int_dense.sol.t && sol.u == dde_int_dense.sol.u
+    # time steps of solution
+    @test sol_dense.t == (save_start ? [0.0, 25.0, 50.0, 75.0, 100.0] :
+                          [25.0, 50.0, 75.0, 100.0])
 
-            # solution lies on interpolation of full solution above
-            @test sol(sol_dense.t).u == sol_dense.u
+    # solution of ODE integrator equals full solution above
+    @test sol.t == dde_int_dense.sol.t && sol.u == dde_int_dense.sol.u
 
-            # full solution above lies on interpolation of solution
-            @test sol_dense(sol.t).u == sol.u
-        end
-    end
+    # solution lies on interpolation of full solution above
+    @test sol(sol_dense.t).u == sol_dense.u
 
-    # save every step
-    @testset "every step (save_start=$save_start)" for save_start in (false, true)
-        # for time(s) as scalar (implicitly adds end point as well!) and vectors
-        for saveat in (25.0, [25.0, 50.0, 75.0])
-            ## minimal ODE solution (is not possible to minimize ODE solution actually!)
-            dde_int_min = init(prob, alg; saveat=saveat, save_everystep=true,
-                               save_start=save_start, minimal_solution=true)
+    # full solution above lies on interpolation of solution
+    @test sol_dense(sol.t).u == sol.u
+  end
+end
 
-            # solution of ODE integrator will not be reduced
-            @test dde_int_min.saveat === nothing
+# save every step
+@testset "every step (save_start=$save_start)" for save_start in (false, true)
+  # for time(s) as scalar (implicitly adds end point as well!) and vectors
+  for saveat in (25.0, [25.0, 50.0, 75.0])
+    ## minimal ODE solution (is not possible to minimize ODE solution actually!)
+    dde_int_min = init(prob, alg; saveat=saveat, save_everystep=true,
+                       save_start=save_start, minimal_solution=true)
 
-            ## full ODE solution
-            dde_int_full = init(prob, alg; saveat=saveat, save_everystep=true,
-                                save_start=save_start, minimal_solution=false)
+    # solution of ODE integrator will not be reduced
+    @test dde_int_min.saveat === nothing
 
-            # solution of ODE integrator will not be reduced
-            @test dde_int_full.saveat === nothing
+    ## full ODE solution
+    dde_int_full = init(prob, alg; saveat=saveat, save_everystep=true,
+                        save_start=save_start, minimal_solution=false)
 
-            sol_full = solve!(dde_int_full)
+    # solution of ODE integrator will not be reduced
+    @test dde_int_full.saveat === nothing
 
-            # time steps of solution
-            @test symdiff(sol.t, sol_full.t) == (save_start ? [25.0, 50.0, 75.0] :
-                                                 [0.0, 25.0, 50.0, 75.0])
+    sol_full = solve!(dde_int_full)
 
-            # solution of ODE integrator equals full solution above
-            @test sol.t == dde_int_full.sol.t && sol.u == dde_int_full.sol.u
+    # time steps of solution
+    @test symdiff(sol.t, sol_full.t) == (save_start ? [25.0, 50.0, 75.0] :
+                                         [0.0, 25.0, 50.0, 75.0])
 
-            # solution lies on interpolation of full solution above
-            @test sol(sol_full.t).u == sol_full.u
+    # solution of ODE integrator equals full solution above
+    @test sol.t == dde_int_full.sol.t && sol.u == dde_int_full.sol.u
 
-            ## dense interpolation
-            dde_int_dense = init(prob, alg; saveat=saveat, save_everystep=true,
-                                 save_start=save_start, dense=true)
+    # solution lies on interpolation of full solution above
+    @test sol(sol_full.t).u == sol_full.u
 
-            # solution of ODE integrator will not be reduced
-            @test dde_int_dense.saveat === nothing
+    ## dense interpolation
+    dde_int_dense = init(prob, alg; saveat=saveat, save_everystep=true,
+                         save_start=save_start, dense=true)
 
-            sol_dense = solve!(dde_int_dense)
+    # solution of ODE integrator will not be reduced
+    @test dde_int_dense.saveat === nothing
 
-            # time steps of solution
-            @test symdiff(sol.t, sol_dense.t) == (save_start ? [25.0, 50.0, 75.0] :
-                                                  [0.0, 25.0, 50.0, 75.0])
+    sol_dense = solve!(dde_int_dense)
 
-            # solution of ODE integrator equals full solution above
-            @test sol.t == dde_int_dense.sol.t && sol.u == dde_int_dense.sol.u
+    # time steps of solution
+    @test symdiff(sol.t, sol_dense.t) == (save_start ? [25.0, 50.0, 75.0] :
+                                          [0.0, 25.0, 50.0, 75.0])
 
-            # solution lies on interpolation of full solution above
-            @test sol(sol_dense.t).u == sol_dense.u
+    # solution of ODE integrator equals full solution above
+    @test sol.t == dde_int_dense.sol.t && sol.u == dde_int_dense.sol.u
 
-            # full solution above lies on interpolation of solution
-            @test sol_dense(sol.t).u == sol.u
-        end
-    end
+    # solution lies on interpolation of full solution above
+    @test sol(sol_dense.t).u == sol_dense.u
+
+    # full solution above lies on interpolation of solution
+    @test sol_dense(sol.t).u == sol.u
+  end
 end

--- a/test/sdirk_integrators.jl
+++ b/test/sdirk_integrators.jl
@@ -1,20 +1,22 @@
 include("common.jl")
-@testset "SDIRK integrators" begin
-    prob_inplace = prob_dde_1delay
-    prob_notinplace = prob_dde_1delay_scalar_notinplace
 
-    # ODE algorithms
-    algs = [GenericImplicitEuler(), GenericTrapezoid(),
-            ImplicitEuler(), ImplicitMidpoint(), Trapezoid(),
-            TRBDF2(), SDIRK2(), SSPSDIRK2(),
-            Kvaerno3(), KenCarp3(),
-            Cash4(), Hairer4(), Hairer42(), Kvaerno4(), KenCarp4(),
-            Kvaerno5(), KenCarp5()]
+const prob_ip = prob_dde_constant_1delay_ip
+const prob_scalar = prob_dde_constant_1delay_scalar
 
-    @testset for alg in algs
-        @show alg
-        stepsalg = MethodOfSteps(alg)
-        solve(prob_inplace, stepsalg)
-        solve(prob_notinplace, stepsalg)
-    end
+# ODE algorithms
+const algs = [GenericImplicitEuler(), GenericTrapezoid(),
+              ImplicitEuler(), ImplicitMidpoint(), Trapezoid(),
+              TRBDF2(), SDIRK2(), SSPSDIRK2(),
+              Kvaerno3(), KenCarp3(),
+              Cash4(), Hairer4(), Hairer42(), Kvaerno4(), KenCarp4(),
+              Kvaerno5(), KenCarp5()]
+
+@testset "Algorithm $(nameof(typeof(alg)))" for alg in algs
+  println(nameof(typeof(alg)))
+
+  stepsalg = MethodOfSteps(alg)
+  sol_ip = solve(prob_ip, stepsalg)
+  sol_scalar = solve(prob_scalar, stepsalg)
+
+  @test sol_ip.t ≈ sol_scalar.t && sol_ip[1, :] ≈ sol_scalar.u
 end

--- a/test/unconstrained.jl
+++ b/test/unconstrained.jl
@@ -1,122 +1,116 @@
 include("common.jl")
-@testset "Unconstrained time step" begin
-    # Check that numerical solutions approximate analytical solutions,
-    # independent of problem structure
-    @testset "standard history" begin
-        # standard algorithm
-        alg = MethodOfSteps(BS3(); constrained=false)
 
-        # different tolerances
-        alg1 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
-                             fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
-        alg2 = MethodOfSteps(DP8(), constrained=false, max_fixedpoint_iters=10,
-                             fixedpoint_abstol=1e-8, fixedpoint_reltol=1e-10)
-        alg3 = MethodOfSteps(Tsit5(), constrained=true, max_fixedpoint_iters=10,
-                             fixedpoint_abstol=1e-8, fixedpoint_reltol=1e-10)
-        alg4 = MethodOfSteps(DP5(), constrained=false, max_fixedpoint_iters=100,
-                             fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
+# Check that numerical solutions approximate analytical solutions,
+# independent of problem structure
 
-        ## Single constant delay
-        @testset "single constant delay" begin
-            @testset "short time span" begin
-                ### Not in-place function with scalar history function
-                prob = prob_dde_1delay_scalar_notinplace
-                sol = solve(prob, alg)
+@testset "standard history" begin
+  # standard algorithm
+  alg = MethodOfSteps(BS3(); constrained=false)
 
-                @test sol.errors[:l∞] < 3.0e-5
-                @test sol.errors[:final] < 2.1e-5
-                @test sol.errors[:l2] < 1.2e-5
+  # different tolerances
+  alg1 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                       fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
+  alg2 = MethodOfSteps(DP8(), constrained=false, max_fixedpoint_iters=10,
+                       fixedpoint_abstol=1e-8, fixedpoint_reltol=1e-10)
+  alg3 = MethodOfSteps(Tsit5(), constrained=true, max_fixedpoint_iters=10,
+                       fixedpoint_abstol=1e-8, fixedpoint_reltol=1e-10)
+  alg4 = MethodOfSteps(DP5(), constrained=false, max_fixedpoint_iters=100,
+                       fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
 
-                ### Not in-place function with vectorized history function
-                prob = prob_dde_1delay_notinplace
-                sol2 = solve(prob, alg)
+  ## Single constant delay
+  @testset "single constant delay" begin
+    @testset "short time span" begin
+      ### Scalar function
+      sol_scalar = solve(prob_dde_constant_1delay_scalar, alg)
 
-                @test sol.t ≈ sol2.t && sol.u ≈ sol2[1, :]
+      @test sol_scalar.errors[:l∞] < 3.0e-5
+      @test sol_scalar.errors[:final] < 2.1e-5
+      @test sol_scalar.errors[:l2] < 1.2e-5
 
-                ### In-place function
-                prob = prob_dde_1delay
-                sol2 = solve(prob, alg)
+      ### Out-of-place function
+      sol_oop = solve(prob_dde_constant_1delay_oop, alg)
 
-                @test sol.t ≈ sol2.t && sol.u ≈ sol2[1, :]
-            end
+      @test sol_scalar.t ≈ sol_oop.t && sol_scalar.u ≈ sol_oop[1, :]
 
-            @testset "long time span" begin
-                prob = prob_dde_1delay_long_scalar_notinplace
+      ### In-place function
+      sol_ip = solve(prob_dde_constant_1delay_ip, alg)
 
-                sol1 = solve(prob, alg1)
-                sol2 = solve(prob, alg2)
-                sol3 = solve(prob, alg3)
-                sol4 = solve(prob, alg4)
-
-                @test abs(sol1[end] - sol2[end]) < 5.3e-4
-                @test abs(sol1[end] - sol3[end]) < 1.1e-8
-                @test abs(sol1[end] - sol4[end]) < 2.9e-4
-            end
-        end
-
-        ## Two constant delays
-        @testset "two constant delays" begin
-            @testset "short time span" begin
-                ### Not in-place function with scalar history function
-                prob = prob_dde_2delays_scalar_notinplace
-                sol = solve(prob, alg)
-
-                @test sol.errors[:l∞] < 2.5e-6
-                @test sol.errors[:final] < 2.2e-6
-                @test sol.errors[:l2] < 1.2e-6
-
-                ### Not in-place function with vectorized history function
-                prob = prob_dde_2delays_notinplace
-                sol2 = solve(prob, alg)
-
-                @test sol.t ≈ sol2.t && sol.u ≈ sol2[1, :]
-
-                ### In-place function
-                prob = prob_dde_2delays
-                sol2 = solve(prob, alg)
-
-                @test sol.t ≈ sol2.t && sol.u ≈ sol2[1, :]
-            end
-
-            @testset "long time span" begin
-                prob = prob_dde_2delays_long_scalar_notinplace
-
-                sol1 = solve(prob, alg1)
-                # sol2 = solve(prob, alg) # aborted because of dt <= dtmin
-                sol3 = solve(prob, alg3)
-                sol4 = solve(prob, alg4)
-
-                # relaxed tests to prevent floating point issues
-                @test abs(sol1[end] - sol3[end]) < 7.9e-13 # 7.9e-15
-                @test abs(sol1[end] - sol4[end]) < 1.6e-12 # 1.6e-14
-            end
-        end
+      @test sol_scalar.t ≈ sol_ip.t && sol_scalar.u ≈ sol_ip[1, :]
     end
 
-    ## Non-standard history functions
-    @testset "non-standard history" begin
-        alg = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
-                            fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
+    @testset "long time span" begin
+      prob = prob_dde_constant_1delay_long_scalar
 
-        @testset "idxs" begin
-            function f(du,u,h,p,t)
-                du[1] = -h(p, t-0.2;idxs=1) + u[1]
-            end
-            h(p, t; idxs=nothing) = typeof(idxs) <: Number ? 0.0 : [0.0]
+      sol1 = solve(prob, alg1)
+      sol2 = solve(prob, alg2)
+      sol3 = solve(prob, alg3)
+      sol4 = solve(prob, alg4)
 
-            prob = DDEProblem(f, [1.0], h, (0.0, 100.), constant_lags = [0.2])
-            solve(prob, alg)
-        end
-
-        @testset "in-place" begin
-            function f(du,u,h,p,t)
-                h(du, p, t-0.2)
-                du[1] = -du[1] + u[1]
-            end
-            h(val, p, t) = (val .= 0.0)
-
-            prob = DDEProblem(f, [1.0], h, (0.0, 100.0), constant_lags = [0.2])
-            solve(prob, alg)
-        end
+      @test abs(sol1[end] - sol2[end]) < 5.3e-4
+      @test abs(sol1[end] - sol3[end]) < 1.1e-8
+      @test abs(sol1[end] - sol4[end]) < 2.9e-4
     end
+  end
+
+  ## Two constant delays
+  @testset "two constant delays" begin
+    @testset "short time span" begin
+      ### Scalar function
+      sol_scalar = solve(prob_dde_constant_2delays_scalar, alg)
+
+      @test sol_scalar.errors[:l∞] < 2.5e-6
+      @test sol_scalar.errors[:final] < 2.2e-6
+      @test sol_scalar.errors[:l2] < 1.2e-6
+
+      ### Out-of-place function
+      sol_oop = solve(prob_dde_constant_2delays_oop, alg)
+
+      @test sol_scalar.t ≈ sol_oop.t && sol_scalar.u ≈ sol_oop[1, :]
+
+      ### In-place function
+      sol_ip = solve(prob_dde_constant_2delays_ip, alg)
+
+      @test sol_scalar.t ≈ sol_ip.t && sol_scalar.u ≈ sol_ip[1, :]
+    end
+
+    @testset "long time span" begin
+      prob = prob_dde_constant_2delays_long_scalar
+
+      sol1 = solve(prob, alg1)
+      # sol2 = solve(prob, alg) # aborted because of dt <= dtmin
+      sol3 = solve(prob, alg3)
+      sol4 = solve(prob, alg4)
+
+      # relaxed tests to prevent floating point issues
+      @test abs(sol1[end] - sol3[end]) < 7.9e-13 # 7.9e-15
+      @test abs(sol1[end] - sol4[end]) < 1.6e-12 # 1.6e-14
+    end
+  end
+end
+
+## Non-standard history functions
+@testset "non-standard history" begin
+  alg = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                      fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
+
+  @testset "idxs" begin
+    function f(du,u,h,p,t)
+      du[1] = -h(p, t-0.2;idxs=1) + u[1]
+    end
+    h(p, t; idxs=nothing) = typeof(idxs) <: Number ? 0.0 : [0.0]
+
+    prob = DDEProblem(f, [1.0], h, (0.0, 100.), constant_lags = [0.2])
+    solve(prob, alg)
+  end
+
+  @testset "in-place" begin
+    function f(du,u,h,p,t)
+      h(du, p, t-0.2)
+      du[1] = -du[1] + u[1]
+    end
+    h(val, p, t) = (val .= 0.0)
+
+    prob = DDEProblem(f, [1.0], h, (0.0, 100.0), constant_lags = [0.2])
+    solve(prob, alg)
+  end
 end

--- a/test/unique_times.jl
+++ b/test/unique_times.jl
@@ -1,11 +1,8 @@
 include("common.jl")
-@testset "Unique times" begin
-    prob = prob_dde_1delay_long
 
-    @testset for constrained in (false, true)
-        alg = MethodOfSteps(Tsit5(), constrained=constrained)
-        sol = solve(prob, alg)
+@testset for constrained in (false, true)
+  sol = solve(prob_dde_constant_1delay_long_ip,
+              MethodOfSteps(Tsit5(), constrained=constrained))
 
-        @test allunique(sol.t)
-    end
+  @test allunique(sol.t)
 end

--- a/test/units.jl
+++ b/test/units.jl
@@ -1,49 +1,52 @@
 include("common.jl")
+using DiffEqProblemLibrary.DDEProblemLibrary: remake_dde_constant_u0_tType
 using Unitful
 
-@testset "Units" begin
-    prob_notinplace =
-        DiffEqProblemLibrary.DDEProblemLibrary.build_prob_dde_1delay_long_scalar_notinplace(1.0u"N", 1.0u"s")
-    prob_inplace = DiffEqProblemLibrary.DDEProblemLibrary.build_prob_dde_1delay_long(1.0u"N", 1.0u"s")
+const probs =
+  Dict(true => remake_dde_constant_u0_tType(prob_dde_constant_1delay_long_ip, [1.0u"N"],
+                                            typeof(1.0u"s")),
+       false => remake_dde_constant_u0_tType(prob_dde_constant_1delay_long_scalar, 1.0u"N",
+                                             typeof(1.0u"s")))
 
-    @testset for prob in (prob_notinplace, prob_inplace)
-        @testset "correct" begin
-            # default tolerances
-            alg1 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100)
-            sol1 = solve(prob, alg1)
+@testset for inplace in (true, false)
+  prob = probs[inplace]
 
-            # with correct units
-            alg2 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
-                                 fixedpoint_abstol=1e-6u"N", fixedpoint_reltol=1e-3u"N")
-            sol2 = solve(prob, alg2)
+  @testset "correct" begin
+    # default tolerances
+    alg1 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100)
+    sol1 = solve(prob, alg1)
 
-            @test sol1.t == sol2.t && sol1.u == sol2.u
+    # with correct units
+    alg2 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                         fixedpoint_abstol=1e-6u"N", fixedpoint_reltol=1e-3u"N")
+    sol2 = solve(prob, alg2)
 
-            # with correct units as vectors
-            if typeof(prob.u0) <: AbstractArray
-                alg3 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
-                                     fixedpoint_abstol=[1e-6u"N"], fixedpoint_reltol=[1e-3u"N"])
-                sol3 = solve(prob, alg3)
+    @test sol1.t == sol2.t && sol1.u == sol2.u
 
-                @test sol1.t == sol3.t && sol1.u == sol3.u
-            end
-        end
+    # with correct units as vectors
+    if inplace
+      alg3 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                           fixedpoint_abstol=[1e-6u"N"], fixedpoint_reltol=[1e-3u"N"])
+      sol3 = solve(prob, alg3)
 
-        @testset "incorrect" begin
-            # without units
-            alg1 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
-                                 fixedpoint_abstol=1e-6, fixedpoint_reltol=1e-3)
-            @test_throws Unitful.DimensionError solve(prob, alg1)
-
-            # with incorrect units for absolute tolerance
-            alg2 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
-                                fixedpoint_abstol=1e-6u"s", fixedpoint_reltol=1e-3u"N")
-            @test_throws Unitful.DimensionError solve(prob, alg2)
-
-            # with incorrect units for relative tolerance
-            alg3 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
-                                fixedpoint_abstol=1e-6u"N", fixedpoint_reltol=1e-3u"s")
-            @test_throws Unitful.DimensionError solve(prob, alg3)
-        end
+      @test sol1.t == sol3.t && sol1.u == sol3.u
     end
+  end
+
+  @testset "incorrect" begin
+    # without units
+    alg1 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                         fixedpoint_abstol=1e-6, fixedpoint_reltol=1e-3)
+    @test_throws Unitful.DimensionError solve(prob, alg1)
+
+    # with incorrect units for absolute tolerance
+    alg2 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                         fixedpoint_abstol=1e-6u"s", fixedpoint_reltol=1e-3u"N")
+    @test_throws Unitful.DimensionError solve(prob, alg2)
+
+    # with incorrect units for relative tolerance
+    alg3 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
+                         fixedpoint_abstol=1e-6u"N", fixedpoint_reltol=1e-3u"s")
+    @test_throws Unitful.DimensionError solve(prob, alg3)
+  end
 end


### PR DESCRIPTION
This PR gets rid of the deprecation warnings introduced by DiffEqProblemLibrary 4.2.0 (tests on Travis fail since it's not registered yet) and uses SafeTestsets.

BTW, with the updated DDE problems Vern8 tests do not fail anymore. 