### PR TITLE
Add Anderson acceleration

### DIFF
--- a/src/DelayDiffEq.jl
+++ b/src/DelayDiffEq.jl
@@ -12,11 +12,13 @@ using Roots
 
 using DiffEqBase: AbstractDDEAlgorithm, AbstractDDEIntegrator, AbstractODEIntegrator, DEIntegrator, AbstractDDEProblem
 
+using DiffEqBase: @..
+
+using DiffEqBase: FastConvergence, Convergence, SlowConvergence, VerySlowConvergence, Divergence
+
 using OrdinaryDiffEq: GenericImplicitEulerCache, GenericTrapezoidCache, RosenbrockMutableCache
 
 export Discontinuity, MethodOfSteps
-
-export FPFunctional
 
 include("discontinuity_type.jl")
 include("functionwrapper.jl")

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -7,7 +7,7 @@ struct MethodOfSteps{algType,F,constrained} <: AbstractMethodOfStepsAlgorithm{co
 end
 
 """
-    MethodOfSteps(alg; constrained = false, fpsolve = FPFunctional())
+    MethodOfSteps(alg; constrained = false, fpsolve = NLFunctional())
 
 Construct an algorithm that solves delay differential equations by the method of steps,
 where `alg` is an ODE algorithm from OrdinaryDiffEq.jl upon which the calculation of
@@ -17,5 +17,5 @@ If the algorithm is `constrained` only steps of size at most the minimal delay w
 taken. If it is unconstrained, fixed-point iteration `fpsolve` is applied for step sizes
 that exceed the minimal delay.
 """
-MethodOfSteps(alg; constrained = false, fpsolve = FPFunctional()) =
+MethodOfSteps(alg; constrained = false, fpsolve = NLFunctional()) =
   MethodOfSteps{typeof(alg),typeof(fpsolve),constrained}(alg, fpsolve)

--- a/src/fpsolve/functional.jl
+++ b/src/fpsolve/functional.jl
@@ -1,30 +1,52 @@
-function fpsolve!(integrator::DDEIntegrator, fpsolver::FPSolver{<:FPFunctionalConstantCache})
+function fpsolve!(fpsolver::FPSolver{<:Union{NLFunctional,NLAnderson},false},
+                  integrator::DDEIntegrator)
   @unpack f, t, p, k, uprev, dt, alg, cache = integrator
-  @unpack κ, max_iter = fpsolver
   ode_integrator = integrator.integrator
+
+  @unpack κ, max_iter, fast_convergence_cutoff = fpsolver.alg
+  fpcache = fpsolver.cache
+
+  if fpcache isa FPAndersonConstantCache
+    @unpack aa_start,droptol = fpsolver.alg
+    @unpack Δus,Q,R,γs = fpcache
+  end
 
   # ODE integrator caches state u at next time point
   # DDE integrator contains updated state u₊ at next time point
 
   # precalculations
   η = fpsolver.ηold
-
-  # update ODE integrator to next time interval together with correct interpolation
-  advance_ode_integrator!(integrator)
+  if fpcache isa FPAndersonConstantCache
+    history = 0
+    max_history = length(Δus)
+  end
 
   # fixed point iteration
   local ndu
+  if fpcache isa FPAndersonConstantCache
+    local duold, uold
+  end
   fail_convergence = true
   iter = 0
   while iter < max_iter
     iter += 1
 
+    # update ODE integrator to next time interval together with correct interpolation
+    if iter == 1
+      advance_ode_integrator!(integrator)
+    else
+      # for Anderson acceleration force recomputation of all interpolation data
+      update_ode_integrator!(integrator,
+                             fpsolver.alg isa NLAnderson && iter > aa_start + 1)
+    end
+
     # calculate next step
-    OrdinaryDiffEq.perform_step!(integrator, integrator.cache, true)
+    OrdinaryDiffEq.perform_step!(integrator, cache, true)
 
     # compute norm of residuals
     iter > 1 && (nduprev = ndu)
-    atmp = OrdinaryDiffEq.calculate_residuals(ode_integrator.u, integrator.u,
+    du = integrator.u .- ode_integrator.u
+    atmp = OrdinaryDiffEq.calculate_residuals(du, ode_integrator.u, integrator.u,
                                               integrator.opts.abstol,
                                               integrator.opts.reltol,
                                               integrator.opts.internalnorm, t)
@@ -40,30 +62,78 @@ function fpsolve!(integrator::DDEIntegrator, fpsolver::FPSolver{<:FPFunctionalCo
       end
     end
 
-    # complete interpolation data of DDE integrator for time interval [t, t+dt]
-    # and copy it to ODE integrator
-    # has to be done before updates to ODE integrator, otherwise history function
-    # is incorrect
-    if iscomposite(alg)
-      addsteps!(k, t, uprev, integrator.u, dt, f, p, cache.caches[integrator.cache.current],
-                false, true, true)
-    else
-      addsteps!(k, t, uprev, integrator.u, dt, f, p, cache, false, true, true)
-    end
-    @inbounds for i in 1:length(k)
-      copyat_or_push!(ode_integrator.k, i, k[i])
-    end
-
-    # update state of the dummy ODE solver
-    ode_integrator.u = integrator.u
-
     # check stopping criterion
     iter > 1 && (η = θ / (1 - θ))
     if η * ndu < κ && (iter > 1 || iszero(ndu))
       # fixed-point iteration converges
-      fpsolver.status = η < fpsolver.fast_convergence_cutoff ? FastConvergence : Convergence
+      fpsolver.status = η < fast_convergence_cutoff ? FastConvergence : Convergence
       fail_convergence = false
       break
+    end
+
+    # perform Anderson acceleration
+    if fpcache isa FPAndersonConstantCache && iter < max_iter
+      if iter == aa_start
+        # update cached values for next step of Anderson acceleration
+        duold = du
+        uold = integrator.u
+      elseif iter > aa_start
+        # increase size of history
+        history += 1
+
+        # remove oldest history if maximum size is exceeded
+        if history > max_history
+          # circularly shift differences of u
+          for i in 1:(max_history-1)
+            Δus[i] = Δus[i + 1]
+          end
+
+          # delete left-most column of QR decomposition
+          DiffEqBase.qrdelete!(Q, R, max_history)
+
+          # update size of history
+          history = max_history
+        end
+
+        # update history of differences of u
+        Δus[history] = @.. integrator.u - uold
+
+        # replace/add difference of residuals as right-most column to QR decomposition
+        qradd!(Q, R, _vec(du .- duold), history)
+
+        # update cached values
+        duold = du
+        uold = integrator.u
+
+        # define current Q and R matrices
+        Qcur, Rcur = view(Q, :, 1:history), UpperTriangular(view(R, 1:history, 1:history))
+
+        # check condition (TODO: incremental estimation)
+        if droptol !== nothing
+          while cond(R) > droptol && history > 1
+            qrdelete!(Q, R, history)
+            history -= 1
+            Qcur, Rcur = view(Q, :, 1:history), UpperTriangular(view(R, 1:history, 1:history))
+          end
+        end
+
+        # solve least squares problem
+        γscur = view(γs, 1:history)
+        ldiv!(Rcur, mul!(γscur, Qcur', _vec(du)))
+
+        # update next iterate
+        for i in 1:history
+          integrator.u = @.. integrator.u - γs[i] * Δus[i]
+        end
+
+        # update norm of residuals
+        du = integrator.u .- uold .+ du
+        atmp = OrdinaryDiffEq.calculate_residuals(du, ode_integrator.u, integrator.u,
+                                                  integrator.opts.abstol,
+                                                  integrator.opts.reltol,
+                                                  integrator.opts.internalnorm, t)
+        ndu = integrator.opts.internalnorm(atmp, t)
+      end
     end
   end
 
@@ -74,20 +144,19 @@ function fpsolve!(integrator::DDEIntegrator, fpsolver::FPSolver{<:FPFunctionalCo
   nothing
 end
 
-function fpsolve!(integrator::DDEIntegrator, fpsolver::FPSolver{<:FPFunctionalCache})
-  @unpack f, t, p, k, uprev, dt, alg = integrator
-  @unpack κ, max_iter, cache = fpsolver
-  @unpack resid = cache
+function fpsolve!(fpsolver::FPSolver{<:Union{NLFunctional,NLAnderson},true}, integrator::DDEIntegrator)
+  @unpack f, t, p, k, uprev, dt, alg, cache = integrator
   ode_integrator = integrator.integrator
+
+  @unpack κ, max_iter, fast_convergence_cutoff = fpsolver.alg
+  fpcache = fpsolver.cache
+  @unpack du,atmp = fpcache
 
   # ODE integrator caches state u at next time point
   # DDE integrator contains updated state u₊ at next time point
 
   # precalculations
   η = fpsolver.ηold
-
-  # update ODE integrator to next time interval together with correct interpolation
-  advance_ode_integrator!(integrator)
 
   # fixed-point iteration without Newton
   local ndu
@@ -96,15 +165,25 @@ function fpsolve!(integrator::DDEIntegrator, fpsolver::FPSolver{<:FPFunctionalCa
   while iter < max_iter
     iter += 1
 
+    # update ODE integrator to next time interval together with correct interpolation
+    if iter == 1
+      advance_ode_integrator!(integrator)
+    else
+      # for Anderson acceleration force recomputation of all interpolation data
+      update_ode_integrator!(integrator,
+                             fpsolver.alg isa NLAnderson && iter > aa_start + 1)
+    end
+
     # calculate next step
-    OrdinaryDiffEq.perform_step!(integrator, integrator.cache, true)
+    OrdinaryDiffEq.perform_step!(integrator, cache, true)
 
     # compute norm of residuals
     iter > 1 && (nduprev = ndu)
-    OrdinaryDiffEq.calculate_residuals!(resid, ode_integrator.u, integrator.u,
+    @.. du = integrator.u - ode_integrator.u
+    OrdinaryDiffEq.calculate_residuals!(atmp, du, ode_integrator.u, integrator.u,
                                         integrator.opts.abstol, integrator.opts.reltol,
                                         integrator.opts.internalnorm, t)
-    ndu = integrator.opts.internalnorm(resid, t)
+    ndu = integrator.opts.internalnorm(atmp, t)
 
     # check divergence (not in initial step)
     if iter > 1
@@ -116,30 +195,78 @@ function fpsolve!(integrator::DDEIntegrator, fpsolver::FPSolver{<:FPFunctionalCa
       end
     end
 
-    # complete interpolation data of DDE integrator for time interval [t, t+dt]
-    # and copy it to ODE integrator
-    # has to be done before updates to ODE integrator, otherwise history function
-    # is incorrect
-    if iscomposite(alg)
-      addsteps!(k, t, uprev, integrator.u, dt, f, p, cache.caches[integrator.cache.current],
-                false, true, true)
-    else
-      addsteps!(k, t, uprev, integrator.u, dt, f, p, cache, false, true, true)
-    end
-    @inbounds for i in 1:length(k)
-      copyat_or_push!(ode_integrator.k, i, k[i])
-    end
-
-    # update state of the dummy ODE solver
-    recursivecopy!(ode_integrator.u, integrator.u)
-
     # check stopping criterion
     iter > 1 && (η = θ / (1 - θ))
     if η * ndu < κ && (iter > 1 || iszero(ndu))
       # fixed-point iteration converges
-      fpsolver.status = η < fpsolver.fast_convergence_cutoff ? FastConvergence : Convergence
+      fpsolver.status = η < fast_convergence_cutoff ? FastConvergence : Convergence
       fail_convergence = false
       break
+    end
+
+    # perform Anderson acceleration
+    if fpcache isa FPAndersonConstantCache && iter < max_iter
+      if iter == aa_start
+        # update cached values for next step of Anderson acceleration
+        duold = du
+        uold = integrator.u
+      elseif iter > aa_start
+        # increase size of history
+        history += 1
+
+        # remove oldest history if maximum size is exceeded
+        if history > max_history
+          # circularly shift differences of u
+          for i in 1:(max_history-1)
+            Δus[i] = Δus[i + 1]
+          end
+
+          # delete left-most column of QR decomposition
+          DiffEqBase.qrdelete!(Q, R, max_history)
+
+          # update size of history
+          history = max_history
+        end
+
+        # update history of differences of u
+        Δus[history] = @.. integrator.u - uold
+
+        # replace/add difference of residuals as right-most column to QR decomposition
+        qradd!(Q, R, _vec(du .- duold), history)
+
+        # update cached values
+        duold = du
+        uold = integrator.u
+
+        # define current Q and R matrices
+        Qcur, Rcur = view(Q, :, 1:history), UpperTriangular(view(R, 1:history, 1:history))
+
+        # check condition (TODO: incremental estimation)
+        if droptol !== nothing
+          while cond(R) > droptol && history > 1
+            qrdelete!(Q, R, history)
+            history -= 1
+            Qcur, Rcur = view(Q, :, 1:history), UpperTriangular(view(R, 1:history, 1:history))
+          end
+        end
+
+        # solve least squares problem
+        γscur = view(γs, 1:history)
+        ldiv!(Rcur, mul!(γscur, Qcur', _vec(du)))
+
+        # update next iterate
+        for i in 1:history
+          @.. integrator.u = integrator.u - γs[i] * Δus[i]
+        end
+
+        # update norm of residuals
+        @.. du = integrator.u - uold + du
+        OrdinaryDiffEq.calculate_residuals!(atmp, du, ode_integrator.u, integrator.u,
+                                            integrator.opts.abstol,
+                                            integrator.opts.reltol,
+                                            integrator.opts.internalnorm, t)
+        ndu = integrator.opts.internalnorm(atmp, t)
+      end
     end
   end
 

--- a/src/fpsolve/type.jl
+++ b/src/fpsolve/type.jl
@@ -1,40 +1,34 @@
-abstract type AbstractFPSolverAlgorithm end
-abstract type AbstractFPSolverCache end
-
-@enum FPStatus::Int8 begin
-  FastConvergence     = 2
-  Convergence         = 1
-  SlowConvergence     = 0
-  VerySlowConvergence = -1
-  Divergence          = -2
-end
-
 # solver
-mutable struct FPSolver{C<:AbstractFPSolverCache,uTolType,K,C1}
+mutable struct FPSolver{algType<:DiffEqBase.AbstractNLSolverAlgorithm,IIP,uTolType,C}
+  alg::algType
   ηold::uTolType
-  κ::K
-  max_iter::Int
   fp_iters::Int
-  status::FPStatus
-  fast_convergence_cutoff::C1
+  status::DiffEqBase.NLStatus
   cache::C
 end
 
-struct FPNone end
-
-# algorithms
-struct FPFunctional{K,C} <: AbstractFPSolverAlgorithm
-  κ::K
-  fast_convergence_cutoff::C
-  max_iter::Int
-end
-
-FPFunctional(; κ=1//100, max_iter=10, fast_convergence_cutoff=1//5) =
-  FPFunctional(κ, fast_convergence_cutoff, max_iter)
-
 # caches
-struct FPFunctionalCache{uType} <: AbstractFPSolverCache
-  resid::uType
+struct FPFunctionalCache{uType,uNoUnitsType} <: DiffEqBase.AbstractNLSolverCache
+  du::uType
+  atmp::uNoUnitsType
 end
 
-struct FPFunctionalConstantCache <: AbstractFPSolverCache end
+struct FPFunctionalConstantCache <: DiffEqBase.AbstractNLSolverCache end
+
+struct FPAndersonCache{uType,uNoUnitsType,gsType,QType,RType,gType} <: DiffEqBase.AbstractNLSolverCache
+  du::uType
+  duold::uType
+  uold::uType
+  atmp::uNoUnitsType
+  Δus::gsType
+  Q::QType
+  R::RType
+  γs::gType
+end
+
+struct FPAndersonConstantCache{gsType,QType,RType,gType} <: DiffEqBase.AbstractNLSolverCache
+  Δus::gsType
+  Q::QType
+  R::RType
+  γs::gType
+end

--- a/src/integrators/interface.jl
+++ b/src/integrators/interface.jl
@@ -128,11 +128,11 @@ function OrdinaryDiffEq.perform_step!(integrator::DDEIntegrator)
   # solution, i.e. returned extrapolated values, continue with a fixed-point iteration
   if history.isout
     # perform fixed-point iteration
-    fpsolve!(integrator)
-  else
-    # update ODE integrator to next time interval together with correct interpolation
-    advance_ode_integrator!(integrator)
+    fpsolve!(integrator.fpsolver, integrator)
   end
+
+  # update ODE integrator to next time interval together with correct interpolation
+  advance_or_update_ode_integrator!(integrator)
 
   nothing
 end

--- a/test/interface/composite_solution.jl
+++ b/test/interface/composite_solution.jl
@@ -19,8 +19,30 @@ end
 
   # compare integration grid
   sol2 = solve(prob, MethodOfSteps(Tsit5()))
-  @test sol1.t == sol2.t && sol1.u == sol2.u
+  @test sol1.t == sol2.t
+  @test sol1.u == sol2.u
 
   # compare interpolation
   @test sol1(0:0.1:1) == sol2(0:0.1:1)
+end
+
+@testset "issue #148" begin
+  alg = MethodOfSteps(Tsit5())
+  compositealg = MethodOfSteps(CompositeAlgorithm((Tsit5(), RK4()), integrator -> 1))
+
+  prob = DDEProblem((du, u, h, p, t) -> -h(p, t - 1)[1], [1.0], (p, t) -> [1.0],
+                    (0.0, 5.0))
+  sol = solve(prob, alg)
+  compositesol = solve(prob, compositealg)
+  @test compositesol isa T
+  @test sol.t == compositesol.t
+  @test sol.u == compositesol.u
+
+  prob_oop = DDEProblem((u, h, p, t) -> -h(p, t - 1), [1.0], (p, t) -> [1.0],
+                        (0.0, 5.0))
+  sol_oop = solve(prob_oop, alg)
+  compositesol_oop = solve(prob_oop, compositealg)
+  @test compositesol_oop isa T
+  @test sol_oop.t == compositesol_oop.t
+  @test sol_oop.u == compositesol_oop.u
 end

--- a/test/interface/composite_solution.jl
+++ b/test/interface/composite_solution.jl
@@ -28,8 +28,8 @@ end
   alg = MethodOfSteps(Tsit5())
   compositealg = MethodOfSteps(CompositeAlgorithm((Tsit5(), RK4()), integrator -> 1))
 
-  prob = DDEProblem((du, u, h, p, t) -> -h(p, t - 1)[1], [1.0], (p, t) -> [1.0],
-                    (0.0, 5.0))
+  prob = DDEProblem((du, u, h, p, t) -> (du[1] = -h(p, t - 1)[1]; nothing),
+                    [1.0], (p, t) -> [1.0], (0.0, 5.0))
   sol = solve(prob, alg)
   compositesol = solve(prob, compositealg)
   @test compositesol isa T

--- a/test/interface/composite_solution.jl
+++ b/test/interface/composite_solution.jl
@@ -4,16 +4,14 @@ using Test
 DDEProblemLibrary.importddeproblems()
 
 const T = OrdinaryDiffEq.ODECompositeSolution
-const prob = DDEProblemLibrary.prob_dde_constant_1delay_ip
 
-const integrator = init(prob, MethodOfSteps(AutoTsit5(Rosenbrock23())))
+@testset "integrator" begin
+  prob = DDEProblemLibrary.prob_dde_constant_1delay_ip
 
-@testset "init" begin
+  integrator = init(prob, MethodOfSteps(AutoTsit5(Rosenbrock23())))
   @test integrator.sol isa T
   @test integrator.integrator.sol isa T
-end
 
-@testset "solve" begin
   sol1 = solve!(integrator)
   @test sol1 isa T
 

--- a/test/interface/fpsolve.jl
+++ b/test/interface/fpsolve.jl
@@ -1,0 +1,38 @@
+using DelayDiffEq, DiffEqProblemLibrary.DDEProblemLibrary
+using Test
+
+DDEProblemLibrary.importddeproblems()
+
+const prob = DDEProblemLibrary.prob_dde_constant_2delays_ip
+const prob_oop = DDEProblemLibrary.prob_dde_constant_2delays_oop
+const prob_scalar = DDEProblemLibrary.prob_dde_constant_2delays_scalar
+
+@testset "NLFunctional" begin
+  alg = MethodOfSteps(Tsit5(); fpsolve = NLFunctional(; max_iter = 10))
+
+  sol = solve(prob, alg)
+  @test sol.errors[:l∞] < 4.5e-3
+
+  sol_oop = solve(prob_oop, alg)
+  @test sol.t ≈ sol_oop.t
+  @test sol.u ≈ sol_oop.u
+
+  sol_scalar = solve(prob_scalar, alg)
+  @test sol.t ≈ sol_scalar.t
+  @test sol[1, :] ≈ sol_scalar.u
+end
+
+@testset "NLAnderson" begin
+  alg = MethodOfSteps(Tsit5(); fpsolve = NLAnderson(; max_iter = 10))
+
+  sol = solve(prob, alg)
+  @test sol.errors[:l∞] < 4.5e-3
+
+  sol_oop = solve(prob_oop, alg)
+  @test sol.t ≈ sol_oop.t
+  @test sol.u ≈ sol_oop.u
+
+  sol_scalar = solve(prob_scalar, alg)
+  @test sol.t ≈ sol_scalar.t
+  @test sol[1, :] ≈ sol_scalar.u
+end

--- a/test/interface/unconstrained.jl
+++ b/test/interface/unconstrained.jl
@@ -11,12 +11,12 @@ DDEProblemLibrary.importddeproblems()
   alg = MethodOfSteps(BS3(); constrained = false)
 
   alg1 = MethodOfSteps(Tsit5(); constrained = false,
-                       fpsolve = FPFunctional(; max_iter = 100))
+                       fpsolve = NLFunctional(; max_iter = 100))
   alg2 = MethodOfSteps(DP8(); constrained = false,
-                       fpsolve = FPFunctional(; max_iter = 10))
+                       fpsolve = NLFunctional(; max_iter = 10))
   alg3 = MethodOfSteps(Tsit5(); constrained = true)
   alg4 = MethodOfSteps(DP5(); constrained = false,
-                       fpsolve = FPFunctional(; max_iter = 100))
+                       fpsolve = NLFunctional(; max_iter = 100))
 
   ## Single constant delay
   @testset "single constant delay" begin
@@ -93,7 +93,7 @@ end
 ## Non-standard history functions
 @testset "non-standard history" begin
   alg = MethodOfSteps(Tsit5(); constrained = false,
-                      fpsolve = FPFunctional(; max_iter = 100))
+                      fpsolve = NLFunctional(; max_iter = 100))
 
   @testset "idxs" begin
     function f(du,u,h,p,t)

--- a/test/interface/units.jl
+++ b/test/interface/units.jl
@@ -19,7 +19,7 @@ const probs =
   prob = probs[inplace]
 
   alg = MethodOfSteps(Tsit5(); constrained = false,
-                      fpsolve = FPFunctional(; max_iter = 100))
+                      fpsolve = NLFunctional(; max_iter = 100))
 
   # default
   sol1 = solve(prob, alg)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ if GROUP == "All" || GROUP == "Interface"
   @time @safetestset "Dependent Delay Tests" begin include("interface/dependent_delays.jl") end
   @time @safetestset "Discontinuity Tests" begin include("interface/discontinuities.jl") end
   @time @safetestset "Export Tests" begin include("interface/export.jl") end
+  @time @safetestset "Fixed-point Iteration Tests" begin include("interface/fpsolve.jl") end
   @time @safetestset "History Function Tests" begin include("interface/history_function.jl") end
   @time @safetestset "Jacobian Tests" begin include("interface/jacobian.jl") end
   @time @safetestset "Parameterized Function Tests" begin include("interface/parameters.jl") end


### PR DESCRIPTION
Fixes https://github.com/JuliaDiffEq/DelayDiffEq.jl/issues/8.

Moreover, this PR updates the type structure and dispatches of the fixed-point iteration (similar to https://github.com/JuliaDiffEq/DiffEqBase.jl/pull/315) and uses `NLFunctional` and `NLAnderson` instead of `FPFunctional` and `FPAnderson`.