### PR TITLE
Exclude QA tests from All group for downstream testing compatibility

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,7 +107,7 @@ if GROUP == "All" || GROUP == "Regression"
     end
 end
 
-if GROUP == "All" || GROUP == "QA"
+if GROUP == "QA"
     @time @safetestset "QA Tests" begin
         include("qa/qa_tests.jl")
     end


### PR DESCRIPTION
## Summary
- Modified `test/runtests.jl` to only run QA tests when `GROUP="QA"` (not when `GROUP="All"`)

Aqua tests do not work properly in downstream testing scenarios, so QA tests should only run when explicitly requested.

Note: CI already has the exclude for QA on pre version.

## Test plan
- [ ] Verify CI passes for Interface, Integrators, Regression groups
- [ ] Verify QA tests run correctly on Julia 1 and lts versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)