### PR TITLE
Remove isout hack

### DIFF
--- a/src/history_function.jl
+++ b/src/history_function.jl
@@ -1,80 +1,94 @@
 """
-    HistoryFunction(h, sol, integrator)
+    HistoryFunction(h, integrator)
 
-Wrap history function `h`, solution `sol`, and integrator `integrator` to create a common
+Wrap history function `h` and integrator `integrator` to create a common
 interface for retrieving values at any time point with varying accuracy.
 
-Before the initial time point of solution `sol` values are calculated by history function
-`h`, for time points in the time span of `sol` interpolated values of `sol` are returned,
-and after the final time point of `sol` an inter- or extrapolation of the current state
-of integrator `integrator` is retrieved.
+Before the initial time point of the solution of the `integrator` values are calculated by
+history function `h`, for time points up to the final time point of the solution
+interpolated values of the solution are returned, and after the final time point an inter-
+or extrapolation of the current state of the `integrator` is retrieved.
 """
-struct HistoryFunction{F1,F2,F3<:ODEIntegrator} <: Function
-    h::F1
-    sol::F2
-    integrator::F3
+mutable struct HistoryFunction{H,I<:ODEIntegrator} <: Function
+  h::H
+  integrator::I
+  isout::Bool
 end
 
+HistoryFunction(h, integrator) = HistoryFunction(h, integrator, false)
+
 function (f::HistoryFunction)(p, t, ::Type{Val{deriv}}=Val{0}; idxs=nothing) where deriv
-    integrator = f.integrator
+  @unpack integrator = f
+  @unpack sol = integrator
 
-    @inbounds if integrator.tdir * t < integrator.tdir * f.sol.t[1]
-        if deriv == 0 && idxs === nothing
-            return f.h(p, t)
-        elseif idxs === nothing
-            return f.h(p, t, Val{deriv})
-        elseif deriv == 0
-            return f.h(p, t; idxs = idxs)
-        else
-            return f.h(p, t, Val{deriv}; idxs = idxs)
-        end
-    elseif integrator.tdir * t <= integrator.tdir * f.sol.t[end] # Put equals back
-        return f.sol.interp(t, idxs, Val{deriv}, f.integrator.p)
-    end
+  @inbounds if integrator.tdir * t < integrator.tdir * sol.t[1]
+    # history function is not evaluated at a time point past the final time point of
+    # the current solution
+    f.isout = false
 
-    # set boolean that indicates that history function was evaluated at time point past the
-    # final time point of the current solution
-    # NOTE: does not interfere with usual use of isout since this integrator is only used
-    # for inter- and extrapolation of future values and saving of the solution but does not
-    # affect whether time steps are accepted
-    integrator.isout = true
-
-    # handle extrapolations at initial time point
-    if integrator.t == integrator.sol.prob.tspan[1]
-        return constant_extrapolant(t, integrator, idxs, Val{deriv})
+    if deriv == 0 && idxs === nothing
+      return f.h(p, t)
+    elseif idxs === nothing
+      return f.h(p, t, Val{deriv})
+    elseif deriv == 0
+      return f.h(p, t; idxs = idxs)
     else
-        return OrdinaryDiffEq.current_interpolant(t, integrator, idxs, Val{deriv})
+      return f.h(p, t, Val{deriv}; idxs = idxs)
     end
+  elseif integrator.tdir * t <= integrator.tdir * sol.t[end] # Put equals back
+    # history function is not evaluated at a time point past the final time point of
+    # the current solution
+    f.isout = false
+
+    return sol.interp(t, idxs, Val{deriv}, f.integrator.p)
+  end
+
+  # history function is evaluated at time point past the final time point of
+  # the current solution
+  f.isout = true
+
+  # handle extrapolations at initial time point
+  if integrator.t == sol.prob.tspan[1]
+    return constant_extrapolant(t, integrator, idxs, Val{deriv})
+  else
+    return OrdinaryDiffEq.current_interpolant(t, integrator, idxs, Val{deriv})
+  end
 end
 
 function (f::HistoryFunction)(val, p, t, ::Type{Val{deriv}}=Val{0}; idxs=nothing) where deriv
-    integrator = f.integrator
+  @unpack integrator = f
+  @unpack sol = integrator
 
-    @inbounds if integrator.tdir * t < integrator.tdir * f.sol.t[1]
-        if deriv == 0 && idxs === nothing
-            return f.h(val, p, t)
-        elseif idxs === nothing
-            return f.h(val, p, t, Val{deriv})
-        elseif deriv == 0
-            return f.h(val, p, t; idxs = idxs)
-        else
-            return f.h(val, p, t, Val{deriv}; idxs = idxs)
-        end
-    elseif integrator.tdir * t <= integrator.tdir * f.sol.t[end] # Put equals back
-        return f.sol.interp(val, t, idxs, Val{deriv}, f.integrator.p)
-    end
+  @inbounds if integrator.tdir * t < integrator.tdir * sol.t[1]
+    # history function is not evaluated at a time point past the final time point of
+    # the current solution
+    f.isout = false
 
-    # set boolean that indicates that history function was evaluated at time point past the
-    # final time point of the current solution
-    # NOTE: does not interfere with usual use of isout since this integrator is only used
-    # for inter- and extrapolation of future values and saving of the solution but does not
-    # affect whether time steps are accepted
-    integrator.isout = true
-
-    # handle extrapolations at initial time point
-    if integrator.t == integrator.sol.prob.tspan[1]
-        return constant_extrapolant!(val, t, integrator, idxs, Val{deriv})
+    if deriv == 0 && idxs === nothing
+      return f.h(val, p, t)
+    elseif idxs === nothing
+      return f.h(val, p, t, Val{deriv})
+    elseif deriv == 0
+      return f.h(val, p, t; idxs = idxs)
     else
-        return OrdinaryDiffEq.current_interpolant!(val, t, f.integrator, idxs, Val{deriv})
+      return f.h(val, p, t, Val{deriv}; idxs = idxs)
     end
+  elseif integrator.tdir * t <= integrator.tdir * sol.t[end] # Put equals back
+    # history function is not evaluated at a time point past the final time point of
+    # the current solution
+    f.isout = false
+
+    return sol.interp(val, t, idxs, Val{deriv}, f.integrator.p)
+  end
+
+  # history function is evaluated at a time point past the final time point of
+  # the current solution
+  f.isout = true
+
+  # handle extrapolations at initial time point
+  if integrator.t == sol.prob.tspan[1]
+    return constant_extrapolant!(val, t, integrator, idxs, Val{deriv})
+  else
+    return OrdinaryDiffEq.current_interpolant!(val, t, f.integrator, idxs, Val{deriv})
+  end
 end

--- a/src/history_function.jl
+++ b/src/history_function.jl
@@ -22,10 +22,6 @@ function (f::HistoryFunction)(p, t, ::Type{Val{deriv}}=Val{0}; idxs=nothing) whe
   @unpack sol = integrator
 
   @inbounds if integrator.tdir * t < integrator.tdir * sol.t[1]
-    # history function is not evaluated at a time point past the final time point of
-    # the current solution
-    f.isout = false
-
     if deriv == 0 && idxs === nothing
       return f.h(p, t)
     elseif idxs === nothing
@@ -36,10 +32,6 @@ function (f::HistoryFunction)(p, t, ::Type{Val{deriv}}=Val{0}; idxs=nothing) whe
       return f.h(p, t, Val{deriv}; idxs = idxs)
     end
   elseif integrator.tdir * t <= integrator.tdir * sol.t[end] # Put equals back
-    # history function is not evaluated at a time point past the final time point of
-    # the current solution
-    f.isout = false
-
     return sol.interp(t, idxs, Val{deriv}, f.integrator.p)
   end
 
@@ -60,10 +52,6 @@ function (f::HistoryFunction)(val, p, t, ::Type{Val{deriv}}=Val{0}; idxs=nothing
   @unpack sol = integrator
 
   @inbounds if integrator.tdir * t < integrator.tdir * sol.t[1]
-    # history function is not evaluated at a time point past the final time point of
-    # the current solution
-    f.isout = false
-
     if deriv == 0 && idxs === nothing
       return f.h(val, p, t)
     elseif idxs === nothing
@@ -74,10 +62,6 @@ function (f::HistoryFunction)(val, p, t, ::Type{Val{deriv}}=Val{0}; idxs=nothing
       return f.h(val, p, t, Val{deriv}; idxs = idxs)
     end
   elseif integrator.tdir * t <= integrator.tdir * sol.t[end] # Put equals back
-    # history function is not evaluated at a time point past the final time point of
-    # the current solution
-    f.isout = false
-
     return sol.interp(val, t, idxs, Val{deriv}, f.integrator.p)
   end
 

--- a/src/integrators/interface.jl
+++ b/src/integrators/interface.jl
@@ -82,6 +82,10 @@ function OrdinaryDiffEq.perform_step!(integrator::DDEIntegrator)
   internalnorm = integrator.opts.internalnorm
   prob = integrator.sol.prob
 
+  # reset boolean which indicates if the history function was evaluated at a time point
+  # past the final point of the current solution
+  history.isout = false
+
   # perform always at least one calculation of the stages
   OrdinaryDiffEq.perform_step!(integrator, cache)
 

--- a/src/integrators/interface.jl
+++ b/src/integrators/interface.jl
@@ -76,25 +76,18 @@ end
 
 # perform next integration step
 function OrdinaryDiffEq.perform_step!(integrator::DDEIntegrator)
-  @unpack f, t, p, k, uprev, dt, resid, alg, cache, max_fixedpoint_iters = integrator
+  @unpack f, t, p, k, uprev, dt, resid, alg, cache, history, max_fixedpoint_iters = integrator
   @unpack fixedpoint_abstol, fixedpoint_reltol, fixedpoint_norm = integrator
   ode_integrator = integrator.integrator
   internalnorm = integrator.opts.internalnorm
   prob = integrator.sol.prob
-
-  # reset boolean which indicates whether history function was evaluated at a time point
-  # past the final point of the current solution
-  # NOTE: does not interfere with usual use of isout since ODE integrator is only used for
-  # inter- and extrapolation of future values and saving of the solution but does not
-  # affect whether time steps are accepted
-  ode_integrator.isout = false
 
   # perform always at least one calculation of the stages
   OrdinaryDiffEq.perform_step!(integrator, cache)
 
   # if the history function was evaluated at time points past the final time point of the
   # solution, i.e. returned extrapolated values, continue with a fixed-point iteration
-  if ode_integrator.isout
+  if history.isout
     # update ODE integrator to next time interval together with correct interpolation
     advance_ode_integrator!(integrator)
 

--- a/src/integrators/type.jl
+++ b/src/integrators/type.jl
@@ -1,7 +1,7 @@
 mutable struct DDEIntegrator{algType,IIP,uType,tType,P,eigenType,absType,relType,
                              residType,tTypeNoUnits,tdirType,ksEltype,
                              SolType,F,CacheType,
-                             IType,NType,O,dAbsType,dRelType,
+                             IType,NType,O,dAbsType,dRelType,H,
                              FSALType,EventErrorType,CallbackCacheType} <: AbstractDDEIntegrator{algType,IIP,uType,tType}
     sol::SolType
     u::uType
@@ -55,6 +55,7 @@ mutable struct DDEIntegrator{algType,IIP,uType,tType,P,eigenType,absType,relType
     u_modified::Bool
     opts::O
     destats::DiffEqBase.DEStats
+    history::H
     integrator::IType
     fsalfirst::FSALType
     fsallast::FSALType
@@ -63,7 +64,7 @@ mutable struct DDEIntegrator{algType,IIP,uType,tType,P,eigenType,absType,relType
     function DDEIntegrator{algType,IIP,uType,tType,P,eigenType,absType,relType,
                            residType,tTypeNoUnits,
                            tdirType,ksEltype,SolType,F,CacheType,IType,
-                           NType,O,dAbsType,dRelType,FSALType,EventErrorType,
+                           NType,O,dAbsType,dRelType,H,FSALType,EventErrorType,
                            CallbackCacheType}(
                                sol,u,k,t,dt,f,p,uprev,uprev2,tprev,prev_idx,prev2_idx,
                                fixedpoint_abstol,fixedpoint_reltol,resid,fixedpoint_norm,
@@ -74,15 +75,15 @@ mutable struct DDEIntegrator{algType,IIP,uType,tType,P,eigenType,absType,relType
                                cache,callback_cache,kshortsize,force_stepfail,last_stepfail,
                                just_hit_tstop,event_last_time,vector_event_last_time,last_event_error,
                                accept_step,isout,reeval_fsal,u_modified,opts,destats,
-                               integrator) where
+                               history,integrator) where
         {algType,IIP,uType,tType,P,eigenType,absType,relType,residType,tTypeNoUnits,
          tdirType,ksEltype,SolType,F,CacheType,IType,NType,O,
-         dAbsType,dRelType,FSALType,EventErrorType,CallbackCacheType}
+         dAbsType,dRelType,H,FSALType,EventErrorType,CallbackCacheType}
 
         new{algType,IIP,uType,tType,P,eigenType,absType,relType,
                                residType,tTypeNoUnits,
                                tdirType,ksEltype,SolType,F,CacheType,IType,
-                               NType,O,dAbsType,dRelType,
+                               NType,O,dAbsType,dRelType,H,
                                FSALType,EventErrorType,CallbackCacheType}(
             sol,u,k,t,dt,f,p,uprev,uprev2,tprev,prev_idx,prev2_idx,fixedpoint_abstol,
             fixedpoint_reltol,resid,fixedpoint_norm,max_fixedpoint_iters,
@@ -91,7 +92,7 @@ mutable struct DDEIntegrator{algType,IIP,uType,tType,P,eigenType,absType,relType
             eigen_est,EEst,qold,q11,erracc,dtacc,success_iter,iter,saveiter,saveiter_dense,
             cache,callback_cache,kshortsize,force_stepfail,last_stepfail,just_hit_tstop,
             event_last_time,vector_event_last_time,last_event_error,accept_step,isout,
-            reeval_fsal,u_modified,opts,destats,integrator)
+            reeval_fsal,u_modified,opts,destats,history,integrator)
     end
 end
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -94,7 +94,7 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractDDEProblem,
   # we use this history information to create a problem function of the DDE with all
   # available history information that is of the form f(du,u,p,t) or f(u,p,t) such that
   # ODE algorithms can be applied
-  history = HistoryFunction(h, ode_integrator.sol, ode_integrator)
+  history = HistoryFunction(h, ode_integrator)
   f_with_history = ODEFunctionWrapper(f, history)
 
   # get states (possibly different from the ODE integrator!)
@@ -246,7 +246,7 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractDDEProblem,
                              typeof(tdir),typeof(k),typeof(sol),typeof(f_with_history),
                              typeof(cache),typeof(ode_integrator),typeof(fixedpoint_norm),
                              typeof(opts),typeof(discontinuity_abstol),
-                             typeof(discontinuity_reltol),
+                             typeof(discontinuity_reltol),typeof(history),
                              OrdinaryDiffEq.fsal_typeof(alg.alg, rate_prototype),
                              typeof(ode_integrator.last_event_error),
                              typeof(callback_cache)}(
@@ -269,7 +269,8 @@ function DiffEqBase.__init(prob::DiffEqBase.AbstractDDEProblem,
                                ode_integrator.vector_event_last_time,
                                ode_integrator.last_event_error, ode_integrator.accept_step,
                                ode_integrator.isout, ode_integrator.reeval_fsal,
-                               ode_integrator.u_modified, opts, destats, ode_integrator)
+                               ode_integrator.u_modified, opts, destats, history,
+                               ode_integrator)
 
   # initialize DDE integrator
   if initialize_integrator

--- a/test/history_function.jl
+++ b/test/history_function.jl
@@ -25,10 +25,8 @@ end
 
   # combined history function
   history_notinplace = DelayDiffEq.HistoryFunction(h_notinplace,
-                                                   integrator.sol,
                                                    integrator)
   history_inplace = DelayDiffEq.HistoryFunction(h_inplace,
-                                                integrator.sol,
                                                 integrator)
 
   # test evaluation of history function
@@ -58,19 +56,20 @@ end
       (idxs === nothing ? zeros(2) : [0.0])
 
     # out-of-place
-    integrator.isout = false
-    @test history_notinplace(nothing, 1, deriv; idxs = idxs) == trueval &&
-      integrator.isout
+    history_notinplace.isout = false
+    @test history_notinplace(nothing, 1, deriv; idxs = idxs) == trueval
+    @test history_notinplace.isout
 
     # in-place
-    integrator.isout = false
-    @test history_inplace(nothing, nothing, 1, deriv; idxs = idxs) == trueval &&
-      integrator.isout
+    history_inplace.isout = false
+    @test history_inplace(nothing, nothing, 1, deriv; idxs = idxs) == trueval
+    @test history_inplace.isout
 
-    integrator.isout = false
+    history_inplace.isout = false
     val = 1 .- trueval # ensures that val ≠ trueval
     history_inplace(val, nothing, 1, deriv; idxs = idxs)
-    @test val == trueval && integrator.isout
+    @test val == trueval
+    @test history_inplace.isout
   end
 
   # add step to integrator
@@ -89,15 +88,16 @@ end
     trueval = OrdinaryDiffEq.current_interpolant(0.01, integrator, idxs, deriv)
 
     # out-of-place
-    integrator.isout = false
-    @test history_notinplace(nothing, 0.01, deriv; idxs = idxs) == trueval &&
-      integrator.isout
+    history_notinplace.isout = false
+    @test history_notinplace(nothing, 0.01, deriv; idxs = idxs) == trueval
+    @test history_notinplace.isout
 
     # in-place
-    integrator.isout = false
+    history_inplace.isout = false
     val = zero(trueval)
     history_inplace(val, nothing, 0.01, deriv; idxs = idxs)
-    @test val == trueval && integrator.isout
+    @test val == trueval
+    @test history_inplace.isout
   end
 
   # add step to solution
@@ -114,13 +114,14 @@ end
     trueval = integrator.sol.interp(0.01, idxs, deriv, integrator.p)
 
     # out-of-place
-    @test history_notinplace(nothing, 0.01, deriv; idxs = idxs) == trueval &&
-      !integrator.isout
+    @test history_notinplace(nothing, 0.01, deriv; idxs = idxs) == trueval
+    @test !history_notinplace.isout
 
     # in-place
     val = zero(trueval)
     history_inplace(val, nothing, 0.01, deriv; idxs = idxs)
-    @test val == trueval && !integrator.isout
+    @test val == trueval
+    @test !history_inplace.isout
   end
 
   # test integrator extrapolation
@@ -131,14 +132,15 @@ end
     trueval = OrdinaryDiffEq.current_interpolant(1, integrator, idxs, deriv)
 
     # out-of-place
-    integrator.isout = false
-    @test history_notinplace(nothing, 1, deriv; idxs = idxs) == trueval &&
-      integrator.isout
+    history_notinplace.isout = false
+    @test history_notinplace(nothing, 1, deriv; idxs = idxs) == trueval
+    @test history_notinplace.isout
 
     # in-place
-    integrator.isout = false
+    history_inplace.isout = false
     val = zero(trueval)
     history_inplace(val, nothing, 1, deriv; idxs = idxs)
-    @test val == trueval && integrator.isout
+    @test val == trueval
+    @test history_inplace.isout
   end
 end

--- a/test/history_function.jl
+++ b/test/history_function.jl
@@ -114,10 +114,12 @@ end
     trueval = integrator.sol.interp(0.01, idxs, deriv, integrator.p)
 
     # out-of-place
+    history_notinplace.isout = false
     @test history_notinplace(nothing, 0.01, deriv; idxs = idxs) == trueval
     @test !history_notinplace.isout
 
     # in-place
+    history_inplace.isout = false
     val = zero(trueval)
     history_inplace(val, nothing, 0.01, deriv; idxs = idxs)
     @test val == trueval


### PR DESCRIPTION
This PR removes the abuse of `isout` in the dummy integrator and instead keeps track of whether the extended history function is evaluated outside of its domain by updating a field `isout` of the history function itself.