### PR TITLE
Fix fixed-point iteration and add proper tests

### DIFF
--- a/test/interface/fpsolve.jl
+++ b/test/interface/fpsolve.jl
@@ -1,38 +1,70 @@
-using DelayDiffEq, DiffEqProblemLibrary.DDEProblemLibrary
+using DelayDiffEq, DiffEqProblemLibrary.DDEProblemLibrary, DiffEqDevTools
+using LinearAlgebra
 using Test
 
 DDEProblemLibrary.importddeproblems()
 
-const prob = DDEProblemLibrary.prob_dde_constant_2delays_ip
-const prob_oop = DDEProblemLibrary.prob_dde_constant_2delays_oop
-const prob_scalar = DDEProblemLibrary.prob_dde_constant_2delays_scalar
+const prob = DDEProblemLibrary.prob_dde_constant_2delays_long_ip
+const prob_oop = DDEProblemLibrary.prob_dde_constant_2delays_long_oop
+const prob_scalar = DDEProblemLibrary.prob_dde_constant_2delays_long_scalar
+
+const testsol = TestSolution(solve(prob, MethodOfSteps(Vern9());
+                             abstol = 1/10^14, reltol = 1/10^14))
 
 @testset "NLFunctional" begin
   alg = MethodOfSteps(Tsit5(); fpsolve = NLFunctional(; max_iter = 10))
 
+  ## in-place problem
+
   sol = solve(prob, alg)
-  @test sol.errors[:l∞] < 4.5e-3
+
+  # compare it with the test solution
+  sol2 = appxtrue(sol, testsol)
+  @test sol2.errors[:L∞] < 2.7e-4
+
+  ## out-of-place problem
 
   sol_oop = solve(prob_oop, alg)
-  @test sol.t ≈ sol_oop.t
-  @test sol.u ≈ sol_oop.u
+
+  # compare it with the in-place solution
+  @test sol_oop.t ≈ sol.t
+  @test_broken sol_oop.u ≈ sol.u
+  @test isapprox(sol.u, sol_oop.u; atol = 1e-7)
+
+  ## scalar problem
 
   sol_scalar = solve(prob_scalar, alg)
-  @test sol.t ≈ sol_scalar.t
-  @test sol[1, :] ≈ sol_scalar.u
+
+  # compare it with the in-place solution
+  @test sol_scalar.t ≈ sol.t
+  @test sol_scalar.u ≈ sol[1, :]
 end
 
 @testset "NLAnderson" begin
   alg = MethodOfSteps(Tsit5(); fpsolve = NLAnderson(; max_iter = 10))
 
+  ## in-place problem
+
   sol = solve(prob, alg)
-  @test sol.errors[:l∞] < 4.5e-3
+
+  # compare it with the test solution
+  sol2 = appxtrue(sol, testsol)
+  @test sol2.errors[:L∞] < 2.7e-4
+
+  ## out-of-place problem
 
   sol_oop = solve(prob_oop, alg)
-  @test sol.t ≈ sol_oop.t
-  @test sol.u ≈ sol_oop.u
 
+  # compare it with the in-place solution
+  @test_broken sol_oop.t ≈ sol.t
+  @test_broken sol_oop.u ≈ sol.u
+  @test appxtrue(sol, sol_oop).errors[:L∞] < 1.5e-7
+
+  ## scalar problem
+  
   sol_scalar = solve(prob_scalar, alg)
-  @test sol.t ≈ sol_scalar.t
-  @test sol[1, :] ≈ sol_scalar.u
+
+  # compare it with the in-place solution
+  @test_broken sol_scalar.t ≈ sol.t
+  @test_broken sol_scalar.u ≈ sol[1, :]
 end


### PR DESCRIPTION
Embarrassingly, Anderson acceleration is broken on master since our test problem did not perform any fixed-point iterations at all. It works now, but there's some weird discrepancy between the in-place and out-of-place results (it also exists for the fixed-point iteration without Anderson acceleration, so maybe it's not only due to a possible bug in the Anderson implementation).

However, I don't want to spend more time on trying to debug this right now since once https://github.com/JuliaDiffEq/DiffEqBase.jl/pull/325 is available, we can clean everything up in a nice and well-structured way. You can have a look at a first draft in https://github.com/JuliaDiffEq/DelayDiffEq.jl/tree/fpsolver_unified - the implementation of the Anderson acceleration is gone completely and we just call into `anderson` and `anderson!` in DiffEqBase.

BTW, tests with a DDEStats struct that tracks the fixed-point iterations and convergence failures shows that with Anderson acceleration the number of function evaluations on the in-place test problem goes down from 3045 to 2385, the number of fixed-point iterations from 305 to 234, and the number of fixed-point convergence failures from 60 to 27.