### PR TITLE
Fix AbstractDiffEqArray getindex deprecation warnings in tests

### DIFF
--- a/test/integrators/iterator.jl
+++ b/test/integrators/iterator.jl
@@ -76,7 +76,7 @@ end
     for (u, t) in TimeChoiceIterator(integrator4, ts)
         push!(us, u)
     end
-    @test us ≈ integrator4.sol(ts)
+    @test us ≈ integrator4.sol(ts).u
 end
 
 @testset "iter" begin

--- a/test/interface/save_idxs.jl
+++ b/test/interface/save_idxs.jl
@@ -42,7 +42,7 @@ const alg = MethodOfSteps(BS3())
             @test sol.u == dde_int.sol.u
 
             ## interpolation
-            @test sol(25:100, idxs = 2) ≈ [u[1] for u in sol(25:100, idxs = [2])]
+            @test sol(25:100, idxs = 2).u ≈ [u[1] for u in sol(25:100, idxs = [2]).u]
         end
 
         # with keyword argument
@@ -61,7 +61,7 @@ const alg = MethodOfSteps(BS3())
             @test sol.u == dde_int.sol.u
 
             # interpolation
-            @test sol[2, :] ≈ dde_int.integrator.sol(sol.t, idxs = 2)
+            @test sol[2, :] ≈ dde_int.integrator.sol(sol.t, idxs = 2).u
         end
     end
 
@@ -84,8 +84,8 @@ const alg = MethodOfSteps(BS3())
             @test sol2.u == dde_int2.sol.u
 
             # interpolation
-            @test sol(25:100, idxs = 2) ≈ sol2(25:100, idxs = 1)
-            @test sol(25:100, idxs = [2]) ≈ sol2(25:100, idxs = [1])
+            @test sol(25:100, idxs = 2).u ≈ sol2(25:100, idxs = 1).u
+            @test sol(25:100, idxs = [2]).u ≈ sol2(25:100, idxs = [1]).u
         end
 
         # scalar index
@@ -109,7 +109,7 @@ const alg = MethodOfSteps(BS3())
 
             # interpolation of solution equals second component of
             # interpolation of complete solution
-            @test sol(25:100, idxs = 2) ≈ sol2(25:100, idxs = 1)
+            @test sol(25:100, idxs = 2).u ≈ sol2(25:100, idxs = 1).u
         end
     end
 end


### PR DESCRIPTION
## Summary

- Fix deprecation warnings for `Base.getindex(VA::AbstractDiffEqArray{T, N, A}, i::Int)` that appear in CI during Interface and Integrators test groups
- The deprecated integer indexing was triggered by broadcasting inside `isapprox` (`≈`) when comparing `DiffEqArray` objects returned by solution interpolation (e.g., `sol(25:100, idxs = 2)`)
- Use `.u` to extract the underlying array from `DiffEqArray` objects before comparison, avoiding the deprecated `getindex` path

## Changes

**`test/interface/save_idxs.jl`** (5 lines): Access `.u` on `DiffEqArray` results from `sol(range, idxs=...)` and `dde_int.integrator.sol(ts, idxs=...)` before `≈` comparisons

**`test/integrators/iterator.jl`** (1 line): Access `.u` on `integrator4.sol(ts)` before `≈` comparison with plain `Vector`

## Test plan

- [x] `save_idxs Tests`: 52/52 pass, zero deprecation warnings
- [x] `Iterator Tests`: 12/12 pass, zero deprecation warnings
- [x] Full Interface test group passes
- [x] Full Integrators test group passes
- [x] Runic formatting check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)