### PR TITLE
WIP: Fix for nlsolver changes

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -169,7 +169,7 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractDDEProblem,
         dde_cache = OrdinaryDiffEq.CompositeCache(caches, alg.alg.choice_function, 1)
     else
         dde_cache = build_linked_cache(integrator.cache, alg.alg, u, uprev, uprev2, dde_f,
-                                       tspan[1], dt, p)
+                                       tspan[1], dt, p, uEltypeNoUnits)
     end
 
     # filter provided discontinuities

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -164,7 +164,7 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractDDEProblem,
     # new cache with updated u, uprev, uprev2, and function f
     if typeof(alg.alg) <: OrdinaryDiffEq.OrdinaryDiffEqCompositeAlgorithm
         caches = map((x,y) -> build_linked_cache(x, y, u, uprev, uprev2, dde_f,
-                                                 tspan[1], dt, p),
+                                                 tspan[1], dt, p, uEltypeNoUnits),
                      integrator.cache.caches, alg.alg.algs)
         dde_cache = OrdinaryDiffEq.CompositeCache(caches, alg.alg.choice_function, 1)
     else


### PR DESCRIPTION
Test case:

```julia
using DelayDiffEq, Test
using DiffEqProblemLibrary.DDEProblemLibrary

DDEProblemLibrary.importddeproblems()

using DiffEqProblemLibrary.DDEProblemLibrary:
  # DDE problems with 1 constant delay
  prob_dde_constant_1delay_ip, prob_dde_constant_1delay_oop, prob_dde_constant_1delay_scalar,
  prob_dde_constant_1delay_long_ip, prob_dde_constant_1delay_long_oop, prob_dde_constant_1delay_long_scalar,
  # DDE problems with 2 constant delays
  prob_dde_constant_2delays_ip, prob_dde_constant_2delays_oop, prob_dde_constant_2delays_scalar,
  prob_dde_constant_2delays_long_ip, prob_dde_constant_2delays_long_oop, prob_dde_constant_2delays_long_scalar,
  # Mackey-Glass equation (model of blood production) with 1 constant delay
  prob_dde_DDETST_A1

const prob_ip = prob_dde_constant_1delay_ip
const prob_scalar = prob_dde_constant_1delay_scalar
const ts = 0:0.1:10

alg = ImplicitEuler()
println(nameof(typeof(alg)))

stepsalg = MethodOfSteps(alg)
sol_ip = solve(prob_ip, stepsalg)
sol_scalar = solve(prob_scalar, stepsalg, reltol=1e-6)

@test sol_ip(ts, idxs=1) ≈ sol_scalar(ts)
@test sol_ip.t ≈ sol_scalar.t && sol_ip[1, :] ≈ sol_scalar.u

using Plots
plot(sol_ip)
plot!(sol_scalar)
```

The big change that occurred is that now instead of using a pure macro-based creation of the nonlinear solvers https://github.com/JuliaDiffEq/DiffEqBase.jl/blob/master/src/nlsolve/utils.jl#L98 , we now have proper constructors: https://github.com/JuliaDiffEq/DiffEqBase.jl/blob/master/src/nlsolve/utils.jl#L237 . So we just need to make these two things not alias. I almost have it, but for some reason it's only slightly off now.