### PR TITLE
Switch root finder to ITP

### DIFF
--- a/src/track.jl
+++ b/src/track.jl
@@ -163,7 +163,7 @@ function discontinuity_time(integrator::DDEIntegrator, lag, T, (bottom_Θ, top_�
                     top_Θ,
                 )
             ),
-            SimpleNonlinearSolve.Falsi()
+            SimpleNonlinearSolve.ITP()
         ).left
     end
 


### PR DESCRIPTION
## Summary
- Switches the root finder from Falsi() to ITP() for finding propagated discontinuities
- ITP is faster and more robust

This is a rebase of #310 onto the latest master.

Original PR: #310 by @oscardssmith

🤖 Generated with [Claude Code](https://claude.com/claude-code)