### PR TITLE
Add fixed-point solver

### DIFF
--- a/src/DelayDiffEq.jl
+++ b/src/DelayDiffEq.jl
@@ -17,11 +17,18 @@ using DiffEqBase: AbstractDDEAlgorithm, AbstractDDEIntegrator, AbstractODEIntegr
 
 using OrdinaryDiffEq: GenericImplicitEulerCache, GenericTrapezoidCache, RosenbrockMutableCache
 
+export Discontinuity, MethodOfSteps
+
+export FPFunctional
+
 include("discontinuity_type.jl")
 include("functionwrapper.jl")
 include("integrators/type.jl")
 include("integrators/utils.jl")
 include("integrators/interface.jl")
+include("fpsolve/type.jl")
+include("fpsolve/utils.jl")
+include("fpsolve/functional.jl")
 include("cache_utils.jl")
 include("interpolants.jl")
 include("history_function.jl")
@@ -30,7 +37,5 @@ include("track.jl")
 include("alg_utils.jl")
 include("solve.jl")
 include("utils.jl")
-
-export Discontinuity, MethodOfSteps
 
 end # module

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -1,41 +1,21 @@
 abstract type DelayDiffEqAlgorithm <: AbstractDDEAlgorithm end
 abstract type AbstractMethodOfStepsAlgorithm{constrained} <: DelayDiffEqAlgorithm end
 
-struct MethodOfSteps{algType,AType,RType,NType,constrained} <:
-    AbstractMethodOfStepsAlgorithm{constrained}
-
-    alg::algType
-    fixedpoint_abstol::AType
-    fixedpoint_reltol::RType
-    fixedpoint_norm::NType
-    max_fixedpoint_iters::Int
+struct MethodOfSteps{algType,F,constrained} <: AbstractMethodOfStepsAlgorithm{constrained}
+  alg::algType
+  fpsolve::F
 end
 
 """
-    MethodOfSteps(alg; constrained::Bool=false, fixedpoint_abstol=nothing,
-                  fixedpoint_reltol=nothing, fixedpoint_norm=nothing,
-                  max_fixedpoint_iters::Int=10)
+    MethodOfSteps(alg; constrained = false, fpsolve = FPFunctional())
 
 Construct an algorithm that solves delay differential equations by the method of steps,
-where `alg` is an ODE algorithm from OrdinaryDiffEq.jl without lazy interpolation upon
-which the calculation of steps is based.
+where `alg` is an ODE algorithm from OrdinaryDiffEq.jl upon which the calculation of
+steps is based.
 
 If the algorithm is `constrained` only steps of size at most the minimal delay will be
-taken. If it is unconstrained, fixed-point iteration is applied for step sizes that exceed
-the minimal delay.
-
-The absolute and relative tolerance of the fixed-point iterations can be set by
-`fixedpoint_abstol` and `fixedpoint_reltol`, respectively, either as scalars or vectors.
-Based on these tolerances error estimates are calculated during the fixed-point iterations
-with a norm that may be specified as `fixedpoint_norm`. Fixed-point iterations are stopped
-if the error estimate is less than 1 or after the maximal number `max_fixedpoint_iters` of
-iteration steps.
+taken. If it is unconstrained, fixed-point iteration `fpsolve` is applied for step sizes
+that exceed the minimal delay.
 """
-Base.@pure function MethodOfSteps(alg; constrained::Bool=false, fixedpoint_abstol=nothing,
-                                  fixedpoint_reltol=nothing, fixedpoint_norm=nothing,
-                                  max_fixedpoint_iters::Int=10)
-    MethodOfSteps{typeof(alg),typeof(fixedpoint_abstol),typeof(fixedpoint_reltol),
-                  typeof(fixedpoint_norm),constrained}(alg,fixedpoint_abstol,
-                                                       fixedpoint_reltol,
-                                                       fixedpoint_norm, max_fixedpoint_iters)
-end
+MethodOfSteps(alg; constrained = false, fpsolve = FPFunctional()) =
+  MethodOfSteps{typeof(alg),typeof(fpsolve),constrained}(alg, fpsolve)

--- a/src/fpsolve/functional.jl
+++ b/src/fpsolve/functional.jl
@@ -1,0 +1,151 @@
+function fpsolve!(integrator::DDEIntegrator, fpsolver::FPSolver{<:FPFunctionalConstantCache})
+  @unpack f, t, p, k, uprev, dt, alg, cache = integrator
+  @unpack κ, max_iter = fpsolver
+  ode_integrator = integrator.integrator
+
+  # ODE integrator caches state u at next time point
+  # DDE integrator contains updated state u₊ at next time point
+
+  # precalculations
+  η = fpsolver.ηold
+
+  # update ODE integrator to next time interval together with correct interpolation
+  advance_ode_integrator!(integrator)
+
+  # fixed point iteration
+  local ndu
+  fail_convergence = true
+  iter = 0
+  while iter < max_iter
+    iter += 1
+
+    # calculate next step
+    OrdinaryDiffEq.perform_step!(integrator, integrator.cache, true)
+
+    # compute norm of residuals
+    iter > 1 && (nduprev = ndu)
+    atmp = OrdinaryDiffEq.calculate_residuals(ode_integrator.u, integrator.u,
+                                              integrator.opts.abstol,
+                                              integrator.opts.reltol,
+                                              integrator.opts.internalnorm, t)
+    ndu = integrator.opts.internalnorm(atmp, t)
+
+    # check divergence (not in initial step)
+    if iter > 1
+      θ = ndu / nduprev
+      ( diverge = θ > 1 ) && ( fpsolver.status = Divergence )
+      ( veryslowconvergence = ndu * θ^(max_iter - iter) > κ * (1 - θ) ) && ( fpsolver.status = VerySlowConvergence )
+      if diverge || veryslowconvergence
+        break
+      end
+    end
+
+    # complete interpolation data of DDE integrator for time interval [t, t+dt]
+    # and copy it to ODE integrator
+    # has to be done before updates to ODE integrator, otherwise history function
+    # is incorrect
+    if iscomposite(alg)
+      addsteps!(k, t, uprev, integrator.u, dt, f, p, cache.caches[integrator.cache.current],
+                false, true, true)
+    else
+      addsteps!(k, t, uprev, integrator.u, dt, f, p, cache, false, true, true)
+    end
+    @inbounds for i in 1:length(k)
+      copyat_or_push!(ode_integrator.k, i, k[i])
+    end
+
+    # update state of the dummy ODE solver
+    ode_integrator.u = integrator.u
+
+    # check stopping criterion
+    iter > 1 && (η = θ / (1 - θ))
+    if η * ndu < κ && (iter > 1 || iszero(ndu))
+      # fixed-point iteration converges
+      fpsolver.status = η < fpsolver.fast_convergence_cutoff ? FastConvergence : Convergence
+      fail_convergence = false
+      break
+    end
+  end
+
+  integrator.force_stepfail = fail_convergence || integrator.force_stepfail
+  fpsolver.ηold = η
+  fpsolver.fp_iters = iter
+
+  nothing
+end
+
+function fpsolve!(integrator::DDEIntegrator, fpsolver::FPSolver{<:FPFunctionalCache})
+  @unpack f, t, p, k, uprev, dt, alg = integrator
+  @unpack κ, max_iter, cache = fpsolver
+  @unpack resid = cache
+  ode_integrator = integrator.integrator
+
+  # ODE integrator caches state u at next time point
+  # DDE integrator contains updated state u₊ at next time point
+
+  # precalculations
+  η = fpsolver.ηold
+
+  # update ODE integrator to next time interval together with correct interpolation
+  advance_ode_integrator!(integrator)
+
+  # fixed-point iteration without Newton
+  local ndu
+  fail_convergence = true
+  iter = 0
+  while iter < max_iter
+    iter += 1
+
+    # calculate next step
+    OrdinaryDiffEq.perform_step!(integrator, integrator.cache, true)
+
+    # compute norm of residuals
+    iter > 1 && (nduprev = ndu)
+    OrdinaryDiffEq.calculate_residuals!(resid, ode_integrator.u, integrator.u,
+                                        integrator.opts.abstol, integrator.opts.reltol,
+                                        integrator.opts.internalnorm, t)
+    ndu = integrator.opts.internalnorm(resid, t)
+
+    # check divergence (not in initial step)
+    if iter > 1
+      θ = ndu / nduprev
+      ( diverge = θ > 1 ) && ( fpsolver.status = Divergence )
+      ( veryslowconvergence = ndu * θ^(max_iter - iter) > κ * (1 - θ) ) && ( fpsolver.status = VerySlowConvergence )
+      if diverge || veryslowconvergence
+        break
+      end
+    end
+
+    # complete interpolation data of DDE integrator for time interval [t, t+dt]
+    # and copy it to ODE integrator
+    # has to be done before updates to ODE integrator, otherwise history function
+    # is incorrect
+    if iscomposite(alg)
+      addsteps!(k, t, uprev, integrator.u, dt, f, p, cache.caches[integrator.cache.current],
+                false, true, true)
+    else
+      addsteps!(k, t, uprev, integrator.u, dt, f, p, cache, false, true, true)
+    end
+    @inbounds for i in 1:length(k)
+      copyat_or_push!(ode_integrator.k, i, k[i])
+    end
+
+    # update state of the dummy ODE solver
+    recursivecopy!(ode_integrator.u, integrator.u)
+
+    # check stopping criterion
+    iter > 1 && (η = θ / (1 - θ))
+    if η * ndu < κ && (iter > 1 || iszero(ndu))
+      # fixed-point iteration converges
+      fpsolver.status = η < fpsolver.fast_convergence_cutoff ? FastConvergence : Convergence
+      fail_convergence = false
+      break
+    end
+  end
+
+  integrator.force_stepfail = fail_convergence || integrator.force_stepfail
+  fpsolver.ηold = η
+  fpsolver.fp_iters = iter
+
+  nothing
+end

--- a/src/fpsolve/type.jl
+++ b/src/fpsolve/type.jl
@@ -1,0 +1,40 @@
+abstract type AbstractFPSolverAlgorithm end
+abstract type AbstractFPSolverCache end
+
+@enum FPStatus::Int8 begin
+  FastConvergence     = 2
+  Convergence         = 1
+  SlowConvergence     = 0
+  VerySlowConvergence = -1
+  Divergence          = -2
+end
+
+# solver
+mutable struct FPSolver{C<:AbstractFPSolverCache,uTolType,K,C1}
+  ηold::uTolType
+  κ::K
+  max_iter::Int
+  fp_iters::Int
+  status::FPStatus
+  fast_convergence_cutoff::C1
+  cache::C
+end
+
+struct FPNone end
+
+# algorithms
+struct FPFunctional{K,C} <: AbstractFPSolverAlgorithm
+  κ::K
+  fast_convergence_cutoff::C
+  max_iter::Int
+end
+
+FPFunctional(; κ=1//100, max_iter=10, fast_convergence_cutoff=1//5) =
+  FPFunctional(κ, fast_convergence_cutoff, max_iter)
+
+# caches
+struct FPFunctionalCache{uType} <: AbstractFPSolverCache
+  resid::uType
+end
+
+struct FPFunctionalConstantCache <: AbstractFPSolverCache end

--- a/src/fpsolve/utils.jl
+++ b/src/fpsolve/utils.jl
@@ -1,0 +1,36 @@
+# construct solver for fixed-point iterations
+function fpsolver(alg, u, uEltypeNoUnits, uBottomEltypeNoUnits, ::Val{iip}) where iip
+  # return dummy solver if the algorithm is constrained
+  isconstrained(alg) && return FPNone()
+
+  @unpack κ, fast_convergence_cutoff, max_iter = alg.fpsolve
+
+  uTolType = real(uBottomEltypeNoUnits)
+
+  # create cache
+  if alg.fpsolve isa FPFunctional
+    if iip
+      z = similar(u, uEltypeNoUnits)
+      fpcache = FPFunctionalCache(z)
+    else
+      fpcache = FPFunctionalConstantCache()
+    end
+  end
+
+  # create solver
+  FPSolver{typeof(fpcache),uTolType,typeof(κ),typeof(fast_convergence_cutoff)}(one(uTolType), κ, max_iter, 10000, Convergence, fast_convergence_cutoff, fpcache)
+end
+
+# perform fixed-point iteration
+fpsolve!(integrator::DDEIntegrator) = fpsolve!(integrator, integrator.fpsolver)
+fpsolve!(integrator, ::FPNone) = (@show integrator.t, integrator.tprev, integrator.dt, integrator.integrator.t, integrator.integrator.tprev, integrator.integrator.sol.t; error("Tried to perform fixed-point iteration although the algorithm is constrained. This is strictly forbidden."))
+
+# resize solver for fixed-point iterations
+fpsolve_resize!(integrator::DDEIntegrator, i) =
+  fpsolve_resize!(integrator, integrator.fpsolver, i)
+
+fpsolve_resize!(integrator, fpsolver, i) = nothing
+function fpsolve_resize!(integrator, fpsolver::FPSolver{<:FPFunctionalCache}, i)
+  resize!(fpsolver.cache.resid, i)
+  nothing
+end

--- a/src/integrators/type.jl
+++ b/src/integrators/type.jl
@@ -14,10 +14,8 @@ mutable struct HistoryODEIntegrator{algType,IIP,uType,tType,tdirType,ksEltype,So
   cache::CacheType
 end
 
-mutable struct DDEIntegrator{algType,IIP,uType,tType,P,eigenType,absType,relType,
-                             residType,tTypeNoUnits,tdirType,ksEltype,
-                             SolType,F,CacheType,
-                             IType,NType,O,dAbsType,dRelType,H,
+mutable struct DDEIntegrator{algType,IIP,uType,tType,P,eigenType,tTypeNoUnits,tdirType,
+                             ksEltype,SolType,F,CacheType,IType,FP,O,dAbsType,dRelType,H,
                              FSALType,EventErrorType,CallbackCacheType} <: AbstractDDEIntegrator{algType,IIP,uType,tType}
     sol::SolType
     u::uType
@@ -31,11 +29,7 @@ mutable struct DDEIntegrator{algType,IIP,uType,tType,P,eigenType,absType,relType
     tprev::tType
     prev_idx::Int
     prev2_idx::Int
-    fixedpoint_abstol::absType
-    fixedpoint_reltol::relType
-    resid::residType # This would have to resize for resizing DDE to work
-    fixedpoint_norm::NType
-    max_fixedpoint_iters::Int
+    fpsolver::FP
     order_discontinuity_t0::Int
     tracked_discontinuities::Vector{Discontinuity{tType}}
     discontinuity_interp_points::Int
@@ -77,14 +71,12 @@ mutable struct DDEIntegrator{algType,IIP,uType,tType,P,eigenType,absType,relType
     fsallast::FSALType
 
     # incomplete initialization without fsalfirst and fsallast
-    function DDEIntegrator{algType,IIP,uType,tType,P,eigenType,absType,relType,
-                           residType,tTypeNoUnits,
-                           tdirType,ksEltype,SolType,F,CacheType,IType,
-                           NType,O,dAbsType,dRelType,H,FSALType,EventErrorType,
+    function DDEIntegrator{algType,IIP,uType,tType,P,eigenType,tTypeNoUnits,
+                           tdirType,ksEltype,SolType,F,CacheType,IType,FP,
+                           O,dAbsType,dRelType,H,FSALType,EventErrorType,
                            CallbackCacheType}(
                                sol,u,k,t,dt,f,p,uprev,uprev2,tprev,prev_idx,prev2_idx,
-                               fixedpoint_abstol,fixedpoint_reltol,resid,fixedpoint_norm,
-                               max_fixedpoint_iters,order_discontinuity_t0,tracked_discontinuities,
+                               fpsolver,order_discontinuity_t0,tracked_discontinuities,
                                discontinuity_interp_points,discontinuity_abstol,discontinuity_reltol,
                                alg,dtcache,dtchangeable,dtpropose,tdir,eigen_est,EEst,qold,
                                q11,erracc,dtacc,success_iter,iter,saveiter,saveiter_dense,
@@ -92,17 +84,13 @@ mutable struct DDEIntegrator{algType,IIP,uType,tType,P,eigenType,absType,relType
                                just_hit_tstop,event_last_time,vector_event_last_time,last_event_error,
                                accept_step,isout,reeval_fsal,u_modified,opts,destats,
                                history,integrator) where
-        {algType,IIP,uType,tType,P,eigenType,absType,relType,residType,tTypeNoUnits,
-         tdirType,ksEltype,SolType,F,CacheType,IType,NType,O,
-         dAbsType,dRelType,H,FSALType,EventErrorType,CallbackCacheType}
+      {algType,IIP,uType,tType,P,eigenType,tTypeNoUnits,tdirType,ksEltype,SolType,F,
+       CacheType,IType,FP,O,dAbsType,dRelType,H,FSALType,EventErrorType,CallbackCacheType}
 
-        new{algType,IIP,uType,tType,P,eigenType,absType,relType,
-                               residType,tTypeNoUnits,
-                               tdirType,ksEltype,SolType,F,CacheType,IType,
-                               NType,O,dAbsType,dRelType,H,
-                               FSALType,EventErrorType,CallbackCacheType}(
-            sol,u,k,t,dt,f,p,uprev,uprev2,tprev,prev_idx,prev2_idx,fixedpoint_abstol,
-            fixedpoint_reltol,resid,fixedpoint_norm,max_fixedpoint_iters,
+      new{algType,IIP,uType,tType,P,eigenType,tTypeNoUnits,tdirType,ksEltype,SolType,F,
+          CacheType,IType,FP,O,dAbsType,dRelType,H,FSALType,EventErrorType,
+          CallbackCacheType}(
+            sol,u,k,t,dt,f,p,uprev,uprev2,tprev,prev_idx,prev2_idx,fpsolver,
             order_discontinuity_t0,tracked_discontinuities,discontinuity_interp_points,
             discontinuity_abstol,discontinuity_reltol,alg,dtcache,dtchangeable,dtpropose,tdir,
             eigen_est,EEst,qold,q11,erracc,dtacc,success_iter,iter,saveiter,saveiter_dense,

--- a/test/dependent_delays.jl
+++ b/test/dependent_delays.jl
@@ -23,23 +23,23 @@ end
     getfield.(dde_int2.tracked_discontinuities, :order)
 
   # worse than results above with constant delays specified as scalars
-  @test sol2.errors[:l∞] < 4e-3
-  @test sol2.errors[:final] < 2e-4
-  @test sol2.errors[:l2] < 2e-3
+  @test sol2.errors[:l∞] < 3.2e-3
+  @test sol2.errors[:final] < 1.2e-4
+  @test sol2.errors[:l2] < 1.2e-3
 
   # simple convergence tests
   @testset "convergence" begin
-    sol3 = solve(prob2, alg, abstol=1e-9, reltol=1e-6)
+    sol3 = solve(prob2, alg; abstol=1e-9, reltol=1e-6)
 
-    @test sol3.errors[:l∞] < 3e-6
-    @test sol3.errors[:final] < 1.5e-7
-    @test sol3.errors[:l2] < 8.5e-7
+    @test sol3.errors[:l∞] < 3.0e-6
+    @test sol3.errors[:final] < 1.4e-7
+    @test sol3.errors[:l2] < 8.4e-7
 
-    sol4 = solve(prob2, alg, abstol=1e-13, reltol=1e-13)
+    sol4 = solve(prob2, alg; abstol=1e-13, reltol=1e-13)
 
-    @test sol4.errors[:l∞] < 5.5e-11
-    @test sol4.errors[:final] < 5e-11
-    @test sol4.errors[:l2] < 6e-12
+    @test sol4.errors[:l∞] < 5.0e-11
+    @test sol4.errors[:final] < 4.7e-11
+    @test sol4.errors[:l2] < 5.9e-12
   end
 end
 
@@ -48,7 +48,7 @@ end
   prob2 = remake(prob_dde_constant_1delay_ip; constant_lags = nothing)
   sol2 = solve(prob2, alg)
 
-  @test sol2.errors[:l∞] > 1e-3
-  @test sol2.errors[:final] > 4e-5
-  @test sol2.errors[:l2] > 7e-4
+  @test sol2.errors[:l∞] > 1.0e-2
+  @test sol2.errors[:final] > 6.3e-6
+  @test sol2.errors[:l2] > 4.6e-3
 end

--- a/test/lazy_interpolants.jl
+++ b/test/lazy_interpolants.jl
@@ -1,9 +1,12 @@
-include("common.jl")
+using DelayDiffEq, DiffEqProblemLibrary.DDEProblemLibrary
+using Test
+
+DDEProblemLibrary.importddeproblems()
 
 # simple problems
 @testset "simple problems" begin
-  prob_ip = prob_dde_constant_1delay_ip
-  prob_scalar = prob_dde_constant_1delay_scalar
+  prob_ip = DDEProblemLibrary.prob_dde_constant_1delay_ip
+  prob_scalar = DDEProblemLibrary.prob_dde_constant_1delay_scalar
   ts = 0:0.1:10
 
   # Vern6
@@ -13,8 +16,8 @@ include("common.jl")
     sol_ip = solve(prob_ip, alg)
 
     @test sol_ip.errors[:l∞] < 8.7e-4
-    @test sol_ip.errors[:final] < 7.5e-6
-    @test sol_ip.errors[:l2] < 5.5e-4
+    @test sol_ip.errors[:final] < 3.9e-6
+    @test sol_ip.errors[:l2] < 5.4e-4
 
     sol_scalar = solve(prob_scalar, alg)
 
@@ -58,7 +61,7 @@ include("common.jl")
 
     @test sol_ip.errors[:l∞] < 2.0e-3
     @test sol_ip.errors[:final] < 1.8e-5
-    @test sol_ip.errors[:l2] < 9.0e-4
+    @test sol_ip.errors[:l2] < 8.4e-4
 
     sol_scalar = solve(prob_scalar, alg)
 
@@ -98,7 +101,7 @@ end
 # model of Mackey and Glass
 println("Mackey and Glass")
 @testset "Mackey and Glass" begin
-  prob = prob_dde_DDETST_A1
+  prob = DDEProblemLibrary.prob_dde_DDETST_A1
 
   # Vern6
   solve(prob, MethodOfSteps(Vern6()))

--- a/test/parameters.jl
+++ b/test/parameters.jl
@@ -21,14 +21,14 @@ h(p, t; idxs=nothing) = 0.1
 
   # solve problem with initial parameter:
   sol1 = solve(prob, MethodOfSteps(Tsit5()))
-  @test length(sol1) == 26
-  @test first(sol1(12)) ≈ 0.884 atol=1e-4
-  @test first(sol1[end]) ≈ 1 atol=1e-5
+  @test length(sol1) == 22
+  @test first(sol1(12)) ≈ 0.884 atol = 1e-4
+  @test first(sol1[end]) ≈ 1 atol = 1e-5
 
   # solve problem with updated parameter
   prob.p[1] = 1.4
   sol2 = solve(prob, MethodOfSteps(Tsit5()))
-  @test length(sol2) == 52
-  @test first(sol2(12)) ≈ 1.127 atol=4e-4
-  @test first(sol2[end]) ≈ 0.995 atol=3e-4
+  @test length(sol2) == 47
+  @test first(sol2(12)) ≈ 1.125 atol = 5e-4
+  @test first(sol2[end]) ≈ 0.994 atol = 2e-5
 end

--- a/test/residual_control.jl
+++ b/test/residual_control.jl
@@ -30,9 +30,10 @@ const prob = remake(prob_dde_constant_1delay_scalar; constant_lags = nothing)
 
   sol = solve(prob, alg; abstol = 1e-13, reltol = 1e-13)
 
+  # relaxed tests to prevent floating point issues
   @test sol.errors[:l∞] < 4.8e-11
   @test sol.errors[:final] < 4.5e-12
-  @test sol.errors[:l2] < 7.7e-12
+  @test sol.errors[:l2] < 7.7e-11 # 7.7e-12
 end
 
 ######## Now show that non-residual control is worse

--- a/test/residual_control.jl
+++ b/test/residual_control.jl
@@ -1,6 +1,6 @@
 include("common.jl")
 
-const alg = MethodOfSteps(RK4(); constrained=false)
+const alg = MethodOfSteps(RK4(); constrained = false)
 
 # reference solution with delays specified
 @testset "reference" begin
@@ -18,41 +18,35 @@ const prob = remake(prob_dde_constant_1delay_scalar; constant_lags = nothing)
 @testset "residual control" begin
   sol = solve(prob, alg)
 
-  @test sol.errors[:l∞] < 1.8e-4
-  @test sol.errors[:final] < 4.1e-6
-  @test sol.errors[:l2] < 9.0e-5
+  @test sol.errors[:l∞] < 1.3e-4
+  @test sol.errors[:final] < 3.5e-6
+  @test sol.errors[:l2] < 6.1e-5
 
-  sol = solve(prob, alg, abstol=1e-9,reltol=1e-6)
+  sol = solve(prob, alg; abstol = 1e-9, reltol = 1e-6)
 
-  @test sol.errors[:l∞] < 1.5e-7
-  @test sol.errors[:final] < 4.1e-9
-  @test sol.errors[:l2] < 7.5e-8
+  @test sol.errors[:l∞] < 5.0e-8
+  @test sol.errors[:final] < 3.4e-9
+  @test sol.errors[:l2] < 2.2e-8
 
-  sol = solve(prob, alg, abstol=1e-13,reltol=1e-13)
+  sol = solve(prob, alg; abstol = 1e-13, reltol = 1e-13)
 
-  @test sol.errors[:l∞] < 7.0e-11
-  @test sol.errors[:final] < 1.1e-11
-  @test sol.errors[:l2] < 9.3e-12
+  @test sol.errors[:l∞] < 4.8e-11
+  @test sol.errors[:final] < 4.5e-12
+  @test sol.errors[:l2] < 7.7e-12
 end
 
 ######## Now show that non-residual control is worse
 # solutions without residual control
 @testset "non-residual control" begin
-  sol = solve(prob, MethodOfSteps(OwrenZen5(); constrained=false))
+  sol = solve(prob, MethodOfSteps(OwrenZen5(); constrained = false))
 
-  @test sol.errors[:l∞] > 1e-1
-  @test sol.errors[:final] > 1e-3
-  @test sol.errors[:l2] > 4e-2
+  @test sol.errors[:l∞] > 1.1e-1
+  @test sol.errors[:final] > 1.2e-3
+  @test sol.errors[:l2] > 4.5e-2
 
-  sol = solve(prob, MethodOfSteps(OwrenZen5(); constrained=true))
+  sol = solve(prob, MethodOfSteps(OwrenZen5(); constrained = false); abstol=1e-13, reltol=1e-13)
 
-  @test sol.errors[:l∞] > 1e-1
-  @test sol.errors[:final] > 1e-3
-  @test sol.errors[:l2] > 4e-2
-
-  sol = solve(prob, MethodOfSteps(OwrenZen5(); constrained=true); abstol=1e-13, reltol=1e-13)
-
-  @test sol.errors[:l∞] > 1e-1
-  @test sol.errors[:final] > 1e-3
-  @test sol.errors[:l2] > 5e-2
+  @test sol.errors[:l∞] > 1.1e-1
+  @test sol.errors[:final] > 1.2e-3
+  @test sol.errors[:l2] > 5.5e-2
 end

--- a/test/sdirk_integrators.jl
+++ b/test/sdirk_integrators.jl
@@ -1,7 +1,10 @@
-include("common.jl")
+using DelayDiffEq, DiffEqProblemLibrary.DDEProblemLibrary
+using Test
 
-const prob_ip = prob_dde_constant_1delay_ip
-const prob_scalar = prob_dde_constant_1delay_scalar
+DDEProblemLibrary.importddeproblems()
+
+const prob_ip = DDEProblemLibrary.prob_dde_constant_1delay_ip
+const prob_scalar = DDEProblemLibrary.prob_dde_constant_1delay_scalar
 const ts = 0:0.1:10
 
 # ODE algorithms
@@ -27,8 +30,8 @@ const algs = Dict(GenericImplicitEuler() => true,
   println(nameof(typeof(alg)))
 
   stepsalg = MethodOfSteps(alg)
-  sol_ip = solve(prob_ip, stepsalg)
-  sol_scalar = solve(prob_scalar, stepsalg)
+  sol_ip = solve(prob_ip, stepsalg; dt = 0.1)
+  sol_scalar = solve(prob_scalar, stepsalg; dt = 0.1)
 
   if pass
     @test sol_ip(ts, idxs=1) ≈ sol_scalar(ts)

--- a/test/unconstrained.jl
+++ b/test/unconstrained.jl
@@ -5,17 +5,15 @@ include("common.jl")
 
 @testset "standard history" begin
   # standard algorithm
-  alg = MethodOfSteps(BS3(); constrained=false)
+  alg = MethodOfSteps(BS3(); constrained = false)
 
-  # different tolerances
-  alg1 = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
-                       fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
-  alg2 = MethodOfSteps(DP8(), constrained=false, max_fixedpoint_iters=10,
-                       fixedpoint_abstol=1e-8, fixedpoint_reltol=1e-10)
-  alg3 = MethodOfSteps(Tsit5(), constrained=true, max_fixedpoint_iters=10,
-                       fixedpoint_abstol=1e-8, fixedpoint_reltol=1e-10)
-  alg4 = MethodOfSteps(DP5(), constrained=false, max_fixedpoint_iters=100,
-                       fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
+  alg1 = MethodOfSteps(Tsit5(); constrained = false,
+                       fpsolve = FPFunctional(; max_iter = 100))
+  alg2 = MethodOfSteps(DP8(); constrained = false,
+                       fpsolve = FPFunctional(; max_iter = 10))
+  alg3 = MethodOfSteps(Tsit5(); constrained = true)
+  alg4 = MethodOfSteps(DP5(); constrained = false,
+                       fpsolve = FPFunctional(; max_iter = 100))
 
   ## Single constant delay
   @testset "single constant delay" begin
@@ -41,14 +39,14 @@ include("common.jl")
     @testset "long time span" begin
       prob = prob_dde_constant_1delay_long_scalar
 
-      sol1 = solve(prob, alg1)
-      sol2 = solve(prob, alg2)
-      sol3 = solve(prob, alg3)
-      sol4 = solve(prob, alg4)
+      sol1 = solve(prob, alg1; abstol = 1e-12, reltol = 1e-12)
+      sol2 = solve(prob, alg2; abstol = 1e-8, reltol = 1e-10)
+      sol3 = solve(prob, alg3; abstol = 1e-8, reltol = 1e-10)
+      sol4 = solve(prob, alg4; abstol = 1e-12, reltol = 1e-12)
 
-      @test abs(sol1[end] - sol2[end]) < 5.3e-4
-      @test abs(sol1[end] - sol3[end]) < 1.1e-8
-      @test abs(sol1[end] - sol4[end]) < 2.9e-4
+      @test abs(sol1[end] - sol2[end]) < 2.3e-8
+      @test abs(sol1[end] - sol3[end]) < 3.7e-8
+      @test abs(sol1[end] - sol4[end]) < 9.0e-13
     end
   end
 
@@ -58,8 +56,8 @@ include("common.jl")
       ### Scalar function
       sol_scalar = solve(prob_dde_constant_2delays_scalar, alg)
 
-      @test sol_scalar.errors[:l∞] < 2.5e-6
-      @test sol_scalar.errors[:final] < 2.2e-6
+      @test sol_scalar.errors[:l∞] < 2.4e-6
+      @test sol_scalar.errors[:final] < 2.1e-6
       @test sol_scalar.errors[:l2] < 1.2e-6
 
       ### Out-of-place function
@@ -76,31 +74,31 @@ include("common.jl")
     @testset "long time span" begin
       prob = prob_dde_constant_2delays_long_scalar
 
-      sol1 = solve(prob, alg1)
-      # sol2 = solve(prob, alg) # aborted because of dt <= dtmin
-      sol3 = solve(prob, alg3)
-      sol4 = solve(prob, alg4)
+      sol1 = solve(prob, alg1; abstol = 1e-12, reltol = 1e-12)
+      sol2 = solve(prob, alg2; abstol = 1e-8, reltol = 1e-10)
+      sol3 = solve(prob, alg3; abstol = 1e-8, reltol = 1e-10)
+      sol4 = solve(prob, alg4; abstol = 1e-12, reltol = 1e-12)
 
       # relaxed tests to prevent floating point issues
-      @test abs(sol1[end] - sol3[end]) < 7.9e-13 # 7.9e-15
-      @test abs(sol1[end] - sol4[end]) < 1.6e-12 # 1.6e-14
+      @test abs(sol1[end] - sol3[end]) < 1.2e-13 # 1.2e-15
+      @test abs(sol1[end] - sol4[end]) < 3.1e-13 # 3.1e-15
     end
   end
 end
 
 ## Non-standard history functions
 @testset "non-standard history" begin
-  alg = MethodOfSteps(Tsit5(), constrained=false, max_fixedpoint_iters=100,
-                      fixedpoint_abstol=1e-12, fixedpoint_reltol=1e-12)
+  alg = MethodOfSteps(Tsit5(); constrained = false,
+                      fpsolve = FPFunctional(; max_iter = 100))
 
   @testset "idxs" begin
     function f(du,u,h,p,t)
       du[1] = -h(p, t-0.2;idxs=1) + u[1]
     end
-    h(p, t; idxs=nothing) = typeof(idxs) <: Number ? 0.0 : [0.0]
+    h(p, t; idxs = nothing) = idxs isa Number ? 0.0 : [0.0]
 
-    prob = DDEProblem(f, [1.0], h, (0.0, 100.), constant_lags = [0.2])
-    solve(prob, alg)
+    prob = DDEProblem(f, [1.0], h, (0.0, 100.0); constant_lags = [0.2])
+    solve(prob, alg; abstol = 1e-12, reltol = 1e-12)
   end
 
   @testset "in-place" begin
@@ -110,7 +108,7 @@ end
     end
     h(val, p, t) = (val .= 0.0)
 
-    prob = DDEProblem(f, [1.0], h, (0.0, 100.0), constant_lags = [0.2])
-    solve(prob, alg)
+    prob = DDEProblem(f, [1.0], h, (0.0, 100.0); constant_lags = [0.2])
+    solve(prob, alg; abstol = 1e-12, reltol = 1e-12)
   end
 end

--- a/test/unconstrained.jl
+++ b/test/unconstrained.jl
@@ -44,9 +44,10 @@ include("common.jl")
       sol3 = solve(prob, alg3; abstol = 1e-8, reltol = 1e-10)
       sol4 = solve(prob, alg4; abstol = 1e-12, reltol = 1e-12)
 
+      # relaxed tests to prevent floating point issues
       @test abs(sol1[end] - sol2[end]) < 2.3e-8
       @test abs(sol1[end] - sol3[end]) < 3.7e-8
-      @test abs(sol1[end] - sol4[end]) < 9.0e-13
+      @test abs(sol1[end] - sol4[end]) < 9.0e-11 # 9.0e-13
     end
   end
 


### PR DESCRIPTION
This PR introduces a dedicated fixed-point solver. Currently, the stopping and convergence criterion of the fixed-point iterations is a very ad-hoc heuristic. In this PR it is updated to basically the same logic as the non-linear solvers in DiffEqBase.

To reduce the amount of changes, intentionally this PR does not include Anderson acceleration. However, it should be straightforward to add it afterwards by more or less copying from the implementation of the non-linear solvers.