### PR TITLE
Remove initial_order

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 
 [compat]
 DataStructures = "≥ 0.4.6"
-DiffEqBase = "≥ 5.12.0"
+DiffEqBase = "≥ 5.13.0"
 DiffEqDiffTools = "≥ 0.3.0"
 DiffEqProblemLibrary = "≥ 4.3.0"
 NLSolversBase = "≥ 4.2.0"

--- a/src/integrators/interface.jl
+++ b/src/integrators/interface.jl
@@ -309,7 +309,7 @@ function reinit!(integrator::DDEIntegrator, u0 = integrator.sol.prob.u0;
                  tstops = integrator.opts.tstops_cache,
                  saveat = integrator.opts.saveat_cache,
                  d_discontinuities = integrator.opts.d_discontinuities_cache,
-                 initial_order = agrees(integrator.sol.prob.h, u0, integrator.sol.prob.p, t0) ? 1 : 0,
+                 order_discontinuity_t0 = t0 == integrator.sol.prob.tspan[1] && u0 == integrator.sol.prob.u0 ? integrator.sol.prob.order_discontinuity_t0 : 0,
                  reset_dt = iszero(integrator.dtcache) && integrator.opts.adaptive,
                  reinit_callbacks = true, initialize_save = true,
                  reinit_cache = true)
@@ -344,7 +344,7 @@ function reinit!(integrator::DDEIntegrator, u0 = integrator.sol.prob.u0;
     # reinit time stops, time points at which solution is saved, and discontinuities
     integrator.opts.tstops, integrator.opts.saveat, integrator.opts.d_discontinuities =
         tstop_saveat_disc_handling(tstops, saveat, d_discontinuities, integrator.tdir,
-                                   (t0,tf), initial_order, alg_maximum_order(integrator.alg),
+                                   (t0,tf), order_discontinuity_t0, alg_maximum_order(integrator.alg),
                                    integrator.sol.prob.constant_lags, typeof(integrator.t))
 
     # copy time points at which solution is saved if solution should be
@@ -355,9 +355,9 @@ function reinit!(integrator::DDEIntegrator, u0 = integrator.sol.prob.u0;
 
     if erase_sol
         # erase array of tracked discontinuities
-        if initial_order ≤ alg_maximum_order(integrator.alg)
+        if order_discontinuity_t0 ≤ alg_maximum_order(integrator.alg)
             resize!(integrator.tracked_discontinuities, 1)
-            integrator.tracked_discontinuities[1] = Discontinuity(t0, initial_order)
+            integrator.tracked_discontinuities[1] = Discontinuity(t0, order_discontinuity_t0)
         else
             resize!(integrator.tracked_discontinuities, 0)
         end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,27 +1,4 @@
 """
-    agrees(h, u, p, t)
-
-Determine whether history function evaluates to `u` at time point `t`
-for parameters `p`.
-"""
-function agrees(h, u, p, t)
-    # Obtain signatures of h
-    sigs = [m.sig for m in methods(h)]
-
-    # Compare evaluation of h at time point t with u
-    if any(sig<:Tuple{Any, Any, Any} for sig in sigs)
-        return h(p, t) == u
-    elseif any(sig<:Tuple{Any, Any, Any, Any} for sig in sigs)
-        val = recursivecopy(u)
-        h(val, p, t)
-        return val == u
-    end
-
-    return false
-end
-
-
-"""
     fsal_typeof(integrator::ODEIntegrator)
 
 Return type of FSAL of `integrator`.

--- a/test/history_function.jl
+++ b/test/history_function.jl
@@ -19,11 +19,6 @@ end
     end
   end
 
-  @testset "agrees (h=$h)" for h in (h_notinplace, h_inplace)
-    @test DelayDiffEq.agrees(h, zeros(2), nothing, 0)
-    @test !DelayDiffEq.agrees(h, ones(2), nothing, 1)
-  end
-
   # ODE integrator
   prob = ODEProblem((du,u,p,t)->@.(du=p*u), ones(2), (0.0, 1.0),1.01)
   integrator = init(prob, Tsit5())

--- a/test/parameters.jl
+++ b/test/parameters.jl
@@ -6,27 +6,28 @@ include("common.jl")
 f_inplace(du, u, h, p, t) = (du[1] = p[1] * u[1] * (1 - h(p, t-1; idxs = 1)))
 f_scalar(u, h, p, t) = p[1] * u * (1 - h(p, t-1))
 
-# simple history function (simplicity here comes at a price, see below)
+# simple history function
 h(p, t; idxs=nothing) = 0.1
 
 @testset for inplace in (true, false)
   # define problem
+  # we specify order_discontinuity_t0 = 1 to indicate that the discontinuity at
+  # t = 0 is of first order
   prob = DDEProblem(inplace ? f_inplace : f_scalar,
                     inplace ? [0.1] : 0.1,
-                    h, (0.0, 50.0), [0.3]; constant_lags = [1])
+                    h, (0.0, 50.0), [0.3];
+                    constant_lags = [1],
+                    order_discontinuity_t0 = 1)
 
   # solve problem with initial parameter:
-  # since h(p, 0) = u0 holds only in the scalar case we have to specify
-  # initial_order=1 to indicate that the discontinuity at t = 0 is of first
-  # order and to obtain the same results in both cases
-  sol1 = solve(prob, MethodOfSteps(Tsit5()); initial_order = 1)
+  sol1 = solve(prob, MethodOfSteps(Tsit5()))
   @test length(sol1) == 26
   @test first(sol1(12)) ≈ 0.884 atol=1e-4
   @test first(sol1[end]) ≈ 1 atol=1e-5
 
   # solve problem with updated parameter
   prob.p[1] = 1.4
-  sol2 = solve(prob, MethodOfSteps(Tsit5()); initial_order = 1)
+  sol2 = solve(prob, MethodOfSteps(Tsit5()))
   @test length(sol2) == 52
   @test first(sol2(12)) ≈ 1.127 atol=4e-4
   @test first(sol2[end]) ≈ 0.995 atol=3e-4


### PR DESCRIPTION
Deprecates the use of the keyword argument `initial_order`.

Requires https://github.com/JuliaDiffEq/DiffEqBase.jl/pull/270.