### PR TITLE
Use CompatHelper to update [compat] entries

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,26 @@
+name: CompatHelper
+
+on:
+  schedule:
+    - cron: '00 * * * *'
+  issues:
+    types: [opened, reopened]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: [1.2.0]
+        julia-arch: [x86]
+        os: [ubuntu-latest]
+    steps:
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.julia-version }}
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'


### PR DESCRIPTION
IMO it would be useful to figure out new releases of dependent packages in a more automated fashion to avoid issues such as https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/963. Apparently https://github.com/bcbi/CompatHelper.jl (it is used, e.g., by Turing.jl) tries to solve this problem.