### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,1 +1,0 @@
-style = "sciml"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,14 +1,19 @@
-name: "Format Check"
+name: format-check
 
 on:
   push:
     branches:
       - 'master'
+      - 'main'
       - 'release-'
     tags: '*'
   pull_request:
 
 jobs:
-  format-check:
-    name: "Format Check"
-    uses: "SciML/.github/.github/workflows/format-check.yml@v1"
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -1,4 +1,4 @@
 pages = [
     "DelayDiffEq.jl: DDE solvers" => "index.md",
-    "Solver API" => "solvers/api.md"
+    "Solver API" => "solvers/api.md",
 ]

--- a/src/DelayDiffEq.jl
+++ b/src/DelayDiffEq.jl
@@ -2,7 +2,7 @@ module DelayDiffEq
 
 import Reexport: @reexport, Reexport
 import OrdinaryDiffEqCore, OrdinaryDiffEqNonlinearSolve, OrdinaryDiffEqDifferentiation,
-       OrdinaryDiffEqRosenbrock
+    OrdinaryDiffEqRosenbrock
 import OrdinaryDiffEqDefault: OrdinaryDiffEqDefault
 import OrdinaryDiffEqFunctionMap: OrdinaryDiffEqFunctionMap
 @reexport using OrdinaryDiffEq
@@ -11,8 +11,8 @@ using DataStructures: BinaryMinHeap
 using LinearAlgebra: opnorm, I
 using Logging: @logmsg
 using RecursiveArrayTools: copyat_or_push!, recursivecopy, recursivecopy!,
-                           recursive_bottom_eltype, recursive_unitless_bottom_eltype,
-                           recursive_unitless_eltype
+    recursive_bottom_eltype, recursive_unitless_bottom_eltype,
+    recursive_unitless_eltype
 using ForwardDiff: ForwardDiff
 
 import ArrayInterface
@@ -20,14 +20,14 @@ import SimpleNonlinearSolve
 import SymbolicIndexingInterface as SII
 
 using SciMLBase: AbstractDDEAlgorithm, AbstractDDEIntegrator, AbstractODEIntegrator,
-                 DEIntegrator
+    DEIntegrator
 
 using Base: deleteat!
 import FastBroadcast: @..
 
 using OrdinaryDiffEqNonlinearSolve: NLAnderson, NLFunctional
 using OrdinaryDiffEqCore: AbstractNLSolverCache, SlowConvergence,
-                          alg_extrapolates, alg_maximum_order, initialize!
+    alg_extrapolates, alg_maximum_order, initialize!
 using OrdinaryDiffEqRosenbrock: RosenbrockMutableCache
 using OrdinaryDiffEqFunctionMap: FunctionMap
 # using OrdinaryDiffEqDifferentiation: resize_grad_config!, resize_jac_config!
@@ -37,15 +37,15 @@ using OrdinaryDiffEqCore: AutoSwitch, CompositeAlgorithm
 using OrdinaryDiffEq: OrdinaryDiffEq
 using OrdinaryDiffEqDefault: DefaultODEAlgorithm
 using SciMLBase: CallbackSet, DAEProblem, DDEProblem, DESolution, ODEProblem, ReturnCode,
-                 VectorContinuousCallback, addat!, addat_non_user_cache!,
-                 deleteat_non_user_cache!,
-                 du_cache, full_cache, get_tmp_cache, isinplace,
-                 reeval_internals_due_to_modification!,
-                 reinit!, resize_non_user_cache!, savevalues!, u_cache, user_cache,
-                 step!, terminate!, u_modified!, get_proposed_dt, set_proposed_dt!,
-                 auto_dt_reset!,
-                 add_tstop!, add_saveat!, get_du, get_du!, addsteps!,
-                 change_t_via_interpolation!, isadaptive
+    VectorContinuousCallback, addat!, addat_non_user_cache!,
+    deleteat_non_user_cache!,
+    du_cache, full_cache, get_tmp_cache, isinplace,
+    reeval_internals_due_to_modification!,
+    reinit!, resize_non_user_cache!, savevalues!, u_cache, user_cache,
+    step!, terminate!, u_modified!, get_proposed_dt, set_proposed_dt!,
+    auto_dt_reset!,
+    add_tstop!, add_saveat!, get_du, get_du!, addsteps!,
+    change_t_via_interpolation!, isadaptive
 using DiffEqBase: initialize!
 import DiffEqBase
 
@@ -75,10 +75,10 @@ include("utils.jl")
 
 # Default solver for DDEProblems
 function SciMLBase.__solve(prob::DDEProblem; kwargs...)
-    SciMLBase.solve(prob, MethodOfSteps(DefaultODEAlgorithm()); kwargs...)
+    return SciMLBase.solve(prob, MethodOfSteps(DefaultODEAlgorithm()); kwargs...)
 end
 function SciMLBase.__init(prob::DDEProblem; kwargs...)
-    DiffEqBase.init(prob, MethodOfSteps(DefaultODEAlgorithm()); kwargs...)
+    return DiffEqBase.init(prob, MethodOfSteps(DefaultODEAlgorithm()); kwargs...)
 end
 
 end # module

--- a/src/alg_utils.jl
+++ b/src/alg_utils.jl
@@ -1,13 +1,13 @@
 ## SciMLBase Trait Definitions
 
 function SciMLBase.isautodifferentiable(alg::AbstractMethodOfStepsAlgorithm)
-    SciMLBase.isautodifferentiable(alg.alg)
+    return SciMLBase.isautodifferentiable(alg.alg)
 end
 function SciMLBase.allows_arbitrary_number_types(alg::AbstractMethodOfStepsAlgorithm)
-    SciMLBase.allows_arbitrary_number_types(alg.alg)
+    return SciMLBase.allows_arbitrary_number_types(alg.alg)
 end
 function SciMLBase.allowscomplex(alg::AbstractMethodOfStepsAlgorithm)
-    SciMLBase.allowscomplex(alg.alg)
+    return SciMLBase.allowscomplex(alg.alg)
 end
 SciMLBase.isdiscrete(alg::AbstractMethodOfStepsAlgorithm) = SciMLBase.isdiscrete(alg.alg)
 SciMLBase.isadaptive(alg::AbstractMethodOfStepsAlgorithm) = SciMLBase.isadaptive(alg.alg)
@@ -15,51 +15,51 @@ SciMLBase.isadaptive(alg::AbstractMethodOfStepsAlgorithm) = SciMLBase.isadaptive
 ## DelayDiffEq Internal Traits
 
 function isconstrained(alg::AbstractMethodOfStepsAlgorithm{constrained}) where {constrained}
-    constrained
+    return constrained
 end
 OrdinaryDiffEqCore.uses_uprev(alg::AbstractMethodOfStepsAlgorithm, adaptive) = true
 
 function OrdinaryDiffEqCore.isimplicit(alg::AbstractMethodOfStepsAlgorithm)
-    OrdinaryDiffEqCore.isimplicit(alg.alg)
+    return OrdinaryDiffEqCore.isimplicit(alg.alg)
 end
 function OrdinaryDiffEqCore.isdtchangeable(alg::AbstractMethodOfStepsAlgorithm)
-    OrdinaryDiffEqCore.isdtchangeable(alg.alg)
+    return OrdinaryDiffEqCore.isdtchangeable(alg.alg)
 end
 function OrdinaryDiffEqCore.ismultistep(alg::AbstractMethodOfStepsAlgorithm)
-    OrdinaryDiffEqCore.ismultistep(alg.alg)
+    return OrdinaryDiffEqCore.ismultistep(alg.alg)
 end
 function OrdinaryDiffEqCore.isautoswitch(alg::AbstractMethodOfStepsAlgorithm)
-    OrdinaryDiffEqCore.isautoswitch(alg.alg)
+    return OrdinaryDiffEqCore.isautoswitch(alg.alg)
 end
 function OrdinaryDiffEqCore.get_chunksize(alg::AbstractMethodOfStepsAlgorithm)
-    OrdinaryDiffEqCore.get_chunksize(alg.alg)
+    return OrdinaryDiffEqCore.get_chunksize(alg.alg)
 end
 function OrdinaryDiffEqCore.get_chunksize_int(alg::AbstractMethodOfStepsAlgorithm)
-    OrdinaryDiffEqCore.get_chunksize_int(alg.alg)
+    return OrdinaryDiffEqCore.get_chunksize_int(alg.alg)
 end
 function OrdinaryDiffEqCore.alg_autodiff(alg::AbstractMethodOfStepsAlgorithm)
-    OrdinaryDiffEqCore.alg_autodiff(alg.alg)
+    return OrdinaryDiffEqCore.alg_autodiff(alg.alg)
 end
 function OrdinaryDiffEqCore.alg_difftype(alg::AbstractMethodOfStepsAlgorithm)
-    OrdinaryDiffEqCore.alg_difftype(alg.alg)
+    return OrdinaryDiffEqCore.alg_difftype(alg.alg)
 end
 function OrdinaryDiffEqCore.standardtag(alg::AbstractMethodOfStepsAlgorithm)
-    OrdinaryDiffEqCore.standardtag(alg.alg)
+    return OrdinaryDiffEqCore.standardtag(alg.alg)
 end
 function OrdinaryDiffEqCore.concrete_jac(alg::AbstractMethodOfStepsAlgorithm)
-    OrdinaryDiffEqCore.concrete_jac(alg.alg)
+    return OrdinaryDiffEqCore.concrete_jac(alg.alg)
 end
 function OrdinaryDiffEqCore.alg_extrapolates(alg::AbstractMethodOfStepsAlgorithm)
-    OrdinaryDiffEqCore.alg_extrapolates(alg.alg)
+    return OrdinaryDiffEqCore.alg_extrapolates(alg.alg)
 end
 function SciMLBase.alg_order(alg::AbstractMethodOfStepsAlgorithm)
-    SciMLBase.alg_order(alg.alg)
+    return SciMLBase.alg_order(alg.alg)
 end
 function OrdinaryDiffEqCore.alg_maximum_order(alg::AbstractMethodOfStepsAlgorithm)
-    OrdinaryDiffEqCore.alg_maximum_order(alg.alg)
+    return OrdinaryDiffEqCore.alg_maximum_order(alg.alg)
 end
 function OrdinaryDiffEqCore.alg_adaptive_order(alg::AbstractMethodOfStepsAlgorithm)
-    OrdinaryDiffEqCore.alg_adaptive_order(alg.alg)
+    return OrdinaryDiffEqCore.alg_adaptive_order(alg.alg)
 end
 
 """
@@ -72,7 +72,9 @@ iscomposite(::OrdinaryDiffEqCore.OrdinaryDiffEqCompositeAlgorithm) = true
 iscomposite(alg::AbstractMethodOfStepsAlgorithm) = iscomposite(alg.alg)
 
 function DiffEqBase.prepare_alg(alg::MethodOfSteps, u0, p, prob)
-    MethodOfSteps(DiffEqBase.prepare_alg(alg.alg, u0, p, prob);
+    return MethodOfSteps(
+        DiffEqBase.prepare_alg(alg.alg, u0, p, prob);
         constrained = isconstrained(alg),
-        fpsolve = alg.fpsolve)
+        fpsolve = alg.fpsolve
+    )
 end

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -32,5 +32,5 @@ sixth-order Runge-Kutta methods for the solution of state-dependent functional d
 equations", Applied Numerical Mathematics, 1997.
 """
 function MethodOfSteps(alg; constrained = false, fpsolve = NLFunctional())
-    MethodOfSteps{typeof(alg), typeof(fpsolve), constrained}(alg, fpsolve)
+    return MethodOfSteps{typeof(alg), typeof(fpsolve), constrained}(alg, fpsolve)
 end

--- a/src/discontinuity_type.jl
+++ b/src/discontinuity_type.jl
@@ -12,10 +12,10 @@ end
 # ordering of discontinuities
 Base.:<(a::Discontinuity, b::Discontinuity) = a.t < b.t || (a.t == b.t && a.order < b.order)
 function Base.isless(a::Discontinuity, b::Discontinuity)
-    isless(a.t, b.t) || (isequal(a.t, b.t) && isless(a.order, b.order))
+    return isless(a.t, b.t) || (isequal(a.t, b.t) && isless(a.order, b.order))
 end
 function Base.isequal(a::Discontinuity, b::Discontinuity)
-    isequal(a.t, b.t) && isequal(a.order, b.order)
+    return isequal(a.t, b.t) && isequal(a.order, b.order)
 end
 Base.:(==)(a::Discontinuity, b::Discontinuity) = a.t == b.t && a.order == b.order
 
@@ -38,10 +38,17 @@ Base.convert(::Type{T}, d::Discontinuity) where {T <: Number} = convert(T, d.t)
 Base.convert(::Type{T}, d::Discontinuity{T}) where {T <: Number} = d.t
 
 # Fix ForwardDiff ambiguities
-function Base.convert(::Type{ForwardDiff.Dual{T, V, N}},
-        ::Discontinuity{ForwardDiff.Dual{T, V, N}}) where {N, V, T}
-    throw(MethodError(convert, (
-        ForwardDiff.Dual{T, V, N}, Discontinuity{ForwardDiff.Dual{T, V, N}})))
+function Base.convert(
+        ::Type{ForwardDiff.Dual{T, V, N}},
+        ::Discontinuity{ForwardDiff.Dual{T, V, N}}
+    ) where {N, V, T}
+    throw(
+        MethodError(
+            convert, (
+                ForwardDiff.Dual{T, V, N}, Discontinuity{ForwardDiff.Dual{T, V, N}},
+            )
+        )
+    )
 end
 function Base.convert(::Type{ForwardDiff.Dual{T, V, N}}, ::Discontinuity) where {N, V, T}
     throw(MethodError(convert, (ForwardDiff.Dual{T, V, N}, Discontinuity)))

--- a/src/fpsolve/fpsolve.jl
+++ b/src/fpsolve/fpsolve.jl
@@ -1,5 +1,5 @@
 function OrdinaryDiffEqNonlinearSolve.initial_η(fpsolver::FPSolver, integrator::DDEIntegrator)
-    fpsolver.ηold
+    return fpsolver.ηold
 end
 
 OrdinaryDiffEqCore.apply_step!(fpsolver::FPSolver, integrator::DDEIntegrator) = nothing
@@ -11,7 +11,7 @@ function SciMLBase.postamble!(fpsolver::FPSolver, integrator::DDEIntegrator)
         integrator.stats.nfpconvfail += 1
     end
     integrator.force_stepfail = OrdinaryDiffEqNonlinearSolve.nlsolvefail(fpsolver) ||
-                                integrator.force_stepfail
+        integrator.force_stepfail
 
-    nothing
+    return nothing
 end

--- a/src/fpsolve/functional.jl
+++ b/src/fpsolve/functional.jl
@@ -1,5 +1,7 @@
-function OrdinaryDiffEqNonlinearSolve.compute_step!(fpsolver::FPSolver{<:NLFunctional},
-        integrator::DDEIntegrator)
+function OrdinaryDiffEqNonlinearSolve.compute_step!(
+        fpsolver::FPSolver{<:NLFunctional},
+        integrator::DDEIntegrator
+    )
     # update ODE integrator to next time interval together with correct interpolation
     if fpsolver.iter == 1
         advance_ode_integrator!(integrator)
@@ -7,12 +9,13 @@ function OrdinaryDiffEqNonlinearSolve.compute_step!(fpsolver::FPSolver{<:NLFunct
         update_ode_integrator!(integrator)
     end
 
-    compute_step_fixedpoint!(fpsolver, integrator)
+    return compute_step_fixedpoint!(fpsolver, integrator)
 end
 
 function OrdinaryDiffEqNonlinearSolve.compute_step!(
         fpsolver::FPSolver{<:NLAnderson, false},
-        integrator::DDEIntegrator)
+        integrator::DDEIntegrator
+    )
     (; cache, iter) = fpsolver
     (; aa_start) = cache
 
@@ -37,11 +40,13 @@ function OrdinaryDiffEqNonlinearSolve.compute_step!(
     end
 
     # compute next step
-    compute_step_fixedpoint!(fpsolver, integrator)
+    return compute_step_fixedpoint!(fpsolver, integrator)
 end
 
-function OrdinaryDiffEqNonlinearSolve.compute_step!(fpsolver::FPSolver{<:NLAnderson, true},
-        integrator::DDEIntegrator)
+function OrdinaryDiffEqNonlinearSolve.compute_step!(
+        fpsolver::FPSolver{<:NLAnderson, true},
+        integrator::DDEIntegrator
+    )
     (; cache, iter) = fpsolver
     (; aa_start) = cache
 
@@ -66,13 +71,16 @@ function OrdinaryDiffEqNonlinearSolve.compute_step!(fpsolver::FPSolver{<:NLAnder
     end
 
     # compute next step
-    compute_step_fixedpoint!(fpsolver, integrator)
+    return compute_step_fixedpoint!(fpsolver, integrator)
 end
 
 function compute_step_fixedpoint!(
-        fpsolver::FPSolver{<:Union{NLFunctional, NLAnderson},
-            false},
-        integrator::DDEIntegrator)
+        fpsolver::FPSolver{
+            <:Union{NLFunctional, NLAnderson},
+            false,
+        },
+        integrator::DDEIntegrator
+    )
     (; t, opts) = integrator
     (; cache) = fpsolver
     ode_integrator = integrator.integrator
@@ -82,22 +90,27 @@ function compute_step_fixedpoint!(
 
     # compute residuals
     dz = integrator.u .- ode_integrator.u
-    atmp = DiffEqBase.calculate_residuals(dz, ode_integrator.u, integrator.u,
+    atmp = DiffEqBase.calculate_residuals(
+        dz, ode_integrator.u, integrator.u,
         opts.abstol, opts.reltol, opts.internalnorm,
-        t)
+        t
+    )
 
     # cache results
     if isdefined(cache, :dz)
         cache.dz = dz
     end
 
-    opts.internalnorm(atmp, t)
+    return opts.internalnorm(atmp, t)
 end
 
 function compute_step_fixedpoint!(
-        fpsolver::FPSolver{<:Union{NLFunctional, NLAnderson},
-            true},
-        integrator::DDEIntegrator)
+        fpsolver::FPSolver{
+            <:Union{NLFunctional, NLAnderson},
+            true,
+        },
+        integrator::DDEIntegrator
+    )
     (; t, opts) = integrator
     (; cache) = fpsolver
     (; dz, atmp) = cache
@@ -108,10 +121,12 @@ function compute_step_fixedpoint!(
 
     # compute residuals
     @.. dz = integrator.u - ode_integrator.u
-    DiffEqBase.calculate_residuals!(atmp, dz, ode_integrator.u, integrator.u,
-        opts.abstol, opts.reltol, opts.internalnorm, t)
+    DiffEqBase.calculate_residuals!(
+        atmp, dz, ode_integrator.u, integrator.u,
+        opts.abstol, opts.reltol, opts.internalnorm, t
+    )
 
-    opts.internalnorm(atmp, t)
+    return opts.internalnorm(atmp, t)
 end
 
 ## resize!
@@ -119,12 +134,14 @@ end
 function Base.resize!(fpcache::FPFunctionalCache, i::Int)
     resize!(fpcache.atmp, i)
     resize!(fpcache.dz, i)
-    nothing
+    return nothing
 end
 
-function Base.resize!(fpcache::FPAndersonCache, fpsolver::FPSolver{<:NLAnderson},
-        integrator::DDEIntegrator, i::Int)
-    resize!(fpcache, fpsolver.alg, i)
+function Base.resize!(
+        fpcache::FPAndersonCache, fpsolver::FPSolver{<:NLAnderson},
+        integrator::DDEIntegrator, i::Int
+    )
+    return resize!(fpcache, fpsolver.alg, i)
 end
 
 function Base.resize!(fpcache::FPAndersonCache, fpalg::NLAnderson, i::Int)
@@ -154,5 +171,5 @@ function Base.resize!(fpcache::FPAndersonCache, fpalg::NLAnderson, i::Int)
         end
     end
 
-    nothing
+    return nothing
 end

--- a/src/fpsolve/type.jl
+++ b/src/fpsolve/type.jl
@@ -1,6 +1,6 @@
 # solver
 mutable struct FPSolver{algType, iip, uTolType, C <: AbstractNLSolverCache} <:
-               OrdinaryDiffEqCore.AbstractNLSolver{algType, iip}
+    OrdinaryDiffEqCore.AbstractNLSolver{algType, iip}
     alg::algType
     κ::uTolType
     fast_convergence_cutoff::uTolType
@@ -21,7 +21,7 @@ end
 struct FPFunctionalConstantCache <: AbstractNLSolverCache end
 
 mutable struct FPAndersonCache{uType, uNoUnitsType, uEltypeNoUnits, D} <:
-               AbstractNLSolverCache
+    AbstractNLSolverCache
     atmp::uNoUnitsType
     dz::uType
     dzold::uType
@@ -36,7 +36,7 @@ mutable struct FPAndersonCache{uType, uNoUnitsType, uEltypeNoUnits, D} <:
 end
 
 mutable struct FPAndersonConstantCache{uType, uEltypeNoUnits, D} <:
-               AbstractNLSolverCache
+    AbstractNLSolverCache
     dz::uType
     dzold::uType
     z₊old::uType

--- a/src/fpsolve/utils.jl
+++ b/src/fpsolve/utils.jl
@@ -1,6 +1,8 @@
 # construct solver for fixed-point iterations
-function build_fpsolver(alg, fpalg::Union{NLFunctional, NLAnderson}, u, uEltypeNoUnits,
-        uBottomEltypeNoUnits, ::Val{true})
+function build_fpsolver(
+        alg, fpalg::Union{NLFunctional, NLAnderson}, u, uEltypeNoUnits,
+        uBottomEltypeNoUnits, ::Val{true}
+    )
     # no fixed-point iterations if the algorithm is constrained
     isconstrained(alg) && return
 
@@ -30,11 +32,13 @@ function build_fpsolver(alg, fpalg::Union{NLFunctional, NLAnderson}, u, uEltypeN
     # build solver
     ηold = one(uTolType)
 
-    FPSolver{typeof(fpalg), true, uTolType, typeof(fpcache)}(fpalg, uTolType(fpalg.κ), uTolType(fpalg.fast_convergence_cutoff), ηold, 10000, fpalg.max_iter, SlowConvergence, fpcache, 0)
+    return FPSolver{typeof(fpalg), true, uTolType, typeof(fpcache)}(fpalg, uTolType(fpalg.κ), uTolType(fpalg.fast_convergence_cutoff), ηold, 10000, fpalg.max_iter, SlowConvergence, fpcache, 0)
 end
 
-function build_fpsolver(alg, fpalg::Union{NLFunctional, NLAnderson}, u, uEltypeNoUnits,
-        uBottomEltypeNoUnits, ::Val{false})
+function build_fpsolver(
+        alg, fpalg::Union{NLFunctional, NLAnderson}, u, uEltypeNoUnits,
+        uBottomEltypeNoUnits, ::Val{false}
+    )
     # no fixed-point iterations if the algorithm is constrained
     isconstrained(alg) && return
 
@@ -55,19 +59,23 @@ function build_fpsolver(alg, fpalg::Union{NLFunctional, NLAnderson}, u, uEltypeN
         dzold = u
         z₊old = u
 
-        fpcache = FPAndersonConstantCache(dz, dzold, z₊old, Δz₊s, Q, R, γs, 0,
+        fpcache = FPAndersonConstantCache(
+            dz, dzold, z₊old, Δz₊s, Q, R, γs, 0,
             fpalg.aa_start,
-            fpalg.droptol)
+            fpalg.droptol
+        )
     end
 
     # build solver
     ηold = one(uTolType)
 
-    FPSolver{typeof(fpalg), false, uTolType, typeof(fpcache)}(fpalg, uTolType(fpalg.κ),
+    return FPSolver{typeof(fpalg), false, uTolType, typeof(fpcache)}(
+        fpalg, uTolType(fpalg.κ),
         uTolType(fpalg.fast_convergence_cutoff),
         ηold, 10_000,
         fpalg.max_iter,
-        SlowConvergence, fpcache, 0)
+        SlowConvergence, fpcache, 0
+    )
 end
 
 ## resize
@@ -79,9 +87,9 @@ function resize_fpsolver!(integrator::DDEIntegrator, i::Int)
         resize!(fpsolver, integrator, i)
     end
 
-    nothing
+    return nothing
 end
 
 function Base.resize!(fpsolver::FPSolver, integrator::DDEIntegrator, i::Int)
-    resize!(fpsolver.cache, fpsolver, integrator, i)
+    return resize!(fpsolver.cache, fpsolver, integrator, i)
 end

--- a/src/functionwrapper.jl
+++ b/src/functionwrapper.jl
@@ -7,7 +7,7 @@ macro wrap_h(signature)
     args = signature.args[2:end]
     args_wo_h = [arg for arg in args if arg !== :h]
 
-    quote
+    return quote
         if f.$name === nothing
             nothing
         else
@@ -25,7 +25,7 @@ macro wrap_h(signature)
 end
 
 struct ODEFunctionWrapper{iip, F, H, TMM, Ta, Tt, TJ, JP, SP, TW, TWt, TPJ, S, TCV, ID} <:
-       SciMLBase.AbstractODEFunction{iip}
+    SciMLBase.AbstractODEFunction{iip}
     f::F
     h::H
     mass_matrix::TMM
@@ -48,12 +48,15 @@ function ODEFunctionWrapper(f::SciMLBase.AbstractDDEFunction, h)
     Wfact = @wrap_h Wfact(W, u, h, p, dtgamma, t)
     Wfact_t = @wrap_h Wfact_t(W, u, h, p, dtgamma, t)
 
-    ODEFunctionWrapper{isinplace(f), typeof(f.f), typeof(h), typeof(f.mass_matrix),
+    return ODEFunctionWrapper{
+        isinplace(f), typeof(f.f), typeof(h), typeof(f.mass_matrix),
         typeof(f.analytic), typeof(f.tgrad), typeof(jac),
         typeof(f.jac_prototype), typeof(f.sparsity),
         typeof(Wfact), typeof(Wfact_t),
         typeof(f.paramjac), typeof(f.sys), typeof(f.colorvec),
-        typeof(f.initialization_data)}(f.f, h,
+        typeof(f.initialization_data),
+    }(
+        f.f, h,
         f.mass_matrix,
         f.analytic,
         f.tgrad, jac,
@@ -64,7 +67,8 @@ function ODEFunctionWrapper(f::SciMLBase.AbstractDDEFunction, h)
         f.paramjac,
         f.sys,
         f.colorvec,
-        f.initialization_data)
+        f.initialization_data
+    )
 end
 
 (f::ODEFunctionWrapper{true})(du, u, p, t) = f.f(du, u, f.h, p, t)

--- a/src/history_function.jl
+++ b/src/history_function.jl
@@ -17,8 +17,10 @@ end
 
 HistoryFunction(h, integrator) = HistoryFunction(h, integrator, false)
 
-function (f::HistoryFunction)(p, t, ::Type{Val{deriv}} = Val{0};
-        idxs = nothing) where {deriv}
+function (f::HistoryFunction)(
+        p, t, ::Type{Val{deriv}} = Val{0};
+        idxs = nothing
+    ) where {deriv}
     (; integrator) = f
     (; tdir, sol) = integrator
 
@@ -59,8 +61,10 @@ function (f::HistoryFunction)(p, t, ::Type{Val{deriv}} = Val{0};
     end
 end
 
-function (f::HistoryFunction)(val, p, t, ::Type{Val{deriv}} = Val{0};
-        idxs = nothing) where {deriv}
+function (f::HistoryFunction)(
+        val, p, t, ::Type{Val{deriv}} = Val{0};
+        idxs = nothing
+    ) where {deriv}
     (; integrator) = f
     (; tdir, sol) = integrator
 

--- a/src/integrators/interface.jl
+++ b/src/integrators/interface.jl
@@ -13,12 +13,14 @@ function OrdinaryDiffEqCore.loopfooter!(integrator::DDEIntegrator)
         end
     end
 
-    nothing
+    return nothing
 end
 
 # save current state of the integrator
-function DiffEqBase.savevalues!(integrator::HistoryODEIntegrator, force_save = false,
-        reduce_size = false)::Tuple{Bool, Bool}
+function DiffEqBase.savevalues!(
+        integrator::HistoryODEIntegrator, force_save = false,
+        reduce_size = false
+    )::Tuple{Bool, Bool}
     integrator.saveiter += 1
     # TODO: save history only for a subset of components
     copyat_or_push!(integrator.sol.t, integrator.saveiter, integrator.t)
@@ -28,15 +30,19 @@ function DiffEqBase.savevalues!(integrator::HistoryODEIntegrator, force_save = f
     copyat_or_push!(integrator.sol.k, integrator.saveiter_dense, integrator.k)
 
     if iscomposite(integrator.alg)
-        copyat_or_push!(integrator.sol.alg_choice, integrator.saveiter,
-            integrator.cache.current)
+        copyat_or_push!(
+            integrator.sol.alg_choice, integrator.saveiter,
+            integrator.cache.current
+        )
     end
 
-    true, true
+    return true, true
 end
 
-function DiffEqBase.savevalues!(integrator::DDEIntegrator, force_save = false,
-        reduce_size = false)::Tuple{Bool, Bool}
+function DiffEqBase.savevalues!(
+        integrator::DDEIntegrator, force_save = false,
+        reduce_size = false
+    )::Tuple{Bool, Bool}
     ode_integrator = integrator.integrator
 
     # update time of ODE integrator (can be slightly modified (< 10ϵ) because of time stops)
@@ -61,8 +67,10 @@ function DiffEqBase.savevalues!(integrator::DDEIntegrator, force_save = false,
     end
 
     # update history
-    saved, savedexactly = DiffEqBase.savevalues!(ode_integrator, force_save,
-        false) # reduce_size = false
+    saved, savedexactly = DiffEqBase.savevalues!(
+        ode_integrator, force_save,
+        false
+    ) # reduce_size = false
 
     # check that history was actually updated
     saved || error("dense history could not be updated")
@@ -80,7 +88,7 @@ function DiffEqBase.savevalues!(integrator::DDEIntegrator, force_save = false,
     ode_integrator.dtcache = ode_integrator.dt
 
     # update solution
-    OrdinaryDiffEqCore._savevalues!(integrator, force_save, reduce_size)
+    return OrdinaryDiffEqCore._savevalues!(integrator, force_save, reduce_size)
 end
 
 # clean up the solution of the integrator
@@ -94,8 +102,10 @@ function SciMLBase.postamble!(integrator::HistoryODEIntegrator)
         copyat_or_push!(integrator.sol.k, integrator.saveiter_dense, integrator.k)
 
         if iscomposite(integrator.alg)
-            copyat_or_push!(integrator.sol.alg_choice, integrator.saveiter,
-                integrator.cache.current)
+            copyat_or_push!(
+                integrator.sol.alg_choice, integrator.saveiter,
+                integrator.cache.current
+            )
         end
     end
 
@@ -103,7 +113,7 @@ function SciMLBase.postamble!(integrator::HistoryODEIntegrator)
     resize!(integrator.sol.u, integrator.saveiter)
     resize!(integrator.sol.k, integrator.saveiter_dense)
 
-    nothing
+    return nothing
 end
 
 function SciMLBase.postamble!(integrator::DDEIntegrator)
@@ -111,7 +121,7 @@ function SciMLBase.postamble!(integrator::DDEIntegrator)
     SciMLBase.postamble!(integrator.integrator)
 
     # clean solution of the DDE integrator
-    OrdinaryDiffEqCore._postamble!(integrator)
+    return OrdinaryDiffEqCore._postamble!(integrator)
 end
 
 # perform next integration step
@@ -135,17 +145,19 @@ function OrdinaryDiffEqCore.perform_step!(integrator::DDEIntegrator)
     # update ODE integrator to next time interval together with correct interpolation
     advance_or_update_ode_integrator!(integrator)
 
-    nothing
+    return nothing
 end
 
 # DefaultCache sumtype does lazy initializations of sub-caches
 # Need to overload this function so that the history function has initialized caches
 # https://github.com/SciML/DelayDiffEq.jl/issues/329
-function OrdinaryDiffEqCore.perform_step!(integrator::DDEIntegrator,
-        cache::OrdinaryDiffEqCore.DefaultCache, repeat_step = false)
+function OrdinaryDiffEqCore.perform_step!(
+        integrator::DDEIntegrator,
+        cache::OrdinaryDiffEqCore.DefaultCache, repeat_step = false
+    )
     algs = integrator.alg.algs
     OrdinaryDiffEqCore.init_ith_default_cache(cache, algs, cache.current)
-    if cache.current == 1
+    return if cache.current == 1
         integrator.history.integrator.cache.cache1 = cache.cache1
         OrdinaryDiffEqCore.perform_step!(integrator, @inbounds(cache.cache1), repeat_step)
     elseif cache.current == 2
@@ -178,12 +190,12 @@ function DiffEqBase.initialize!(integrator::DDEIntegrator)
         copyat_or_push!(ode_integrator.k, i, integrator.k[i])
     end
 
-    nothing
+    return nothing
 end
 
 # signal the integrator that state u was modified
 function DiffEqBase.u_modified!(integrator::DDEIntegrator, bool::Bool)
-    integrator.u_modified = bool
+    return integrator.u_modified = bool
 end
 
 # return next integration time step
@@ -192,12 +204,12 @@ DiffEqBase.get_proposed_dt(integrator::DDEIntegrator) = integrator.dtpropose
 # set next integration time step
 function DiffEqBase.set_proposed_dt!(integrator::DDEIntegrator, dt)
     integrator.dtpropose = dt
-    nothing
+    return nothing
 end
 
 # obtain caches
 function DiffEqBase.get_tmp_cache(integrator::DDEIntegrator)
-    get_tmp_cache(integrator, integrator.alg, integrator.cache)
+    return get_tmp_cache(integrator, integrator.alg, integrator.cache)
 end
 DiffEqBase.user_cache(integrator::DDEIntegrator) = user_cache(integrator.cache)
 DiffEqBase.u_cache(integrator::DDEIntegrator) = u_cache(integrator.cache)
@@ -222,13 +234,15 @@ function Base.resize!(integrator::DDEIntegrator, cache, i)
     OrdinaryDiffEqCore.resize_J_W!(cache, integrator, i)
     resize_non_user_cache!(integrator, cache, i)
     resize_fpsolver!(integrator, i)
-    nothing
+    return nothing
 end
 
 DiffEqBase.resize_non_user_cache!(integrator::DDEIntegrator, cache, i) = nothing
 
-function DiffEqBase.resize_non_user_cache!(integrator::DDEIntegrator,
-        cache::RosenbrockMutableCache, i)
+function DiffEqBase.resize_non_user_cache!(
+        integrator::DDEIntegrator,
+        cache::RosenbrockMutableCache, i
+    )
     cache.J = similar(cache.J, i, i)
     cache.W = similar(cache.W, i, i)
 
@@ -242,7 +256,7 @@ function DiffEqBase.resize_non_user_cache!(integrator::DDEIntegrator,
         OrdinaryDiffEqDifferentiation.resize_grad_config!(cache.grad_config, i)
     end
 
-    nothing
+    return nothing
 end
 
 # delete component(s)
@@ -258,12 +272,12 @@ function Base.deleteat!(integrator::DDEIntegrator, idxs)
     for c in full_cache(integrator)
         deleteat!(c, idxs)
     end
-    deleteat_non_user_cache!(integrator, integrator.cache, i)
+    return deleteat_non_user_cache!(integrator, integrator.cache, i)
 end
 
 function DiffEqBase.deleteat_non_user_cache!(integrator::DDEIntegrator, cache, idxs)
     i = length(integrator.u)
-    resize_non_user_cache!(integrator, cache, i)
+    return resize_non_user_cache!(integrator, cache, i)
 end
 
 # add component(s)
@@ -279,34 +293,36 @@ function DiffEqBase.addat!(integrator::DDEIntegrator, idxs)
     for c in full_cache(integrator)
         addat!(c, idxs)
     end
-    addat_non_user_cache!(integrator, integrator.cache, idxs)
+    return addat_non_user_cache!(integrator, integrator.cache, idxs)
 end
 
 function DiffEqBase.addat_non_user_cache!(integrator::DDEIntegrator, cache, idxs)
     i = length(integrator.u)
-    resize_non_user_cache!(integrator, cache, i)
+    return resize_non_user_cache!(integrator, cache, i)
 end
 
 # error check
 function SciMLBase.last_step_failed(integrator::DDEIntegrator)
-    integrator.last_stepfail && !integrator.opts.adaptive
+    return integrator.last_stepfail && !integrator.opts.adaptive
 end
 
 # terminate integration
 function DiffEqBase.terminate!(integrator::DDEIntegrator, retcode = ReturnCode.Terminated)
     integrator.sol = SciMLBase.solution_new_retcode(integrator.sol, retcode)
     integrator.opts.tstops.valtree = typeof(integrator.opts.tstops.valtree)()
-    nothing
+    return nothing
 end
 
 # integrator can be reinitialized
 SciMLBase.has_reinit(::HistoryODEIntegrator) = true
 SciMLBase.has_reinit(integrator::DDEIntegrator) = true
 
-function DiffEqBase.reinit!(integrator::HistoryODEIntegrator, u0 = integrator.sol.prob.u0;
+function DiffEqBase.reinit!(
+        integrator::HistoryODEIntegrator, u0 = integrator.sol.prob.u0;
         t0 = integrator.sol.prob.tspan[1],
         tf = integrator.sol.prob.tspan[end],
-        erase_sol = true)
+        erase_sol = true
+    )
     # reinit initial values of the integrator
     if isinplace(integrator.sol.prob)
         recursivecopy!(integrator.u, u0)
@@ -337,7 +353,7 @@ function DiffEqBase.reinit!(integrator::HistoryODEIntegrator, u0 = integrator.so
         integrator.saveiter_dense = 1
     end
 
-    nothing
+    return nothing
 end
 
 """
@@ -350,7 +366,8 @@ end
 Reinitialize `integrator` with (optionally) different initial state `u0`, different
 integration interval from `t0` to `tf`, and erased solution if `erase_sol = true`.
 """
-function DiffEqBase.reinit!(integrator::DDEIntegrator, u0 = integrator.sol.prob.u0;
+function DiffEqBase.reinit!(
+        integrator::DDEIntegrator, u0 = integrator.sol.prob.u0;
         t0 = integrator.sol.prob.tspan[1],
         tf = integrator.sol.prob.tspan[end],
         erase_sol = true,
@@ -358,12 +375,13 @@ function DiffEqBase.reinit!(integrator::DDEIntegrator, u0 = integrator.sol.prob.
         saveat = integrator.opts.saveat_cache,
         d_discontinuities = integrator.opts.d_discontinuities_cache,
         order_discontinuity_t0 = t0 == integrator.sol.prob.tspan[1] &&
-                                 u0 == integrator.sol.prob.u0 ?
-                                 integrator.order_discontinuity_t0 : 0,
+            u0 == integrator.sol.prob.u0 ?
+            integrator.order_discontinuity_t0 : 0,
         reset_dt = iszero(integrator.dtcache) &&
-                   integrator.opts.adaptive,
+            integrator.opts.adaptive,
         reinit_callbacks = true, initialize_save = true,
-        reinit_cache = true)
+        reinit_cache = true
+    )
     # reinit history
     reinit!(integrator.integrator, u0; t0 = t0, tf = tf, erase_sol = true)
 
@@ -389,22 +407,25 @@ function DiffEqBase.reinit!(integrator::DDEIntegrator, u0 = integrator.sol.prob.
     # reinit time stops, time points at which solution is saved, and discontinuities
     tType = typeof(integrator.t)
     tspan = (tType(t0), tType(tf))
-    integrator.opts.tstops = OrdinaryDiffEqCore.initialize_tstops(tType, tstops,
-        d_discontinuities, tspan)
+    integrator.opts.tstops = OrdinaryDiffEqCore.initialize_tstops(
+        tType, tstops,
+        d_discontinuities, tspan
+    )
     integrator.opts.saveat = OrdinaryDiffEqCore.initialize_saveat(tType, saveat, tspan)
     integrator.opts.d_discontinuities = OrdinaryDiffEqCore.initialize_d_discontinuities(
         Discontinuity{
             tType,
-            Int
+            Int,
         },
         d_discontinuities,
-        tspan)
+        tspan
+    )
 
     # update order of initial discontinuity and propagated discontinuities
     integrator.order_discontinuity_t0 = order_discontinuity_t0
     maximum_order = OrdinaryDiffEqCore.alg_maximum_order(integrator.alg)
     tstops_propagated,
-    d_discontinuities_propagated = initialize_tstops_d_discontinuities_propagated(
+        d_discontinuities_propagated = initialize_tstops_d_discontinuities_propagated(
         tType,
         tstops,
         d_discontinuities,
@@ -412,7 +433,8 @@ function DiffEqBase.reinit!(integrator::DDEIntegrator, u0 = integrator.sol.prob.
         order_discontinuity_t0,
         maximum_order,
         integrator.sol.prob.constant_lags,
-        integrator.sol.prob.neutral)
+        integrator.sol.prob.neutral
+    )
     integrator.tstops_propagated = tstops_propagated
     integrator.d_discontinuities_propagated = d_discontinuities_propagated
 
@@ -447,7 +469,8 @@ function DiffEqBase.reinit!(integrator::DDEIntegrator, u0 = integrator.sol.prob.
         if order_discontinuity_t0 ≤ OrdinaryDiffEqCore.alg_maximum_order(integrator.alg)
             resize!(integrator.tracked_discontinuities, 1)
             integrator.tracked_discontinuities[1] = Discontinuity(
-                integrator.tdir * integrator.t, order_discontinuity_t0)
+                integrator.tdir * integrator.t, order_discontinuity_t0
+            )
         else
             resize!(integrator.tracked_discontinuities, 0)
         end
@@ -480,7 +503,7 @@ function DiffEqBase.reinit!(integrator::DDEIntegrator, u0 = integrator.sol.prob.
         DiffEqBase.initialize!(integrator)
     end
 
-    nothing
+    return nothing
 end
 
 function DiffEqBase.auto_dt_reset!(integrator::DDEIntegrator)
@@ -497,56 +520,60 @@ function DiffEqBase.auto_dt_reset!(integrator::DDEIntegrator)
 
     # determine initial time step
     ode_prob = ODEProblem(f, prob.u0, prob.tspan, prob.p)
-    integrator.dt = OrdinaryDiffEqCore.ode_determine_initdt(u, t, tdir, dtmax, opts.abstol,
+    integrator.dt = OrdinaryDiffEqCore.ode_determine_initdt(
+        u, t, tdir, dtmax, opts.abstol,
         opts.reltol, opts.internalnorm,
-        ode_prob, integrator)
+        ode_prob, integrator
+    )
 
     # update statistics
     stats.nf += 2
 
-    nothing
+    return nothing
 end
 
 function DiffEqBase.add_tstop!(integrator::DDEIntegrator, t)
     integrator.tdir * (t - integrator.t) < 0 &&
         error("Tried to add a tstop that is behind the current time. This is strictly forbidden")
-    push!(integrator.opts.tstops, integrator.tdir * t)
+    return push!(integrator.opts.tstops, integrator.tdir * t)
 end
 
 function DiffEqBase.add_saveat!(integrator::DDEIntegrator, t)
     integrator.tdir * (t - integrator.t) < 0 &&
         error("Tried to add a saveat that is behind the current time. This is strictly forbidden")
-    push!(integrator.opts.saveat, integrator.tdir * t)
+    return push!(integrator.opts.saveat, integrator.tdir * t)
 end
 
 @inline function DiffEqBase.get_du(integrator::DDEIntegrator)
-    integrator.fsallast
+    return integrator.fsallast
 end
 
 @inline function DiffEqBase.get_du!(out, integrator::DDEIntegrator)
-    out .= integrator.fsallast
+    return out .= integrator.fsallast
 end
 
 SciMLBase.has_stats(::DDEIntegrator) = true
 
 function DiffEqBase.addsteps!(integrator::DDEIntegrator, args...)
-    OrdinaryDiffEqCore.ode_addsteps!(integrator, args...)
+    return OrdinaryDiffEqCore.ode_addsteps!(integrator, args...)
 end
 
-function DiffEqBase.change_t_via_interpolation!(integrator::DDEIntegrator,
+function DiffEqBase.change_t_via_interpolation!(
+        integrator::DDEIntegrator,
         t, modify_save_endpoint::Type{Val{T}} = Val{false},
-        reinitialize_alg = nothing) where {T}
-    OrdinaryDiffEqCore._change_t_via_interpolation!(integrator, t, modify_save_endpoint, reinitialize_alg)
+        reinitialize_alg = nothing
+    ) where {T}
+    return OrdinaryDiffEqCore._change_t_via_interpolation!(integrator, t, modify_save_endpoint, reinitialize_alg)
 end
 
 # tstops interface for PeriodicCallback support (issue #341)
 DiffEqBase.get_tstops(integrator::DDEIntegrator) = integrator.opts.tstops
 function DiffEqBase.get_tstops_array(integrator::DDEIntegrator)
-    DiffEqBase.get_tstops(integrator).valtree
+    return DiffEqBase.get_tstops(integrator).valtree
 end
 function DiffEqBase.get_tstops_max(integrator::DDEIntegrator)
     tstops_array = DiffEqBase.get_tstops_array(integrator)
-    isempty(tstops_array) ? integrator.sol.prob.tspan[end] : maximum(tstops_array)
+    return isempty(tstops_array) ? integrator.sol.prob.tspan[end] : maximum(tstops_array)
 end
 
 # update integrator when u is modified by callbacks
@@ -555,20 +582,26 @@ function OrdinaryDiffEqCore.handle_callback_modifiers!(integrator::DDEIntegrator
 
     # update heap of discontinuities
     # discontinuity is assumed to be of order 0, i.e. solution x is discontinuous
-    push!(integrator.opts.d_discontinuities,
-        Discontinuity(integrator.tdir * integrator.t, 0))
+    return push!(
+        integrator.opts.d_discontinuities,
+        Discontinuity(integrator.tdir * integrator.t, 0)
+    )
 end
 
 # recalculate interpolation data and update the ODE integrator
-function DiffEqBase.reeval_internals_due_to_modification!(integrator::DDEIntegrator,
+function DiffEqBase.reeval_internals_due_to_modification!(
+        integrator::DDEIntegrator,
         ::Type{Val{not_initialization}} = Val{true};
-        callback_initializealg = nothing) where {not_initialization}
+        callback_initializealg = nothing
+    ) where {not_initialization}
     ode_integrator = integrator.integrator
 
     if integrator.isdae
-        SciMLBase.initialize_dae!(integrator,
+        SciMLBase.initialize_dae!(
+            integrator,
             isnothing(callback_initializealg) ? integrator.initializealg :
-            callback_initializealg)
+                callback_initializealg
+        )
         OrdinaryDiffEqCore.update_uprev!(integrator)
     end
     if not_initialization
@@ -590,12 +623,12 @@ function DiffEqBase.reeval_internals_due_to_modification!(integrator::DDEIntegra
         ode_integrator.u = integrator.u
     end
 
-    integrator.u_modified = false
+    return integrator.u_modified = false
 end
 
 # perform one step
 function DiffEqBase.step!(integrator::DDEIntegrator)
-    @inbounds begin
+    return @inbounds begin
         if integrator.opts.advance_to_tstop
             while integrator.tdir * integrator.t < first(integrator.opts.tstops)
                 OrdinaryDiffEqCore.loopheader!(integrator)

--- a/src/integrators/type.jl
+++ b/src/integrators/type.jl
@@ -1,7 +1,8 @@
 mutable struct HistoryODEIntegrator{
-    algType, IIP, uType, tType, tdirType, ksEltype, SolType,
-    CacheType, DV} <:
-               AbstractODEIntegrator{algType, IIP, uType, tType}
+        algType, IIP, uType, tType, tdirType, ksEltype, SolType,
+        CacheType, DV,
+    } <:
+    AbstractODEIntegrator{algType, IIP, uType, tType}
     sol::SolType
     u::uType
     k::ksEltype
@@ -19,22 +20,26 @@ mutable struct HistoryODEIntegrator{
 end
 
 function (integrator::HistoryODEIntegrator)(t, deriv::Type = Val{0}; idxs = nothing)
-    OrdinaryDiffEqCore.current_interpolant(t, integrator, idxs, deriv)
+    return OrdinaryDiffEqCore.current_interpolant(t, integrator, idxs, deriv)
 end
 
-function (integrator::HistoryODEIntegrator)(val::AbstractArray,
+function (integrator::HistoryODEIntegrator)(
+        val::AbstractArray,
         t::Union{Number, AbstractArray},
-        deriv::Type = Val{0}; idxs = nothing)
-    OrdinaryDiffEqCore.current_interpolant!(val, t, integrator, idxs, deriv)
+        deriv::Type = Val{0}; idxs = nothing
+    )
+    return OrdinaryDiffEqCore.current_interpolant!(val, t, integrator, idxs, deriv)
 end
 
-mutable struct DDEIntegrator{algType, IIP, uType, tType, P, eigenType, tTypeNoUnits,
-    tdirType,
-    ksEltype, SolType, F, CacheType, IType, FP, O, dAbsType,
-    dRelType, H,
-    tstopsType, discType, FSALType, EventErrorType,
-    CallbackCacheType, DV, IA} <:
-               AbstractDDEIntegrator{algType, IIP, uType, tType}
+mutable struct DDEIntegrator{
+        algType, IIP, uType, tType, P, eigenType, tTypeNoUnits,
+        tdirType,
+        ksEltype, SolType, F, CacheType, IType, FP, O, dAbsType,
+        dRelType, H,
+        tstopsType, discType, FSALType, EventErrorType,
+        CallbackCacheType, DV, IA,
+    } <:
+    AbstractDDEIntegrator{algType, IIP, uType, tType}
     sol::SolType
     u::uType
     k::ksEltype
@@ -99,12 +104,14 @@ mutable struct DDEIntegrator{algType, IIP, uType, tType, P, eigenType, tTypeNoUn
 end
 
 function (integrator::DDEIntegrator)(t, deriv::Type = Val{0}; idxs = nothing)
-    OrdinaryDiffEqCore.current_interpolant(t, integrator, idxs, deriv)
+    return OrdinaryDiffEqCore.current_interpolant(t, integrator, idxs, deriv)
 end
 
-function (integrator::DDEIntegrator)(val::AbstractArray, t::Union{Number, AbstractArray},
-        deriv::Type = Val{0}; idxs = nothing)
-    OrdinaryDiffEqCore.current_interpolant!(val, t, integrator, idxs, deriv)
+function (integrator::DDEIntegrator)(
+        val::AbstractArray, t::Union{Number, AbstractArray},
+        deriv::Type = Val{0}; idxs = nothing
+    )
+    return OrdinaryDiffEqCore.current_interpolant!(val, t, integrator, idxs, deriv)
 end
 
 function SII.get_history_function(integrator::DDEIntegrator)

--- a/src/interpolants.jl
+++ b/src/interpolants.jl
@@ -5,16 +5,16 @@ Calculate constant extrapolation of derivative `deriv` at time `t` and indices `
 for `integrator`.
 """
 function constant_extrapolant(t, integrator::DEIntegrator, idxs, deriv)
-    [constant_extrapolant(τ, integrator, idxs, deriv) for τ in t]
+    return [constant_extrapolant(τ, integrator, idxs, deriv) for τ in t]
 end
 
 function constant_extrapolant(t::Number, integrator::DEIntegrator, idxs, T::Type{Val{0}})
-    idxs === nothing ? integrator.u : integrator.u[idxs]
+    return idxs === nothing ? integrator.u : integrator.u[idxs]
 end
 
 function constant_extrapolant(t::Number, integrator::DEIntegrator, idxs, T::Type{Val{1}})
-    idxs === nothing ? zero(integrator.u) ./ oneunit(t) :
-    zero(integrator.u[idxs]) ./ oneunit(t)
+    return idxs === nothing ? zero(integrator.u) ./ oneunit(t) :
+        zero(integrator.u[idxs]) ./ oneunit(t)
 end
 
 """
@@ -24,12 +24,14 @@ Calculate constant extrapolation of derivative `deriv` at time `t` and indices `
 for `integrator`, and save result in `val` if `val` is not `nothing`.
 """
 function constant_extrapolant!(val, t, integrator::DEIntegrator, idxs, deriv)
-    [constant_extrapolant!(val, τ, integrator, idxs, deriv) for τ in t]
+    return [constant_extrapolant!(val, τ, integrator, idxs, deriv) for τ in t]
 end
 
-function constant_extrapolant!(val, t::Number, integrator::DEIntegrator, idxs,
-        T::Type{Val{0}})
-    if val === nothing
+function constant_extrapolant!(
+        val, t::Number, integrator::DEIntegrator, idxs,
+        T::Type{Val{0}}
+    )
+    return if val === nothing
         if idxs === nothing
             return integrator.u
         else
@@ -42,9 +44,11 @@ function constant_extrapolant!(val, t::Number, integrator::DEIntegrator, idxs,
     end
 end
 
-function constant_extrapolant!(val, t::Number, integrator::DEIntegrator, idxs,
-        T::Type{Val{1}})
-    if val === nothing
+function constant_extrapolant!(
+        val, t::Number, integrator::DEIntegrator, idxs,
+        T::Type{Val{1}}
+    )
+    return if val === nothing
         if idxs === nothing
             return zero(integrator.u) ./ oneunit(t)
         else

--- a/src/track.jl
+++ b/src/track.jl
@@ -12,7 +12,7 @@ function track_propagated_discontinuities!(integrator::DDEIntegrator)
 
     # for dependent lags and previous discontinuities
     for lag in integrator.sol.prob.dependent_lags,
-        discontinuity in integrator.tracked_discontinuities
+            discontinuity in integrator.tracked_discontinuities
         # obtain time of previous discontinuity
         T = discontinuity.t
 
@@ -39,7 +39,7 @@ function track_propagated_discontinuities!(integrator::DDEIntegrator)
         end
     end
 
-    nothing
+    return nothing
 end
 
 """
@@ -60,7 +60,7 @@ function discontinuity_function(integrator::DDEIntegrator, lag, T, t)
         ut = cache
     end
 
-    T + lag(ut, integrator.p, t) - t
+    return T + lag(ut, integrator.p, t) - t
 end
 
 """
@@ -76,9 +76,11 @@ The interval is estimated by checking the signs of `T + lag(u(t), p, t) - t` for
 function discontinuity_interval(integrator::DDEIntegrator, lag, T, Θs)
     # use start and end point of last time interval to check for discontinuities
     previous_condition = discontinuity_function(integrator, lag, T, integrator.t)
-    if isapprox(previous_condition, 0;
-        rtol = integrator.discontinuity_reltol,
-        atol = integrator.discontinuity_abstol)
+    if isapprox(
+            previous_condition, 0;
+            rtol = integrator.discontinuity_reltol,
+            atol = integrator.discontinuity_abstol
+        )
         prev_sign = 0
     else
         prev_sign = cmp(previous_condition, zero(previous_condition))
@@ -113,7 +115,7 @@ function discontinuity_interval(integrator::DDEIntegrator, lag, T, Θs)
         end
     end
 
-    nothing
+    return nothing
 end
 
 """
@@ -130,17 +132,22 @@ function discontinuity_time(integrator::DDEIntegrator, lag, T, (bottom_Θ, top_�
     else
         # define function for root finding
         zero_func = let integrator = integrator, lag = lag, T = T, t = integrator.t,
-            dt = integrator.dt
+                dt = integrator.dt
 
             (θ, p = nothing) -> discontinuity_function(integrator, lag, T, t + θ * dt)
         end
 
         Θ = SimpleNonlinearSolve.solve(
-            SimpleNonlinearSolve.IntervalNonlinearProblem{false}(zero_func,
-                (bottom_Θ,
-                    top_Θ)),
-            SimpleNonlinearSolve.Falsi()).left
+            SimpleNonlinearSolve.IntervalNonlinearProblem{false}(
+                zero_func,
+                (
+                    bottom_Θ,
+                    top_Θ,
+                )
+            ),
+            SimpleNonlinearSolve.Falsi()
+        ).left
     end
 
-    integrator.t + Θ * integrator.dt
+    return integrator.t + Θ * integrator.dt
 end

--- a/test/integrators/cache.jl
+++ b/test/integrators/cache.jl
@@ -2,20 +2,22 @@ using DelayDiffEq, Test
 using Random
 Random.seed!(213)
 
-const CACHE_TEST_ALGS = [Vern7(), Euler(), Midpoint(), RK4(), SSPRK22(), SSPRK33(),
+const CACHE_TEST_ALGS = [
+    Vern7(), Euler(), Midpoint(), RK4(), SSPRK22(), SSPRK33(),
     ORK256(), CarpenterKennedy2N54(), SHLDDRK64(), DGLDDRK73_C(),
     CFRLDDRK64(), TSLDDRK74(),
     CKLLSRK43_2(),
     ParsaniKetchesonDeconinck3S32(),
     BS3(), BS5(), DP5(), DP8(), Feagin10(), Feagin12(), Feagin14(), TanYam7(),
     Tsit5(), TsitPap8(), Vern6(), Vern7(), Vern8(), Vern9(), OwrenZen3(), OwrenZen4(),
-    OwrenZen5()]
+    OwrenZen5(),
+]
 
 function f(du, u, h, p, t)
     for i in 1:length(u)
         du[i] = (0.3 / length(u)) * u[i]
     end
-    nothing
+    return nothing
 end
 
 condition(u, t, integrator) = 1 - maximum(u)
@@ -27,11 +29,13 @@ function affect!(integrator)
     Θ = rand() / 5 + 0.25
     u[maxidx] = Θ
     u[end] = 1 - Θ
-    nothing
+    return nothing
 end
 
-const prob = DDEProblem(f, [0.2], nothing, (0.0, 10.0);
-    callback = ContinuousCallback(condition, affect!))
+const prob = DDEProblem(
+    f, [0.2], nothing, (0.0, 10.0);
+    callback = ContinuousCallback(condition, affect!)
+)
 
 println("Check for stochastic errors")
 for i in 1:10

--- a/test/integrators/events.jl
+++ b/test/integrators/events.jl
@@ -6,15 +6,19 @@ const alg = MethodOfSteps(Tsit5(); constrained = false)
 
 # continuous callback
 @testset "continuous" begin
-    cb = ContinuousCallback((u, t, integrator) -> t - 2.60, # Event when event_f(t,u,k) == 0
-        integrator -> (integrator.u = -integrator.u))
+    cb = ContinuousCallback(
+        (u, t, integrator) -> t - 2.6, # Event when event_f(t,u,k) == 0
+        integrator -> (integrator.u = -integrator.u)
+    )
 
     sol1 = solve(prob, alg, callback = cb)
     ts = findall(x -> x ≈ 2.6, sol1.t)
     @test length(ts) == 2
     @test sol1.u[ts[1]] == -sol1.u[ts[2]]
-    @test sol1(2.6;
-        continuity = :right)≈-sol1(2.6; continuity = :left) atol=1e-5
+    @test sol1(
+        2.6;
+        continuity = :right
+    ) ≈ -sol1(2.6; continuity = :left) atol = 1.0e-5
 
     # fails on 32bit?!
     # see https://github.com/SciML/DelayDiffEq.jl/pull/180
@@ -24,7 +28,7 @@ const alg = MethodOfSteps(Tsit5(); constrained = false)
         @test length(ts) == 2
         @test sol2.u[ts[1]] == -sol2.u[ts[2]]
         @test sol2(2.6; continuity = :right) ≈
-              -sol2(2.6; continuity = :left)
+            -sol2(2.6; continuity = :left)
 
         sol3 = appxtrue(sol1, sol2)
         @test sol3.errors[:L2] < 1.5e-2

--- a/test/integrators/initialization.jl
+++ b/test/integrators/initialization.jl
@@ -23,13 +23,16 @@ using Test
     end
 
     prob_ddae = DDEProblem(
-        DDEFunction{true}(sir_ddae!;
-            mass_matrix = Diagonal([1.0, 1.0, 0.0])),
+        DDEFunction{true}(
+            sir_ddae!;
+            mass_matrix = Diagonal([1.0, 1.0, 0.0])
+        ),
         u0_good,
         sir_history,
         tspan,
         p;
-        constant_lags = (p.τ,))
+        constant_lags = (p.τ,)
+    )
     alg = MethodOfSteps(Rosenbrock23())
     @test_nowarn init(prob_ddae, alg)
     prob_ddae.u0[1] = 2.0

--- a/test/integrators/iterator.jl
+++ b/test/integrators/iterator.jl
@@ -5,12 +5,16 @@ const prob = prob_dde_constant_1delay_scalar
 
 @testset "Basic iterator" begin
     # compute the solution of the DDE
-    sol = solve(prob, MethodOfSteps(BS3());
-        dt = 1 // 2^(4), tstops = [1.5], saveat = 0.01, save_everystep = true)
+    sol = solve(
+        prob, MethodOfSteps(BS3());
+        dt = 1 // 2^(4), tstops = [1.5], saveat = 0.01, save_everystep = true
+    )
 
     # initialize integrator
-    integrator = init(prob, MethodOfSteps(BS3());
-        dt = 1 // 2^(4), tstops = [1.5], saveat = 0.01, save_everystep = true)
+    integrator = init(
+        prob, MethodOfSteps(BS3());
+        dt = 1 // 2^(4), tstops = [1.5], saveat = 0.01, save_everystep = true
+    )
 
     # perform one step
     step!(integrator)
@@ -39,16 +43,20 @@ end
 
 @testset "Advanced iterators" begin
     # move to grid point in one step
-    integrator1 = init(prob, MethodOfSteps(Tsit5());
-        dt = 1 // 2^(4), tstops = [0.5], advance_to_tstop = true)
+    integrator1 = init(
+        prob, MethodOfSteps(Tsit5());
+        dt = 1 // 2^(4), tstops = [0.5], advance_to_tstop = true
+    )
     for (u, t) in tuples(integrator1)
         @test 0.5 ≤ t ≤ 10
     end
 
     # move to grid point in one step and stop there
-    integrator2 = init(prob, MethodOfSteps(Tsit5());
+    integrator2 = init(
+        prob, MethodOfSteps(Tsit5());
         dt = 1 // 2^(4), tstops = [0.5], advance_to_tstop = true,
-        stop_at_next_tstop = true)
+        stop_at_next_tstop = true
+    )
     for (u, t) in tuples(integrator2)
         @test t == 0.5
     end

--- a/test/integrators/residual_control.jl
+++ b/test/integrators/residual_control.jl
@@ -24,16 +24,16 @@ const prob_wo = remake(prob; constant_lags = nothing)
     @test sol.errors[:final] < 3.5e-6
     @test sol.errors[:l2] < 6.5e-5
 
-    sol = solve(prob_wo, alg; abstol = 1e-9, reltol = 1e-6)
+    sol = solve(prob_wo, alg; abstol = 1.0e-9, reltol = 1.0e-6)
 
     @test sol.errors[:l∞] < 6.0e-8
     @test sol.errors[:final] < 3.4e-9
     @test sol.errors[:l2] < 2.2e-8
 
-    sol = solve(prob_wo, alg; abstol = 1e-13, reltol = 1e-13)
+    sol = solve(prob_wo, alg; abstol = 1.0e-13, reltol = 1.0e-13)
 
     # relaxed tests to prevent floating point issues
-    @test sol.errors[:l∞] < 5e-10
+    @test sol.errors[:l∞] < 5.0e-10
     @test sol.errors[:final] < 4.5e-12
     @test sol.errors[:l2] < 7.7e-11 # 7.7e-12
 end
@@ -47,8 +47,10 @@ end
     @test sol.errors[:final] > 1.2e-3
     @test sol.errors[:l2] > 4.5e-2
 
-    sol = solve(prob_wo, MethodOfSteps(OwrenZen5(); constrained = false); abstol = 1e-13,
-        reltol = 1e-13)
+    sol = solve(
+        prob_wo, MethodOfSteps(OwrenZen5(); constrained = false); abstol = 1.0e-13,
+        reltol = 1.0e-13
+    )
 
     @test sol.errors[:l∞] > 1.1e-1
     @test sol.errors[:final] > 1.2e-3

--- a/test/integrators/retcode.jl
+++ b/test/integrators/retcode.jl
@@ -4,8 +4,10 @@ using Test
 const prob = prob_dde_constant_1delay_ip
 
 @testset for composite in (true, false)
-    alg = MethodOfSteps(composite ? AutoTsit5(Rosenbrock23()) : Tsit5();
-        constrained = false)
+    alg = MethodOfSteps(
+        composite ? AutoTsit5(Rosenbrock23()) : Tsit5();
+        constrained = false
+    )
 
     sol1 = solve(prob, alg)
     @test sol1.retcode == ReturnCode.Success

--- a/test/integrators/rosenbrock.jl
+++ b/test/integrators/rosenbrock.jl
@@ -6,9 +6,11 @@ const prob_scalar = prob_dde_constant_1delay_scalar
 const ts = 0:0.1:10
 
 # ODE algorithms
-const algs = [Rosenbrock23(), Rosenbrock32(), ROS3P(), Rodas3(),
+const algs = [
+    Rosenbrock23(), Rosenbrock32(), ROS3P(), Rodas3(),
     RosShamp4(), Veldd4(), Velds4(), GRK4T(), GRK4A(),
-    Ros4LStab(), Rodas4(), Rodas42(), Rodas4P(), Rodas5()]
+    Ros4LStab(), Rodas4(), Rodas42(), Rodas4P(), Rodas5(),
+]
 
 @testset "Algorithm $(nameof(typeof(alg)))" for alg in algs
     println(nameof(typeof(alg)))
@@ -17,7 +19,7 @@ const algs = [Rosenbrock23(), Rosenbrock32(), ROS3P(), Rodas3(),
     sol_ip = solve(prob_ip, stepsalg)
     sol_scalar = solve(prob_scalar, stepsalg)
 
-    @test isapprox(sol_ip(ts, idxs = 1), sol_scalar(ts), rtol = 1e-4)
-    @test isapprox(sol_ip.t, sol_scalar.t, rtol = 1e-4)
-    @test isapprox(sol_ip[1, :], sol_scalar.u, rtol = 1e-4)
+    @test isapprox(sol_ip(ts, idxs = 1), sol_scalar(ts), rtol = 1.0e-4)
+    @test isapprox(sol_ip.t, sol_scalar.t, rtol = 1.0e-4)
+    @test isapprox(sol_ip[1, :], sol_scalar.u, rtol = 1.0e-4)
 end

--- a/test/integrators/sdirk.jl
+++ b/test/integrators/sdirk.jl
@@ -7,19 +7,23 @@ const ts = 0:0.1:10
 
 # ODE algorithms
 noreuse = NLNewton(fast_convergence_cutoff = 0)
-const working_algs = [ImplicitMidpoint(), SSPSDIRK2(), KenCarp5(nlsolve = noreuse),
+const working_algs = [
+    ImplicitMidpoint(), SSPSDIRK2(), KenCarp5(nlsolve = noreuse),
     ImplicitEuler(nlsolve = noreuse), Trapezoid(nlsolve = noreuse),
     TRBDF2(nlsolve = noreuse), SDIRK2(nlsolve = noreuse),
     Kvaerno3(nlsolve = noreuse), KenCarp3(nlsolve = noreuse),
     Cash4(nlsolve = noreuse), Hairer4(nlsolve = noreuse),
     Hairer42(nlsolve = noreuse), Kvaerno4(nlsolve = noreuse), KenCarp4(nlsolve = noreuse),
-    Kvaerno5(nlsolve = noreuse)]
+    Kvaerno5(nlsolve = noreuse),
+]
 
-const broken_algs = [ImplicitEuler(), Trapezoid(),
+const broken_algs = [
+    ImplicitEuler(), Trapezoid(),
     TRBDF2(), SDIRK2(),
     Kvaerno3(), KenCarp3(),
     Cash4(), Hairer4(), Hairer42(), Kvaerno4(), KenCarp4(),
-    Kvaerno5()]
+    Kvaerno5(),
+]
 
 @testset "Algorithm $(nameof(typeof(alg)))" for alg in working_algs
     println(nameof(typeof(alg)))

--- a/test/integrators/verner.jl
+++ b/test/integrators/verner.jl
@@ -14,13 +14,13 @@ using Test
         sol_ip = solve(prob_ip, alg)
 
         @test sol_ip.errors[:l∞] < 8.7e-4
-        @test sol_ip.errors[:final] < 6e-6
+        @test sol_ip.errors[:final] < 6.0e-6
         @test sol_ip.errors[:l2] < 5.4e-4
 
         sol_scalar = solve(prob_scalar, alg)
 
         # fails due to floating point issues
-        @test sol_ip(ts, idxs = 1)≈sol_scalar(ts) atol=1e-5
+        @test sol_ip(ts, idxs = 1) ≈ sol_scalar(ts) atol = 1.0e-5
     end
 
     # Vern7
@@ -35,7 +35,7 @@ using Test
 
         sol_scalar = solve(prob_scalar, alg)
 
-        @test sol_ip(ts, idxs = 1)≈sol_scalar(ts) atol=1e-5
+        @test sol_ip(ts, idxs = 1) ≈ sol_scalar(ts) atol = 1.0e-5
     end
 
     # Vern8
@@ -50,7 +50,7 @@ using Test
 
         sol_scalar = solve(prob_scalar, alg)
 
-        @test sol_ip(ts, idxs = 1)≈sol_scalar(ts) atol=1e-5
+        @test sol_ip(ts, idxs = 1) ≈ sol_scalar(ts) atol = 1.0e-5
     end
 
     # Vern9
@@ -65,7 +65,7 @@ using Test
 
         sol_scalar = solve(prob_scalar, alg)
 
-        @test sol_ip(ts, idxs = 1)≈sol_scalar(ts) atol=1e-5
+        @test sol_ip(ts, idxs = 1) ≈ sol_scalar(ts) atol = 1.0e-5
     end
 end
 

--- a/test/interface/ad.jl
+++ b/test/interface/ad.jl
@@ -11,10 +11,14 @@ h(p, t) = p[4]
 
 @testset "Gradient" begin
     function test(p)
-        prob = DDEProblem(f, p[5], h, eltype(p).((0.0, 10.0)), copy(p);
-            constant_lags = (p[1],))
-        sol = solve(prob, MethodOfSteps(Tsit5()); abstol = 1e-14, reltol = 1e-14,
-            saveat = 1.0)
+        prob = DDEProblem(
+            f, p[5], h, eltype(p).((0.0, 10.0)), copy(p);
+            constant_lags = (p[1],)
+        )
+        sol = solve(
+            prob, MethodOfSteps(Tsit5()); abstol = 1.0e-14, reltol = 1.0e-14,
+            saveat = 1.0
+        )
         sum(sol)
     end
 
@@ -22,7 +26,7 @@ h(p, t) = p[4]
     p = [1.5, 1.0, 0.5]
     findiff = FiniteDiff.finite_difference_gradient(p -> test(vcat(1, p, p[end])), p)
     fordiff = ForwardDiff.gradient(p -> test(vcat(1, p, p[end])), p)
-    @test maximum(abs.(findiff .- fordiff)) < 1e-6
+    @test maximum(abs.(findiff .- fordiff)) < 1.0e-6
 
     # with delay length estimation and without discontinuity
     p = [1.0, 1.5, 1.0, 0.5]
@@ -45,10 +49,14 @@ end
 
 @testset "Jacobian" begin
     function test(p)
-        prob = DDEProblem(f, p[5], h, eltype(p).((0.0, 10.0)), copy(p);
-            constant_lags = (p[1],))
-        sol = solve(prob, MethodOfSteps(Tsit5()); abstol = 1e-14, reltol = 1e-14,
-            saveat = 1.0)
+        prob = DDEProblem(
+            f, p[5], h, eltype(p).((0.0, 10.0)), copy(p);
+            constant_lags = (p[1],)
+        )
+        sol = solve(
+            prob, MethodOfSteps(Tsit5()); abstol = 1.0e-14, reltol = 1.0e-14,
+            saveat = 1.0
+        )
         sol.u
     end
 
@@ -56,7 +64,7 @@ end
     p = [1.5, 1.0, 0.5]
     findiff = FiniteDiff.finite_difference_jacobian(p -> test(vcat(1, p, p[end])), p)
     fordiff = ForwardDiff.jacobian(p -> test(vcat(1, p, p[end])), p)
-    @test maximum(abs.(findiff .- fordiff)) < 2e-6
+    @test maximum(abs.(findiff .- fordiff)) < 2.0e-6
 
     # with delay length estimation and without discontinuity
     p = [1.0, 1.5, 1.0, 0.5]
@@ -79,10 +87,14 @@ end
 
 @testset "Hessian" begin
     function test(p)
-        prob = DDEProblem(f, p[5], h, eltype(p).((0.0, 10.0)), copy(p);
-            constant_lags = (p[1],))
-        sol = solve(prob, MethodOfSteps(Tsit5()); abstol = 1e-14, reltol = 1e-14,
-            saveat = 1.0)
+        prob = DDEProblem(
+            f, p[5], h, eltype(p).((0.0, 10.0)), copy(p);
+            constant_lags = (p[1],)
+        )
+        sol = solve(
+            prob, MethodOfSteps(Tsit5()); abstol = 1.0e-14, reltol = 1.0e-14,
+            saveat = 1.0
+        )
         sum(sol)
     end
 
@@ -90,7 +102,7 @@ end
     p = [1.5, 1.0, 0.5]
     findiff = FiniteDiff.finite_difference_hessian(p -> test(vcat(1, p, p[end])), p)
     fordiff = ForwardDiff.hessian(p -> test(vcat(1, p, p[end])), p)
-    @test maximum(abs.(findiff .- fordiff)) < 1e-5
+    @test maximum(abs.(findiff .- fordiff)) < 1.0e-5
 
     # with delay length estimation and without discontinuity
     p = [1.0, 1.5, 1.0, 0.5]

--- a/test/interface/composite_solution.jl
+++ b/test/interface/composite_solution.jl
@@ -24,16 +24,20 @@ end
     alg = MethodOfSteps(Tsit5())
     compositealg = MethodOfSteps(CompositeAlgorithm((Tsit5(), RK4()), integrator -> 1))
 
-    prob = DDEProblem((du, u, h, p, t) -> (du[1] = -h(p, t - 1)[1]; nothing),
-        [1.0], (p, t) -> [1.0], (0.0, 5.0))
+    prob = DDEProblem(
+        (du, u, h, p, t) -> (du[1] = -h(p, t - 1)[1]; nothing),
+        [1.0], (p, t) -> [1.0], (0.0, 5.0)
+    )
     sol = solve(prob, alg)
     compositesol = solve(prob, compositealg)
     @test compositesol isa SciMLBase.ODESolution
     @test sol.t == compositesol.t
     @test sol.u == compositesol.u
 
-    prob_oop = DDEProblem((u, h, p, t) -> -h(p, t - 1), [1.0], (p, t) -> [1.0],
-        (0.0, 5.0))
+    prob_oop = DDEProblem(
+        (u, h, p, t) -> -h(p, t - 1), [1.0], (p, t) -> [1.0],
+        (0.0, 5.0)
+    )
     sol_oop = solve(prob_oop, alg)
     compositesol_oop = solve(prob_oop, compositealg)
     @test compositesol_oop isa SciMLBase.ODESolution

--- a/test/interface/default.jl
+++ b/test/interface/default.jl
@@ -5,7 +5,7 @@ function delay_lotka_volterra(du, u, h, p, t)
     # Current state.
     x, y = u
     # Evaluate differential equations
-    du[1] = α * h(p, t - 1; idxs=1) - β * x * y
+    du[1] = α * h(p, t - 1; idxs = 1) - β * x * y
     du[2] = -γ * y + δ * x * y
     return nothing
 end

--- a/test/interface/default_solver.jl
+++ b/test/interface/default_solver.jl
@@ -2,7 +2,7 @@ using DelayDiffEq, OrdinaryDiffEqDefault, OrdinaryDiffEqCore, Test
 
 # Simple DDE problem for testing
 function f!(du, u, h, p, t)
-    du[1] = -h(p, t - 0.2)[1]
+    return du[1] = -h(p, t - 0.2)[1]
 end
 
 h(p, t) = [0.0]

--- a/test/interface/dependent_delays.jl
+++ b/test/interface/dependent_delays.jl
@@ -20,7 +20,7 @@ end
     sol2 = solve!(dde_int2)
 
     @test getfield.(dde_int.tracked_discontinuities, :t) ≈
-          getfield.(dde_int2.tracked_discontinuities, :t)
+        getfield.(dde_int2.tracked_discontinuities, :t)
     @test getfield.(dde_int.tracked_discontinuities, :order) == getfield.(dde_int2.tracked_discontinuities, :order)
 
     # worse than results above with constant delays specified as scalars
@@ -30,17 +30,17 @@ end
 
     # simple convergence tests
     @testset "convergence" begin
-        sol3 = solve(prob2, alg; abstol = 1e-9, reltol = 1e-6)
+        sol3 = solve(prob2, alg; abstol = 1.0e-9, reltol = 1.0e-6)
 
         @test sol3.errors[:l∞] < 3.0e-6
         @test sol3.errors[:final] < 1.4e-7
         @test sol3.errors[:l2] < 9.6e-7
 
-        sol4 = solve(prob2, alg; abstol = 1e-13, reltol = 1e-13)
+        sol4 = solve(prob2, alg; abstol = 1.0e-13, reltol = 1.0e-13)
 
         @test sol4.errors[:l∞] < 6.0e-11
         @test sol4.errors[:final] < 4.7e-11
-        @test sol4.errors[:l2] < 8e-12
+        @test sol4.errors[:l2] < 8.0e-12
     end
 end
 
@@ -50,6 +50,6 @@ end
     sol2 = solve(prob2, alg)
 
     @test sol2.errors[:l∞] > 1.0e-2
-    @test sol2.errors[:final] > 1e-6
+    @test sol2.errors[:final] > 1.0e-6
     @test sol2.errors[:l2] > 4.6e-3
 end

--- a/test/interface/discontinuities.jl
+++ b/test/interface/discontinuities.jl
@@ -32,8 +32,10 @@ end
     @testset "initial" begin
         @test integrator.tracked_discontinuities == [Discontinuity(0.0, 0)]
         @test length(integrator.d_discontinuities_propagated) == 2 &&
-              issubset([Discontinuity(1 / 5, 1), Discontinuity(1 / 3, 1)],
-            integrator.d_discontinuities_propagated.valtree)
+            issubset(
+            [Discontinuity(1 / 5, 1), Discontinuity(1 / 3, 1)],
+            integrator.d_discontinuities_propagated.valtree
+        )
         @test isempty(integrator.opts.d_discontinuities)
         @test isempty(integrator.opts.d_discontinuities_cache)
     end
@@ -42,10 +44,14 @@ end
     @testset "tracked" begin
         solve!(integrator)
 
-        discs = [Discontinuity(t, order)
-                 for (t, order) in ((0.0, 0), (1 / 5, 1), (1 / 3, 1), (2 / 5, 2),
-            (8 / 15, 2), (3 / 5, 3),
-            (2 / 3, 2), (11 / 15, 3), (13 / 15, 3))]
+        discs = [
+            Discontinuity(t, order)
+                for (t, order) in (
+                    (0.0, 0), (1 / 5, 1), (1 / 3, 1), (2 / 5, 2),
+                    (8 / 15, 2), (3 / 5, 3),
+                    (2 / 3, 2), (11 / 15, 3), (13 / 15, 3),
+                )
+        ]
 
         for (tracked, disc) in zip(integrator.tracked_discontinuities, discs)
             @test tracked.t ≈ disc.t && tracked.order == disc.order
@@ -55,24 +61,32 @@ end
 
 # additional discontinuities
 @testset "DDE with discontinuities" begin
-    integrator = init(prob, MethodOfSteps(BS3());
-        d_discontinuities = [Discontinuity(0.3, 4), Discontinuity(0.6, 5)])
+    integrator = init(
+        prob, MethodOfSteps(BS3());
+        d_discontinuities = [Discontinuity(0.3, 4), Discontinuity(0.6, 5)]
+    )
 
     @test integrator.tracked_discontinuities == [Discontinuity(0.0, 0)]
     @test length(integrator.d_discontinuities_propagated) == 2 &&
-          issubset([Discontinuity(1 / 5, 1), Discontinuity(1 / 3, 1)],
-        integrator.d_discontinuities_propagated.valtree)
+        issubset(
+        [Discontinuity(1 / 5, 1), Discontinuity(1 / 3, 1)],
+        integrator.d_discontinuities_propagated.valtree
+    )
     @test length(integrator.opts.d_discontinuities) == 2 &&
-          issubset([Discontinuity(0.3, 4), Discontinuity(0.6, 5)],
-        integrator.opts.d_discontinuities.valtree)
+        issubset(
+        [Discontinuity(0.3, 4), Discontinuity(0.6, 5)],
+        integrator.opts.d_discontinuities.valtree
+    )
     @test integrator.opts.d_discontinuities_cache == [Discontinuity(0.3, 4), Discontinuity(0.6, 5)]
 end
 
 # discontinuities induced by callbacks
 @testset "#190" begin
     cb = ContinuousCallback((u, t, integrator) -> 1, integrator -> nothing)
-    integrator = init(prob_dde_constant_1delay_ip, MethodOfSteps(Tsit5());
-        callback = cb)
+    integrator = init(
+        prob_dde_constant_1delay_ip, MethodOfSteps(Tsit5());
+        callback = cb
+    )
     sol = solve!(integrator)
     for t in 0:5
         @test t ∈ sol.t

--- a/test/interface/fpsolve.jl
+++ b/test/interface/fpsolve.jl
@@ -6,8 +6,12 @@ const prob = prob_dde_constant_2delays_long_ip
 const prob_oop = prob_dde_constant_2delays_long_oop
 const prob_scalar = prob_dde_constant_2delays_long_scalar
 
-const testsol = TestSolution(solve(prob, MethodOfSteps(Vern9());
-    abstol = 1 / 10^14, reltol = 1 / 10^14))
+const testsol = TestSolution(
+    solve(
+        prob, MethodOfSteps(Vern9());
+        abstol = 1 / 10^14, reltol = 1 / 10^14
+    )
+)
 
 @testset "NLFunctional" begin
     alg = MethodOfSteps(Tsit5(); fpsolve = NLFunctional(; max_iter = 10))
@@ -35,9 +39,9 @@ const testsol = TestSolution(solve(prob, MethodOfSteps(Vern9());
     @test sol_oop.stats.nsolve == sol.stats.nsolve
     @test sol_oop.stats.nfpiter == sol.stats.nfpiter
     @test sol_oop.stats.nfpconvfail == sol.stats.nfpconvfail
-    @test sol_oop.t≈sol.t atol=1e-3
+    @test sol_oop.t ≈ sol.t atol = 1.0e-3
     @test sol_oop.u ≈ sol.u
-    @test isapprox(sol.u, sol_oop.u; atol = 1e-7)
+    @test isapprox(sol.u, sol_oop.u; atol = 1.0e-7)
 
     ## scalar problem
 
@@ -48,7 +52,7 @@ const testsol = TestSolution(solve(prob, MethodOfSteps(Vern9());
     @test sol_scalar.stats.nsolve == sol.stats.nsolve
     @test sol_scalar.stats.nfpiter == sol.stats.nfpiter
     @test sol_scalar.stats.nfpconvfail == sol.stats.nfpconvfail
-    @test sol_scalar.t≈sol.t atol=1e-3
+    @test sol_scalar.t ≈ sol.t atol = 1.0e-3
     @test sol_scalar.u ≈ sol[1, :]
 end
 
@@ -80,7 +84,7 @@ end
     @test_broken sol_oop.stats.nfpconvfail == sol.stats.nfpconvfail
     @test_broken sol_oop.t ≈ sol.t
     @test_broken sol_oop.u ≈ sol.u
-    @test appxtrue(sol, sol_oop).errors[:L∞] < 3e-6
+    @test appxtrue(sol, sol_oop).errors[:L∞] < 3.0e-6
 
     ## scalar problem
 

--- a/test/interface/history_function.jl
+++ b/test/interface/history_function.jl
@@ -22,14 +22,18 @@ end
     end
 
     # ODE integrator
-    prob = ODEProblem((du, u, p, t) -> @.(du=p * u), ones(2), (0.0, 1.0), 1.01)
+    prob = ODEProblem((du, u, p, t) -> @.(du = p * u), ones(2), (0.0, 1.0), 1.01)
     integrator = init(prob, Tsit5())
 
     # combined history function
-    history_notinplace = DelayDiffEq.HistoryFunction(h_notinplace,
-        integrator)
-    history_inplace = DelayDiffEq.HistoryFunction(h_inplace,
-        integrator)
+    history_notinplace = DelayDiffEq.HistoryFunction(
+        h_notinplace,
+        integrator
+    )
+    history_inplace = DelayDiffEq.HistoryFunction(
+        h_inplace,
+        integrator
+    )
 
     # test evaluation of history function
     @testset "evaluation" for idxs in (nothing, [2])
@@ -53,8 +57,8 @@ end
     @testset "constant extrapolation" for deriv in (Val{0}, Val{1}), idxs in (nothing, [2])
         # expected value
         trueval = deriv == Val{0} ?
-                  (idxs === nothing ? integrator.u : integrator.u[[2]]) :
-                  (idxs === nothing ? zeros(2) : [0.0])
+            (idxs === nothing ? integrator.u : integrator.u[[2]]) :
+            (idxs === nothing ? zeros(2) : [0.0])
 
         # out-of-place
         history_notinplace.isout = false
@@ -84,7 +88,7 @@ end
 
     # test integrator interpolation
     @testset "integrator interpolation" for deriv in (Val{0}, Val{1}),
-        idxs in (nothing, [2])
+            idxs in (nothing, [2])
         # expected value
         trueval = OrdinaryDiffEqCore.current_interpolant(0.01, integrator, idxs, deriv)
 

--- a/test/interface/mass_matrix.jl
+++ b/test/interface/mass_matrix.jl
@@ -23,8 +23,12 @@ using Test
     p = (γ = 0.5, τ = 4.0)
 
     prob_dde = DDEProblem(sir_dde!, u0, sir_history, tspan, p; constant_lags = (p.τ,))
-    sol_dde = TestSolution(solve(prob_dde, MethodOfSteps(Vern9()); reltol = 1e-14,
-        abstol = 1e-14))
+    sol_dde = TestSolution(
+        solve(
+            prob_dde, MethodOfSteps(Vern9()); reltol = 1.0e-14,
+            abstol = 1.0e-14
+        )
+    )
 
     function sir_ddae!(du, u, h, p, t)
         S, I, R = u
@@ -41,13 +45,16 @@ using Test
     end
 
     prob_ddae = DDEProblem(
-        DDEFunction{true}(sir_ddae!;
-            mass_matrix = Diagonal([1.0, 1.0, 0.0])),
+        DDEFunction{true}(
+            sir_ddae!;
+            mass_matrix = Diagonal([1.0, 1.0, 0.0])
+        ),
         u0,
         sir_history,
         tspan,
         p;
-        constant_lags = (p.τ,))
+        constant_lags = (p.τ,)
+    )
     ode_f = DelayDiffEq.ODEFunctionWrapper(prob_ddae.f, prob_ddae.h)
     @test ode_f.mass_matrix == Diagonal([1.0, 1.0, 0.0])
 
@@ -55,12 +62,14 @@ using Test
     @test int.isdae
     @test int.f.mass_matrix == Diagonal([1.0, 1.0, 0.0])
 
-    for (alg, reltol) in ((Rosenbrock23(), nothing),
-        (Rodas4(), nothing),
-        (QNDF(), 1e-6),
-        (Trapezoid(), 1e-6))
+    for (alg, reltol) in (
+            (Rosenbrock23(), nothing),
+            (Rodas4(), nothing),
+            (QNDF(), 1.0e-6),
+            (Trapezoid(), 1.0e-6),
+        )
         sol_ddae = solve(prob_ddae, MethodOfSteps(alg); reltol = reltol)
         sol = appxtrue(sol_ddae, sol_dde)
-        @test sol.errors[:L∞] < 5e-3
+        @test sol.errors[:L∞] < 5.0e-3
     end
 end

--- a/test/interface/parameters.jl
+++ b/test/interface/parameters.jl
@@ -14,22 +14,24 @@ h(p, t; idxs = nothing) = 0.1
     # define problem
     # we specify order_discontinuity_t0 = 1 to indicate that the discontinuity at
     # t = 0 is of first order
-    prob = DDEProblem(inplace ? f_inplace : f_scalar,
+    prob = DDEProblem(
+        inplace ? f_inplace : f_scalar,
         inplace ? [0.1] : 0.1,
         h, (0.0, 50.0), [0.3];
         constant_lags = [1],
-        order_discontinuity_t0 = 1)
+        order_discontinuity_t0 = 1
+    )
 
     # solve problem with initial parameter:
     sol1 = solve(prob, MethodOfSteps(Tsit5()))
     @test length(sol1) == 21
-    @test first(sol1(12))≈0.884 atol=1e-4
-    @test first(sol1.u[end])≈1 atol=1e-5
+    @test first(sol1(12)) ≈ 0.884 atol = 1.0e-4
+    @test first(sol1.u[end]) ≈ 1 atol = 1.0e-5
 
     # solve problem with updated parameter
     prob.p[1] = 1.4
     sol2 = solve(prob, MethodOfSteps(Tsit5()))
     @test length(sol2) == 47
-    @test first(sol2(12))≈1.125 atol=5e-4
-    @test first(sol2.u[end])≈0.994 atol=2e-5
+    @test first(sol2(12)) ≈ 1.125 atol = 5.0e-4
+    @test first(sol2.u[end]) ≈ 0.994 atol = 2.0e-5
 end

--- a/test/interface/save_idxs.jl
+++ b/test/interface/save_idxs.jl
@@ -3,18 +3,22 @@ using Test
 
 # out-of-place problem
 function f_notinplace(u, h, p, t)
-    [-h(p, t - 1 / 5)[1] + u[1]; -h(p, t - 1 / 3)[2] - h(p, t - 1 / 5)[2]]
+    return [-h(p, t - 1 / 5)[1] + u[1]; -h(p, t - 1 / 3)[2] - h(p, t - 1 / 5)[2]]
 end
-const prob_notinplace = DDEProblem(f_notinplace, ones(2), (p, t) -> zeros(2), (0.0, 100.0),
-    constant_lags = [1 / 5, 1 / 3])
+const prob_notinplace = DDEProblem(
+    f_notinplace, ones(2), (p, t) -> zeros(2), (0.0, 100.0),
+    constant_lags = [1 / 5, 1 / 3]
+)
 
 # in-place problem
 function f_inplace(du, u, h, p, t)
     du[1] = -h(p, t - 1 / 5)[1] + u[1]
-    du[2] = -h(p, t - 1 / 3)[2] - h(p, t - 1 / 5)[2]
+    return du[2] = -h(p, t - 1 / 3)[2] - h(p, t - 1 / 5)[2]
 end
-const prob_inplace = DDEProblem(f_inplace, ones(2), (p, t) -> zeros(2), (0.0, 100.0),
-    constant_lags = [1 / 5, 1 / 3])
+const prob_inplace = DDEProblem(
+    f_inplace, ones(2), (p, t) -> zeros(2), (0.0, 100.0),
+    constant_lags = [1 / 5, 1 / 3]
+)
 
 const alg = MethodOfSteps(BS3())
 

--- a/test/interface/saveat.jl
+++ b/test/interface/saveat.jl
@@ -77,8 +77,10 @@ end
 # save every step
 @testset "every step (save_start=$save_start)" for save_start in (false, true)
     for saveat in (25.0, [25.0, 50.0, 75.0])
-        dde_int2 = init(prob, alg; saveat = saveat, save_everystep = true,
-            save_start = save_start)
+        dde_int2 = init(
+            prob, alg; saveat = saveat, save_everystep = true,
+            save_start = save_start
+        )
 
         # end point is saved implicitly
         @test dde_int2.opts.save_end
@@ -101,8 +103,10 @@ end
 # save every step
 @testset "every step (save_end=$save_end)" for save_end in (false, true)
     for saveat in (25.0, [25.0, 50.0, 75.0])
-        dde_int2 = init(prob, alg; saveat = saveat, save_everystep = true,
-            save_end = save_end)
+        dde_int2 = init(
+            prob, alg; saveat = saveat, save_everystep = true,
+            save_end = save_end
+        )
 
         # start point is saved implicitly
         @test dde_int2.opts.save_start
@@ -130,20 +134,26 @@ end
 
 @testset "changing end time point saveat" begin
     _saveat = [0.0, 0.25, 0.5, 1.0]
-    integ = init(DDEProblem((u, h, p, t) -> u, 0.0, (p, t) -> 0.0, (0.0, 1.0)),
-        MethodOfSteps(Tsit5()), saveat = _saveat)
+    integ = init(
+        DDEProblem((u, h, p, t) -> u, 0.0, (p, t) -> 0.0, (0.0, 1.0)),
+        MethodOfSteps(Tsit5()), saveat = _saveat
+    )
     add_tstop!(integ, 2.0)
     solve!(integ)
     @test integ.sol.t == _saveat
 
-    integ = init(DDEProblem((u, h, p, t) -> u, 0.0, (p, t) -> 0.0, (0.0, 1.0)),
-        MethodOfSteps(Tsit5()), saveat = _saveat, save_end = true)
+    integ = init(
+        DDEProblem((u, h, p, t) -> u, 0.0, (p, t) -> 0.0, (0.0, 1.0)),
+        MethodOfSteps(Tsit5()), saveat = _saveat, save_end = true
+    )
     add_tstop!(integ, 2.0)
     solve!(integ)
     @test integ.sol.t == [0.0, 0.25, 0.5, 1.0, 2.0]
 
-    integ = init(DDEProblem((u, h, p, t) -> u, 0.0, (p, t) -> 0.0, (0.0, 1.0)),
-        MethodOfSteps(Tsit5()), saveat = _saveat, save_end = false)
+    integ = init(
+        DDEProblem((u, h, p, t) -> u, 0.0, (p, t) -> 0.0, (0.0, 1.0)),
+        MethodOfSteps(Tsit5()), saveat = _saveat, save_end = false
+    )
     add_tstop!(integ, 2.0)
     solve!(integ)
     @test integ.sol.t == [0.0, 0.25, 0.5]

--- a/test/interface/unconstrained.jl
+++ b/test/interface/unconstrained.jl
@@ -8,13 +8,19 @@ using Test
     # standard algorithm
     alg = MethodOfSteps(BS3(); constrained = false)
 
-    alg1 = MethodOfSteps(Tsit5(); constrained = false,
-        fpsolve = NLFunctional(; max_iter = 100))
-    alg2 = MethodOfSteps(DP8(); constrained = false,
-        fpsolve = NLFunctional(; max_iter = 10))
+    alg1 = MethodOfSteps(
+        Tsit5(); constrained = false,
+        fpsolve = NLFunctional(; max_iter = 100)
+    )
+    alg2 = MethodOfSteps(
+        DP8(); constrained = false,
+        fpsolve = NLFunctional(; max_iter = 10)
+    )
     alg3 = MethodOfSteps(Tsit5(); constrained = true)
-    alg4 = MethodOfSteps(DP5(); constrained = false,
-        fpsolve = NLFunctional(; max_iter = 100))
+    alg4 = MethodOfSteps(
+        DP5(); constrained = false,
+        fpsolve = NLFunctional(; max_iter = 100)
+    )
 
     ## Single constant delay
     @testset "single constant delay" begin
@@ -40,10 +46,10 @@ using Test
         @testset "long time span" begin
             prob = prob_dde_constant_1delay_long_scalar
 
-            sol1 = solve(prob, alg1; abstol = 1e-12, reltol = 1e-12)
-            sol2 = solve(prob, alg2; abstol = 1e-8, reltol = 1e-10)
-            sol3 = solve(prob, alg3; abstol = 1e-8, reltol = 1e-10)
-            sol4 = solve(prob, alg4; abstol = 1e-12, reltol = 1e-12)
+            sol1 = solve(prob, alg1; abstol = 1.0e-12, reltol = 1.0e-12)
+            sol2 = solve(prob, alg2; abstol = 1.0e-8, reltol = 1.0e-10)
+            sol3 = solve(prob, alg3; abstol = 1.0e-8, reltol = 1.0e-10)
+            sol4 = solve(prob, alg4; abstol = 1.0e-12, reltol = 1.0e-12)
 
             # relaxed tests to prevent floating point issues
             @test abs(sol1.u[end] - sol2.u[end]) < 2.5e-8
@@ -76,10 +82,10 @@ using Test
         @testset "long time span" begin
             prob = prob_dde_constant_2delays_long_scalar
 
-            sol1 = solve(prob, alg1; abstol = 1e-12, reltol = 1e-12)
-            sol2 = solve(prob, alg2; abstol = 1e-8, reltol = 1e-10)
-            sol3 = solve(prob, alg3; abstol = 1e-8, reltol = 1e-10)
-            sol4 = solve(prob, alg4; abstol = 1e-12, reltol = 1e-12)
+            sol1 = solve(prob, alg1; abstol = 1.0e-12, reltol = 1.0e-12)
+            sol2 = solve(prob, alg2; abstol = 1.0e-8, reltol = 1.0e-10)
+            sol3 = solve(prob, alg3; abstol = 1.0e-8, reltol = 1.0e-10)
+            sol4 = solve(prob, alg4; abstol = 1.0e-12, reltol = 1.0e-12)
 
             # relaxed tests to prevent floating point issues
             @test abs(sol1.u[end] - sol3.u[end]) < 1.2e-13 # 1.2e-15
@@ -90,8 +96,10 @@ end
 
 ## Non-standard history functions
 @testset "non-standard history" begin
-    alg = MethodOfSteps(Tsit5(); constrained = false,
-        fpsolve = NLFunctional(; max_iter = 100))
+    alg = MethodOfSteps(
+        Tsit5(); constrained = false,
+        fpsolve = NLFunctional(; max_iter = 100)
+    )
 
     @testset "idxs" begin
         function f(du, u, h, p, t)
@@ -100,7 +108,7 @@ end
         h(p, t; idxs = nothing) = idxs isa Number ? 0.0 : [0.0]
 
         prob = DDEProblem(f, [1.0], h, (0.0, 100.0); constant_lags = [0.2])
-        solve(prob, alg; abstol = 1e-12, reltol = 1e-12)
+        solve(prob, alg; abstol = 1.0e-12, reltol = 1.0e-12)
     end
 
     @testset "in-place" begin
@@ -111,6 +119,6 @@ end
         h(val, p, t) = (val .= 0.0)
 
         prob = DDEProblem(f, [1.0], h, (0.0, 100.0); constant_lags = [0.2])
-        solve(prob, alg; abstol = 1e-12, reltol = 1e-12)
+        solve(prob, alg; abstol = 1.0e-12, reltol = 1.0e-12)
     end
 end

--- a/test/interface/units.jl
+++ b/test/interface/units.jl
@@ -4,12 +4,17 @@ using Test
 using DDEProblemLibrary: remake_dde_constant_u0_tType
 
 const probs = Dict(
-    true => remake_dde_constant_u0_tType(prob_dde_constant_1delay_long_ip,
+    true => remake_dde_constant_u0_tType(
+        prob_dde_constant_1delay_long_ip,
         [1.0u"N"],
-        typeof(1.0u"s")),
-    false => remake_dde_constant_u0_tType(prob_dde_constant_1delay_long_scalar,
+        typeof(1.0u"s")
+    ),
+    false => remake_dde_constant_u0_tType(
+        prob_dde_constant_1delay_long_scalar,
         1.0u"N",
-        typeof(1.0u"s")))
+        typeof(1.0u"s")
+    )
+)
 
 # we test the current handling of units for regressions
 # however, it is broken upstream: https://github.com/JuliaDiffEq/OrdinaryDiffEq.jl/issues/828
@@ -17,42 +22,50 @@ const probs = Dict(
 @testset for inplace in (true, false)
     prob = probs[inplace]
 
-    alg = MethodOfSteps(Tsit5(); constrained = false,
-        fpsolve = NLFunctional(; max_iter = 100))
+    alg = MethodOfSteps(
+        Tsit5(); constrained = false,
+        fpsolve = NLFunctional(; max_iter = 100)
+    )
 
     # default
     sol1 = solve(prob, alg)
 
     # without units
     if inplace
-        @test_throws Unitful.DimensionError solve(prob, alg;
-            abstol = 1e-6, reltol = 1e-3)
+        @test_throws Unitful.DimensionError solve(
+            prob, alg;
+            abstol = 1.0e-6, reltol = 1.0e-3
+        )
     else
-        sol2 = solve(prob, alg; abstol = 1e-6, reltol = 1e-3)
+        sol2 = solve(prob, alg; abstol = 1.0e-6, reltol = 1.0e-3)
 
         @test sol1.t == sol2.t
         @test sol1.u == sol2.u
     end
 
     # with correct units
-    sol3 = solve(prob, alg; abstol = 1e-6u"N", reltol = 1e-3u"N")
+    sol3 = solve(prob, alg; abstol = 1.0e-6u"N", reltol = 1.0e-3u"N")
 
     @test sol1.t == sol3.t
     @test sol1.u == sol3.u
 
     # with correct units as vectors
     if inplace
-        sol4 = solve(prob, alg; abstol = [1e-6u"N"], reltol = [1e-3u"N"])
+        sol4 = solve(prob, alg; abstol = [1.0e-6u"N"], reltol = [1.0e-3u"N"])
 
         @test sol1.t == sol4.t
         @test sol1.u == sol4.u
     end
 
     # with incorrect units for absolute tolerance
-    @test_throws Unitful.DimensionError solve(prob, alg;
-        abstol = 1e-6u"s", reltol = 1e-3u"N")
+    @test_throws Unitful.DimensionError solve(
+        prob, alg;
+        abstol = 1.0e-6u"s", reltol = 1.0e-3u"N"
+    )
 
     # with incorrect units for relative tolerance
-    @test_throws Unitful.DimensionError solve(prob, alg;
-        abstol = 1e-6u"N", reltol = 1e-3u"s")
+    @test_throws Unitful.DimensionError solve(
+        prob, alg;
+        abstol = 1.0e-6u"N", reltol = 1.0e-3u"s"
+    )
 end

--- a/test/qa/qa_tests.jl
+++ b/test/qa/qa_tests.jl
@@ -3,14 +3,18 @@ using DelayDiffEq, Test
 @testset "Aqua Tests" begin
     using Aqua
 
-    Aqua.test_all(DelayDiffEq; ambiguities = false, piracies = false,
-        stale_deps = false, deps_compat = false)
+    Aqua.test_all(
+        DelayDiffEq; ambiguities = false, piracies = false,
+        stale_deps = false, deps_compat = false
+    )
     Aqua.test_ambiguities(DelayDiffEq; recursive = false)
     Aqua.test_stale_deps(DelayDiffEq)
     Aqua.test_deps_compat(DelayDiffEq)
     # Allow piracy for the default solver methods
-    Aqua.test_piracies(DelayDiffEq;
-        treat_as_own = [SciMLBase.DDEProblem])
+    Aqua.test_piracies(
+        DelayDiffEq;
+        treat_as_own = [SciMLBase.DDEProblem]
+    )
 end
 
 @testset "Explicit Imports Tests" begin

--- a/test/regression/waltman.jl
+++ b/test/regression/waltman.jl
@@ -2,13 +2,15 @@ using DelayDiffEq, DDEProblemLibrary
 using LinearAlgebra, Test, LinearSolve
 
 const PROB_WALTMAN = DDEProblemLibrary.prob_dde_RADAR5_waltman_5
-const PROB_KWARGS = (reltol = 1e-7, abstol = [1e-21, 1e-21, 1e-21, 1e-21, 1e-9, 1e-9])
+const PROB_KWARGS = (reltol = 1.0e-7, abstol = [1.0e-21, 1.0e-21, 1.0e-21, 1.0e-21, 1.0e-9, 1.0e-9])
 
 # solution at final time point T = 300 obtained from RADAR5
 # with relative tolerance 1e-6 and componentwise absolute tolerances
 # 1e-21, 1e-21, 1e-21, 1e-21, 1e-9, and 1e-9
-const RADAR5_SOL = [6.154488183e-16, 3.377120916e-7, 4.22140331e-7,
-    2.142554562e-6, 299.9999999, 299.6430338]
+const RADAR5_SOL = [
+    6.154488183e-16, 3.377120916e-7, 4.22140331e-7,
+    2.142554562e-6, 299.9999999, 299.6430338,
+]
 
 function test_waltman_sol(sol)
     @test sol.retcode == ReturnCode.Success
@@ -16,8 +18,9 @@ function test_waltman_sol(sol)
 
     # compare solution at the final time point with RADAR5
     for i in 1:6
-        @test sol.u[end][i]≈RADAR5_SOL[i] rtol=1e-3 atol=1e-17
+        @test sol.u[end][i] ≈ RADAR5_SOL[i] rtol = 1.0e-3 atol = 1.0e-17
     end
+    return
 end
 
 # standard factorization
@@ -25,15 +28,18 @@ sol1 = solve(PROB_WALTMAN, MethodOfSteps(Rodas5P()); PROB_KWARGS...)
 test_waltman_sol(sol1)
 
 # in-place LU factorization
-sol2 = solve(PROB_WALTMAN,
+sol2 = solve(
+    PROB_WALTMAN,
     MethodOfSteps(Rodas5P(linsolve = GenericFactorization(lu!)));
-    PROB_KWARGS...)
+    PROB_KWARGS...
+)
 test_waltman_sol(sol2)
 
 # out-of-place LU factorization
 sol3 = solve(
     PROB_WALTMAN, MethodOfSteps(Rodas5P(linsolve = GenericFactorization(lu)));
-    PROB_KWARGS...)
+    PROB_KWARGS...
+)
 test_waltman_sol(sol3)
 
 # compare in-place and out-of-place LU factorization


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)